### PR TITLE
Sets up a new package for the {yourOktaDomain} change 

### DIFF
--- a/packages/@okta/vuepress-plugin-my-okta/clientRootMixin.js
+++ b/packages/@okta/vuepress-plugin-my-okta/clientRootMixin.js
@@ -1,0 +1,59 @@
+export default {
+  mounted() {
+    let iframe = document.createElement('iframe')
+    iframe.id = 'myOktaIFrame'
+    iframe.src = 'https://login.okta.com'
+    iframe.style = 'display:none'
+    document.body.appendChild(iframe)
+
+    window.addEventListener('message', this.receiveMessage, false);
+    document.addEventListener('visibilitychange', this.checkSuccess, false);
+
+    window.addEventListener("load", () => {
+      document.querySelector('.content').innerHTML = document.querySelector('.content').innerHTML.replace(/https:\/\/{yourOktaDomain}/gi, '<span class="okta-preview-domain">https://{yourOktaDomain}</span>')
+      this.getMyOktaAccounts()
+    })
+  },
+
+  methods: {
+    checkSuccess: () => {
+      if (typeof document.hidden !== "undefined") {
+        if (!document.hidden) {
+          if ( document.querySelector('.okta-preview-domain').innerHTML == 'https://{yourOktaDomain}' ) {
+            // We haven't replaced yet: try again.
+            this.getMyOktaAccounts();
+          } else {
+            // We've succeeded: don't try again in the future.
+            document.removeEventListener('visibilitychange', this.checkSuccess, false);
+          }
+        }
+      }
+    },
+
+    getMyOktaAccounts: () => {
+      document.querySelector('#myOktaIFrame').contentWindow.postMessage({messageType: 'get_accounts_json'}, 'https://login.okta.com')
+    },
+
+    receiveMessage: () => {
+      if (event.origin !== 'https://login.okta.com' || !event.data) {
+        return;
+      }
+
+      var accountsExist = event.data.length;
+      if (!accountsExist) {
+        return;
+      }
+
+      var domain = event.data[0].origin;
+      var myOktaAccountFound = new CustomEvent('myOktaAccountFound', {
+        detail: {
+          domain: domain
+        }
+      });
+      window.dispatchEvent(myOktaAccountFound);
+
+      document.querySelector('.content').innerHTML = document.querySelector('.content').innerHTML.replace(/https:\/\/{yourOktaDomain}/gi, domain)
+    }
+
+  }
+}

--- a/packages/@okta/vuepress-plugin-my-okta/clientRootMixin.js
+++ b/packages/@okta/vuepress-plugin-my-okta/clientRootMixin.js
@@ -1,15 +1,15 @@
 export default {
   mounted() {
-    let iframe = document.createElement('iframe')
+    const iframe = document.createElement('iframe')
     iframe.id = 'myOktaIFrame'
     iframe.src = 'https://login.okta.com'
     iframe.style = 'display:none'
     document.body.appendChild(iframe)
 
-    window.addEventListener('message', this.receiveMessage, false);
-    document.addEventListener('visibilitychange', this.checkSuccess, false);
+    window.addEventListener('message', this.receiveMessage, false)
+    document.addEventListener('visibilitychange', this.checkSuccess, false)
 
-    window.addEventListener("load", () => {
+    window.addEventListener('load', () => {
       document.querySelector('.content').innerHTML = document.querySelector('.content').innerHTML.replace(/https:\/\/{yourOktaDomain}/gi, '<span class="okta-preview-domain">https://{yourOktaDomain}</span>')
       this.getMyOktaAccounts()
     })
@@ -17,14 +17,14 @@ export default {
 
   methods: {
     checkSuccess: () => {
-      if (typeof document.hidden !== "undefined") {
+      if (typeof document.hidden !== 'undefined') {
         if (!document.hidden) {
           if ( document.querySelector('.okta-preview-domain').innerHTML == 'https://{yourOktaDomain}' ) {
             // We haven't replaced yet: try again.
-            this.getMyOktaAccounts();
+            this.getMyOktaAccounts()
           } else {
             // We've succeeded: don't try again in the future.
-            document.removeEventListener('visibilitychange', this.checkSuccess, false);
+            document.removeEventListener('visibilitychange', this.checkSuccess, false)
           }
         }
       }
@@ -36,21 +36,21 @@ export default {
 
     receiveMessage: () => {
       if (event.origin !== 'https://login.okta.com' || !event.data) {
-        return;
+        return
       }
 
-      var accountsExist = event.data.length;
+      const accountsExist = event.data.length
       if (!accountsExist) {
         return;
       }
 
-      var domain = event.data[0].origin;
-      var myOktaAccountFound = new CustomEvent('myOktaAccountFound', {
+      const domain = event.data[0].origin
+      const myOktaAccountFound = new CustomEvent('myOktaAccountFound', {
         detail: {
           domain: domain
         }
       });
-      window.dispatchEvent(myOktaAccountFound);
+      window.dispatchEvent(myOktaAccountFound)
 
       document.querySelector('.content').innerHTML = document.querySelector('.content').innerHTML.replace(/https:\/\/{yourOktaDomain}/gi, domain)
     }

--- a/packages/@okta/vuepress-plugin-my-okta/index.js
+++ b/packages/@okta/vuepress-plugin-my-okta/index.js
@@ -1,0 +1,5 @@
+const path = require('path')
+
+module.exports = {
+  clientRootMixin: path.resolve(__dirname, 'clientRootMixin.js')
+}

--- a/packages/@okta/vuepress-plugin-my-okta/package.json
+++ b/packages/@okta/vuepress-plugin-my-okta/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@okta/vuepress-plugin-my-okta",
+  "version": "1.0.0",
+  "description": "VuePress plugin to swap https://{yourOktaDomain} with last logged in domain",
+  "repository": "https://github.com/okta/okta-developer-docs",
+  "main": "index.js",
+  "author": "Brian Retterer <brian.retterer@okta.com>",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "vuepress": "^1.0.0-alpha.33"
+  }
+}

--- a/packages/@okta/vuepress-site/.vuepress/config.js
+++ b/packages/@okta/vuepress-site/.vuepress/config.js
@@ -205,5 +205,10 @@ module.exports = {
       promo_text: 'Learn how to build your app on Okta, fast.',
       cta_text: 'QUICK STARTS'
     }
-  }
+
+  },
+
+  plugins: [
+    '@okta/vuepress-plugin-my-okta'
+  ]
 }

--- a/packages/@okta/vuepress-site/package.json
+++ b/packages/@okta/vuepress-site/package.json
@@ -21,5 +21,8 @@
   "devDependencies": {
     "@okta/vuepress-theme-default": "^0.1.0-alpha.1",
     "vuepress": "^1.0.0-alpha.33"
+  },
+  "dependencies": {
+    "@okta/vuepress-plugin-my-okta": "^1.0.0"
   }
 }


### PR DESCRIPTION
In this PR, there is a new package created to deal with editing the `okta-preview-domain` sections of the page to swap out for your domains based on login.okta.com.

This will only work from approved okta domains, so localhost will not provide the swap.

This code is based on the current live code through jekyll while removing jquery dependency