### PR TITLE
Creates redirects in conductor file from the redirects.json

### DIFF
--- a/packages/@okta/migrate-from-jekyll/index.js
+++ b/packages/@okta/migrate-from-jekyll/index.js
@@ -221,6 +221,17 @@ function run() {
 
 
   fs.writeFileSync(docsRoot+'/.vuepress/redirects.json', JSON.stringify(redirects, null, 2))
+
+  try {
+    fs.writeFileSync(docsRoot + '/conductor.yml', 'redirects: \r\n')
+    //Build conductor redirects
+    redirects.forEach((redirect) => {
+      fs.appendFile(docsRoot + '/conductor.yml', ' - from: ' + redirect.path + '\r\n   to: ' + redirect.redirect + '\r\n')
+    })
+  } catch (e) {
+    console.log(e)
+  }
+
 }
 
 run()

--- a/packages/@okta/migrate-from-jekyll/index.js
+++ b/packages/@okta/migrate-from-jekyll/index.js
@@ -222,15 +222,11 @@ function run() {
 
   fs.writeFileSync(docsRoot+'/.vuepress/redirects.json', JSON.stringify(redirects, null, 2))
 
-  try {
-    fs.writeFileSync(docsRoot + '/conductor.yml', 'redirects: \r\n')
-    //Build conductor redirects
-    redirects.forEach((redirect) => {
-      fs.appendFile(docsRoot + '/conductor.yml', ' - from: ' + redirect.path + '\r\n   to: ' + redirect.redirect + '\r\n')
-    })
-  } catch (e) {
-    console.log(e)
-  }
+  fs.writeFileSync(docsRoot + '/conductor.yml', 'redirects: \r\n')
+  //Build conductor redirects
+  redirects.forEach((redirect) => {
+    fs.appendFileSync(docsRoot + '/conductor.yml', ' - from: ' + redirect.path + '\r\n   to: ' + redirect.redirect + '\r\n')
+  })
 
 }
 

--- a/packages/@okta/migrate-from-jekyll/utils/buildRedirects.js
+++ b/packages/@okta/migrate-from-jekyll/utils/buildRedirects.js
@@ -10,6 +10,16 @@ module.exports = {
         redirects.push({'path': strippedFinalPath, 'redirect':file.frontmatter.redirect_to})
       }
 
+      if('redirect_from' in file.frontmatter) {
+        if(Array.isArray(file.frontmatter.redirect_from)) {
+          file.frontmatter.redirect_from.forEach((from) => {
+            redirects.push({'path': from, 'redirect':strippedFinalPath})
+          })
+        } else {
+          redirects.push({'path': file.frontmatter.redirect_from, 'redirect':strippedFinalPath})
+        }
+      }
+
     }
 
     return redirects

--- a/packages/@okta/vuepress-site/.vuepress/redirects.json
+++ b/packages/@okta/vuepress-site/.vuepress/redirects.json
@@ -8,24 +8,92 @@
     "redirect": "/use_cases/api_access_management/"
   },
   {
+    "path": "/3rd_party_notices/Okta_Rum_Tool",
+    "redirect": "/3rd_party_notices/Okta_Cloud_Provisioning_Connector_Tool/index.html"
+  },
+  {
+    "path": "/docs/how-to/set-up-auth-server.html",
+    "redirect": "/authentication-guide/implementing-authentication/set-up-authz-server/index.html"
+  },
+  {
+    "path": "/docs/how-to/inbound-saml-with-oidc",
+    "redirect": "/authentication-guide/saml-login/index.html"
+  },
+  {
+    "path": "/docs/api/resources/social_authentication",
+    "redirect": "/authentication-guide/social-login/index.html"
+  },
+  {
+    "path": "/code/dotnet/",
+    "redirect": "/code/dotnet/aspnetcore/index.html"
+  },
+  {
     "path": "/code/dotnet/index.html",
     "redirect": "/code/dotnet/aspnetcore/"
+  },
+  {
+    "path": "/code/dotnet/okta-oidc-spa-osw-aspnet",
+    "redirect": "/code/dotnet/index.html"
+  },
+  {
+    "path": "/code/dotnet/okta-oauth-spa-authjs-osw",
+    "redirect": "/code/dotnet/index.html"
+  },
+  {
+    "path": "/code/dotnet/okta-oauth-aspnet-codeflow",
+    "redirect": "/code/dotnet/index.html"
+  },
+  {
+    "path": "/docs/examples/dotnet_sample_application.html",
+    "redirect": "/code/dotnet/sample_application/index.html"
   },
   {
     "path": "/code/dotnet/sdk/index.html",
     "redirect": "https://github.com/okta/okta-sdk-dotnet"
   },
   {
+    "path": "/code/swift/",
+    "redirect": "/code/ios/index.html"
+  },
+  {
     "path": "/code/java/jwt-validation/index.html",
     "redirect": "https://github.com/okta/okta-jwt-verifier-java"
+  },
+  {
+    "path": "/docs/examples/spring_security_saml.html",
+    "redirect": "/code/java/spring_security_saml/index.html"
+  },
+  {
+    "path": "/docs/guides/spring_security_saml.html",
+    "redirect": "/code/java/spring_security_saml/index.html"
+  },
+  {
+    "path": "/docs/guides/okta_auth_sdk.html",
+    "redirect": "/code/javascript/okta_auth_sdk/index.html"
   },
   {
     "path": "/code/javascript/okta_auth_sdk_ref/index.html",
     "redirect": "https://github.com/okta/okta-auth-js"
   },
   {
+    "path": "/code/javascript/okta_auth_sdk_external_ref.html",
+    "redirect": "/code/javascript/okta_auth_sdk_ref/index.html"
+  },
+  {
+    "path": "/docs/guides/okta_sign-in_widget.html",
+    "redirect": "/code/javascript/okta_sign-in_widget/index.html"
+  },
+  {
     "path": "/code/javascript/okta_sign-in_widget_ref/index.html",
     "redirect": "https://github.com/okta/okta-signin-widget"
+  },
+  {
+    "path": "/code/javascript/okta_sign-in_widget_external_ref.html",
+    "redirect": "/code/javascript/okta_sign-in_widget_ref/index.html"
+  },
+  {
+    "path": "/docs/api/resources/okta_signin_widget.html",
+    "redirect": "/code/javascript/okta_sign-in_widget_ref/index.html"
   },
   {
     "path": "/code/php/jwt-validation/index.html",
@@ -36,8 +104,156 @@
     "redirect": "/quickstart/#/okta-sign-in-page/php/generic"
   },
   {
+    "path": "/docs/guides/simplesamlphp.html",
+    "redirect": "/code/php/simplesamlphp/index.html"
+  },
+  {
+    "path": "/docs/examples/pysaml2.html",
+    "redirect": "/code/python/pysaml2/index.html"
+  },
+  {
+    "path": "/docs/guides/pysaml2.html",
+    "redirect": "/code/python/pysaml2/index.html"
+  },
+  {
     "path": "/code/python/sdk/index.html",
     "redirect": "https://github.com/okta/okta-sdk-python"
+  },
+  {
+    "path": "/docs/getting_started/api_test_client.html",
+    "redirect": "/code/rest/index.html"
+  },
+  {
+    "path": "/docs/api/getting_started/api_test_client.html",
+    "redirect": "/code/rest/index.html"
+  },
+  {
+    "path": "/docs/api/getting_started/index.html",
+    "redirect": "/code/rest/index.html"
+  },
+  {
+    "path": "/docs/api/getting_started/",
+    "redirect": "/code/rest/index.html"
+  },
+  {
+    "path": "/docs/getting_started/design_principles.html",
+    "redirect": "/docs/api/getting_started/design_principles/index.html"
+  },
+  {
+    "path": "docs/api/index.html",
+    "redirect": "/docs/api/getting_started/design_principles/index.html"
+  },
+  {
+    "path": "docs/api/",
+    "redirect": "/docs/api/getting_started/design_principles/index.html"
+  },
+  {
+    "path": "/docs/getting_started/getting_a_token.html",
+    "redirect": "/docs/api/getting_started/getting_a_token/index.html"
+  },
+  {
+    "path": "/docs/getting_started/design_principles",
+    "redirect": "/docs/api/getting_started/rate-limits/index.html"
+  },
+  {
+    "path": "/docs/api/",
+    "redirect": "/docs/api/resources/apps/index.html"
+  },
+  {
+    "path": "/docs/api/resources/",
+    "redirect": "/docs/api/resources/apps/index.html"
+  },
+  {
+    "path": "/docs/api/reference/",
+    "redirect": "/docs/api/resources/apps/index.html"
+  },
+  {
+    "path": "/docs/api/reference/index.html",
+    "redirect": "/docs/api/resources/apps/index.html"
+  },
+  {
+    "path": "/docs/api/rest/apps.html",
+    "redirect": "/docs/api/resources/apps/index.html"
+  },
+  {
+    "path": "/docs/api/rest/authn.html",
+    "redirect": "/docs/api/resources/authn/index.html"
+  },
+  {
+    "path": "/docs/api/resources/index.html",
+    "redirect": "/docs/api/resources/authn/index.html"
+  },
+  {
+    "path": "/docs/api/resources/",
+    "redirect": "/docs/api/resources/authn/index.html"
+  },
+  {
+    "path": "/docs/api/rest/events.html",
+    "redirect": "/docs/api/resources/events/index.html"
+  },
+  {
+    "path": "/docs/getting_started/factor_admin.html",
+    "redirect": "/docs/api/resources/factor_admin/index.html"
+  },
+  {
+    "path": "/docs/api/rest/factors.html",
+    "redirect": "/docs/api/resources/factors/index.html"
+  },
+  {
+    "path": "/docs/api/rest/groups.html",
+    "redirect": "/docs/api/resources/groups/index.html"
+  },
+  {
+    "path": "docs/api/rest/idps.html",
+    "redirect": "/docs/api/resources/idps/index.html"
+  },
+  {
+    "path": "/docs/api/rest/oauth-clients.html",
+    "redirect": "/docs/api/resources/oauth-clients/index.html"
+  },
+  {
+    "path": "/docs/api/resources/oauth2",
+    "redirect": "/docs/api/resources/oidc/index.html"
+  },
+  {
+    "path": "/docs/how-to/beta-auth-service/api-access-management-troubleshooting",
+    "redirect": "/docs/api/resources/oidc/index.html"
+  },
+  {
+    "path": "/standards/OIDC/",
+    "redirect": "/docs/api/resources/oidc/index.html"
+  },
+  {
+    "path": "/standards/OAuth/",
+    "redirect": "/docs/api/resources/oidc/index.html"
+  },
+  {
+    "path": "/reference/authentication_reference",
+    "redirect": "/docs/api/resources/oidc/index.html"
+  },
+  {
+    "path": "/docs/getting_started/policy.html",
+    "redirect": "/docs/api/resources/policy/index.html"
+  },
+  {
+    "path": "/docs/api/rest/sessions.html",
+    "redirect": "/docs/api/resources/sessions/index.html"
+  },
+  {
+    "path": "/docs/api/rest/templates.html",
+    "redirect": "/docs/api/resources/templates/index.html"
+  },
+  {
+    "path": "/docs/getting_started/tokens.html",
+    "redirect": "/docs/api/resources/tokens/index.html"
+  },
+  {
+    "path": "/docs/api/rest/users.html",
+    "redirect": "/docs/api/resources/users/index.html"
+  },
+  {
+    "path": "/docs/api/resources/user",
+    "redirect": "/docs/api/resources/users/index.html"
   },
   {
     "path": "/docs/platform-release-notes/platform-release-notes/index.html",
@@ -316,16 +532,104 @@
     "redirect": "/docs/change-log/"
   },
   {
+    "path": "/docs/getting_started/error_codes",
+    "redirect": "/reference/error_codes/index.html"
+  },
+  {
+    "path": "/docs/api/getting_started/error_codes",
+    "redirect": "/reference/error_codes/index.html"
+  },
+  {
+    "path": "/docs/getting_started/okta_expression_lang",
+    "redirect": "/reference/okta_expression_language/index.html"
+  },
+  {
+    "path": "/docs/api/getting_started/okta_expression_lang",
+    "redirect": "/reference/okta_expression_language/index.html"
+  },
+  {
+    "path": "/docs/guides/scim_guidance.html",
+    "redirect": "/reference/scim/index.html"
+  },
+  {
+    "path": "/docs/guides/scim_developer_program.html",
+    "redirect": "/reference/scim/index.html"
+  },
+  {
     "path": "/standards/SAML/index.html",
     "redirect": "https://www.okta.com/integrate/documentation/saml/"
+  },
+  {
+    "path": "/docs/getting_started/saml_guidance.html",
+    "redirect": "/standards/SAML/index.html"
+  },
+  {
+    "path": "/docs/guides/saml_guidance.html",
+    "redirect": "/standards/SAML/index.html"
+  },
+  {
+    "path": "/docs/guides/setting_up_a_saml_application_in_okta",
+    "redirect": "/standards/SAML/setting_up_a_saml_application_in_okta/index.html"
+  },
+  {
+    "path": "/docs/guides/setting_up_a_saml_application_in_okta.html",
+    "redirect": "/standards/SAML/setting_up_a_saml_application_in_okta/index.html"
+  },
+  {
+    "path": "/docs/examples/configuring_a_saml_application_in_okta",
+    "redirect": "/standards/SAML/setting_up_a_saml_application_in_okta/index.html"
+  },
+  {
+    "path": "/docs/examples/configuring_a_saml_application_in_okta.html",
+    "redirect": "/standards/SAML/setting_up_a_saml_application_in_okta/index.html"
   },
   {
     "path": "/standards/SCIM/index.html",
     "redirect": "https://www.okta.com/integrate/documentation/scim/"
   },
   {
+    "path": "/docs/guides/scim_guidance.html",
+    "redirect": "/standards/SCIM/index.html"
+  },
+  {
+    "path": "/docs/guides/scim_developer_program.html",
+    "redirect": "/standards/SCIM/index.html"
+  },
+  {
+    "path": "/docs/api/resources/resource-server-beta/",
+    "redirect": "/use_cases/api_access_management/index.html"
+  },
+  {
+    "path": "/docs/api/resources/resource-server-beta/required-config-changes-for-auth-server",
+    "redirect": "/use_cases/api_access_management/index.html"
+  },
+  {
+    "path": "/docs/examples/session_cookie.html",
+    "redirect": "/use_cases/authentication/session_cookie/index.html"
+  },
+  {
+    "path": "/use_cases/events-api-deprecation/",
+    "redirect": "/use_cases/events-api-migration/index.html"
+  },
+  {
+    "path": "/use_cases/inline_hooks/api_am_hook/api_am_hook",
+    "redirect": "/use_cases/inline_hooks/token_hook/token_hook/index.html"
+  },
+  {
     "path": "/use_cases/integrate_with_okta/index.html",
     "redirect": "https://www.okta.com/integrate/"
+  },
+  {
+    "path": "/docs/api/getting_started/oan_guidance",
+    "redirect": "/use_cases/integrate_with_okta/index.html"
+  },
+  {
+    "path": "/docs/guides/oan_guidance",
+    "redirect": "/use_cases/integrate_with_okta/index.html"
+  },
+  {
+    "path": "/use_cases/sso_and_provisioning/draft",
+    "redirect": "/use_cases/integrate_with_okta/index.html"
   },
   {
     "path": "/use_cases/integrate_with_okta/oan-faqs/index.html",
@@ -362,5 +666,13 @@
   {
     "path": "/use_cases/isv/zindex/index.html",
     "redirect": "https://www.okta.com/integrate/documentation/isv-partner-integrations/"
+  },
+  {
+    "path": "/docs/guides/add_mfa.html",
+    "redirect": "/use_cases/mfa/index.html"
+  },
+  {
+    "path": "/docs/guides/okta_mobile_connect.html",
+    "redirect": "/use_cases/mobile/okta_mobile_connect/index.html"
   }
 ]

--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -3,18 +3,24 @@ redirects:
    to: /documentation/
  - from: /use_cases/api_security
    to: /use_cases/api_access_management/
- - from: /docs/how-to/set-up-auth-server.html
-   to: /authentication-guide/implementing-authentication/set-up-authz-server/index.html
  - from: /3rd_party_notices/Okta_Rum_Tool
    to: /3rd_party_notices/Okta_Cloud_Provisioning_Connector_Tool/index.html
+ - from: /docs/how-to/set-up-auth-server.html
+   to: /authentication-guide/implementing-authentication/set-up-authz-server/index.html
+ - from: /docs/how-to/inbound-saml-with-oidc
+   to: /authentication-guide/saml-login/index.html
+ - from: /docs/api/resources/social_authentication
+   to: /authentication-guide/social-login/index.html
  - from: /code/dotnet/
    to: /code/dotnet/aspnetcore/index.html
  - from: /code/dotnet/index.html
    to: /code/dotnet/aspnetcore/
  - from: /code/dotnet/okta-oidc-spa-osw-aspnet
    to: /code/dotnet/index.html
- - from: /docs/api/resources/social_authentication
-   to: /authentication-guide/social-login/index.html
+ - from: /code/dotnet/okta-oauth-spa-authjs-osw
+   to: /code/dotnet/index.html
+ - from: /code/dotnet/okta-oauth-aspnet-codeflow
+   to: /code/dotnet/index.html
  - from: /docs/examples/dotnet_sample_application.html
    to: /code/dotnet/sample_application/index.html
  - from: /code/dotnet/sdk/index.html
@@ -111,10 +117,10 @@ redirects:
    to: /docs/api/resources/oidc/index.html
  - from: /docs/getting_started/policy.html
    to: /docs/api/resources/policy/index.html
- - from: /docs/api/rest/templates.html
-   to: /docs/api/resources/templates/index.html
  - from: /docs/api/rest/sessions.html
    to: /docs/api/resources/sessions/index.html
+ - from: /docs/api/rest/templates.html
+   to: /docs/api/resources/templates/index.html
  - from: /docs/getting_started/tokens.html
    to: /docs/api/resources/tokens/index.html
  - from: /docs/api/rest/users.html
@@ -155,9 +161,9 @@ redirects:
    to: /docs/change-log/
  - from: /docs/platform-release-notes/platform-release-notes2016-40/index.html
    to: /docs/change-log/
- - from: /docs/platform-release-notes/platform-release-notes2016-43/index.html
-   to: /docs/change-log/
  - from: /docs/platform-release-notes/platform-release-notes2016-41/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-43/index.html
    to: /docs/change-log/
  - from: /docs/platform-release-notes/platform-release-notes2016-45/index.html
    to: /docs/change-log/
@@ -169,11 +175,11 @@ redirects:
    to: /docs/change-log/
  - from: /docs/platform-release-notes/platform-release-notes2016-50/index.html
    to: /docs/change-log/
- - from: /docs/platform-release-notes/platform-release-notes2016-index/index.html
+ - from: /docs/platform-release-notes/platform-release-notes2016-51/index.html
    to: /docs/change-log/
  - from: /docs/platform-release-notes/platform-release-notes2016-52/index.html
    to: /docs/change-log/
- - from: /docs/platform-release-notes/platform-release-notes2016-51/index.html
+ - from: /docs/platform-release-notes/platform-release-notes2016-index/index.html
    to: /docs/change-log/
  - from: /docs/platform-release-notes/platform-release-notes2017-02/index.html
    to: /docs/change-log/
@@ -185,19 +191,19 @@ redirects:
    to: /docs/change-log/
  - from: /docs/platform-release-notes/platform-release-notes2017-09/index.html
    to: /docs/change-log/
- - from: /docs/how-to/inbound-saml-with-oidc
-   to: /authentication-guide/saml-login/index.html
  - from: /docs/platform-release-notes/platform-release-notes2017-10/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-11/index.html
    to: /docs/change-log/
  - from: /docs/platform-release-notes/platform-release-notes2017-12/index.html
    to: /docs/change-log/
  - from: /docs/platform-release-notes/platform-release-notes2017-15/index.html
    to: /docs/change-log/
- - from: /docs/platform-release-notes/platform-release-notes2017-18/index.html
-   to: /docs/change-log/
  - from: /docs/platform-release-notes/platform-release-notes2017-16/index.html
    to: /docs/change-log/
  - from: /docs/platform-release-notes/platform-release-notes2017-17/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-18/index.html
    to: /docs/change-log/
  - from: /docs/platform-release-notes/platform-release-notes2017-19/index.html
    to: /docs/change-log/
@@ -233,9 +239,9 @@ redirects:
    to: /docs/change-log/
  - from: /docs/platform-release-notes/platform-release-notes2017-35/index.html
    to: /docs/change-log/
- - from: /docs/platform-release-notes/platform-release-notes2017-38/index.html
-   to: /docs/change-log/
  - from: /docs/platform-release-notes/platform-release-notes2017-36/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-38/index.html
    to: /docs/change-log/
  - from: /docs/platform-release-notes/platform-release-notes2017-40/index.html
    to: /docs/change-log/
@@ -259,8 +265,8 @@ redirects:
    to: /docs/change-log/
  - from: /docs/platform-release-notes/platform-release-notes2017-index/index.html
    to: /docs/change-log/
- - from: /code/dotnet/okta-oauth-spa-authjs-osw
-   to: /code/dotnet/index.html
+ - from: /docs/getting_started/error_codes
+   to: /reference/error_codes/index.html
  - from: /docs/api/getting_started/error_codes
    to: /reference/error_codes/index.html
  - from: /docs/getting_started/okta_expression_lang
@@ -287,9 +293,9 @@ redirects:
    to: /standards/SAML/setting_up_a_saml_application_in_okta/index.html
  - from: /standards/SCIM/index.html
    to: https://www.okta.com/integrate/documentation/scim/
- - from: /docs/guides/scim_developer_program.html
-   to: /standards/SCIM/index.html
  - from: /docs/guides/scim_guidance.html
+   to: /standards/SCIM/index.html
+ - from: /docs/guides/scim_developer_program.html
    to: /standards/SCIM/index.html
  - from: /docs/api/resources/resource-server-beta/
    to: /use_cases/api_access_management/index.html
@@ -305,12 +311,6 @@ redirects:
    to: https://www.okta.com/integrate/
  - from: /docs/api/getting_started/oan_guidance
    to: /use_cases/integrate_with_okta/index.html
- - from: /docs/getting_started/error_codes
-   to: /reference/error_codes/index.html
- - from: /code/dotnet/okta-oauth-aspnet-codeflow
-   to: /code/dotnet/index.html
- - from: /docs/platform-release-notes/platform-release-notes2017-11/index.html
-   to: /docs/change-log/
  - from: /docs/guides/oan_guidance
    to: /use_cases/integrate_with_okta/index.html
  - from: /use_cases/sso_and_provisioning/draft
@@ -323,17 +323,17 @@ redirects:
    to: https://www.okta.com/integrate/documentation/provisioning/
  - from: /use_cases/integrate_with_okta/sso-with-saml/index.html
    to: https://www.okta.com/integrate/documentation/single-sign-on/
- - from: /use_cases/isv/security-analytics/index.html
-   to: https://www.okta.com/integrate/documentation/security-enforcement-integrations/security-analytics/
  - from: /use_cases/isv/embedded-occ/index.html
    to: https://www.okta.com/integrate/documentation/embedded-okta-cloud-connect/
+ - from: /use_cases/isv/isv-syslog-references/index.html
+   to: https://www.okta.com/integrate/documentation/security-enforcement-integrations/
+ - from: /use_cases/isv/security-analytics/index.html
+   to: https://www.okta.com/integrate/documentation/security-enforcement-integrations/security-analytics/
+ - from: /use_cases/isv/security-enforcement/index.html
+   to: https://www.okta.com/integrate/documentation/security-enforcement-integrations/
  - from: /use_cases/isv/zindex/index.html
    to: https://www.okta.com/integrate/documentation/isv-partner-integrations/
  - from: /docs/guides/add_mfa.html
    to: /use_cases/mfa/index.html
  - from: /docs/guides/okta_mobile_connect.html
    to: /use_cases/mobile/okta_mobile_connect/index.html
- - from: /use_cases/isv/security-enforcement/index.html
-   to: https://www.okta.com/integrate/documentation/security-enforcement-integrations/
- - from: /use_cases/isv/isv-syslog-references/index.html
-   to: https://www.okta.com/integrate/documentation/security-enforcement-integrations/

--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -1,14 +1,339 @@
-# This file instructs conductor to set up S3 redirections. Each redirect has a from and to property, and
-# conductor will set up a 301 redirect for each entry.
-# For the 'from:' attribute, include the leading slash, but not a leading slash.
-# For the 'to:' attribute, any valid URL path can be used, but make sure to include the leading slash.
-# Some examples:
-#   - from: /old.html
-#     to: /new.html
-#   - from: /old-path
-#     to: /new-path
-#   - from: /iossetupinstructions.html
-#     to: /ios/setup/instructions.html
-
-redirects:
-
+redirects: 
+ - from: /code
+   to: /documentation/
+ - from: /use_cases/api_security
+   to: /use_cases/api_access_management/
+ - from: /docs/how-to/set-up-auth-server.html
+   to: /authentication-guide/implementing-authentication/set-up-authz-server/index.html
+ - from: /3rd_party_notices/Okta_Rum_Tool
+   to: /3rd_party_notices/Okta_Cloud_Provisioning_Connector_Tool/index.html
+ - from: /code/dotnet/
+   to: /code/dotnet/aspnetcore/index.html
+ - from: /code/dotnet/index.html
+   to: /code/dotnet/aspnetcore/
+ - from: /code/dotnet/okta-oidc-spa-osw-aspnet
+   to: /code/dotnet/index.html
+ - from: /docs/api/resources/social_authentication
+   to: /authentication-guide/social-login/index.html
+ - from: /docs/examples/dotnet_sample_application.html
+   to: /code/dotnet/sample_application/index.html
+ - from: /code/dotnet/sdk/index.html
+   to: https://github.com/okta/okta-sdk-dotnet
+ - from: /code/swift/
+   to: /code/ios/index.html
+ - from: /code/java/jwt-validation/index.html
+   to: https://github.com/okta/okta-jwt-verifier-java
+ - from: /docs/examples/spring_security_saml.html
+   to: /code/java/spring_security_saml/index.html
+ - from: /docs/guides/spring_security_saml.html
+   to: /code/java/spring_security_saml/index.html
+ - from: /docs/guides/okta_auth_sdk.html
+   to: /code/javascript/okta_auth_sdk/index.html
+ - from: /code/javascript/okta_auth_sdk_ref/index.html
+   to: https://github.com/okta/okta-auth-js
+ - from: /code/javascript/okta_auth_sdk_external_ref.html
+   to: /code/javascript/okta_auth_sdk_ref/index.html
+ - from: /docs/guides/okta_sign-in_widget.html
+   to: /code/javascript/okta_sign-in_widget/index.html
+ - from: /code/javascript/okta_sign-in_widget_ref/index.html
+   to: https://github.com/okta/okta-signin-widget
+ - from: /code/javascript/okta_sign-in_widget_external_ref.html
+   to: /code/javascript/okta_sign-in_widget_ref/index.html
+ - from: /docs/api/resources/okta_signin_widget.html
+   to: /code/javascript/okta_sign-in_widget_ref/index.html
+ - from: /code/php/jwt-validation/index.html
+   to: https://github.com/okta/okta-jwt-verifier-php
+ - from: /code/php/quickstart-signin-widget/index.html
+   to: /quickstart/#/okta-sign-in-page/php/generic
+ - from: /docs/guides/simplesamlphp.html
+   to: /code/php/simplesamlphp/index.html
+ - from: /docs/examples/pysaml2.html
+   to: /code/python/pysaml2/index.html
+ - from: /docs/guides/pysaml2.html
+   to: /code/python/pysaml2/index.html
+ - from: /code/python/sdk/index.html
+   to: https://github.com/okta/okta-sdk-python
+ - from: /docs/getting_started/api_test_client.html
+   to: /code/rest/index.html
+ - from: /docs/api/getting_started/api_test_client.html
+   to: /code/rest/index.html
+ - from: /docs/api/getting_started/index.html
+   to: /code/rest/index.html
+ - from: /docs/api/getting_started/
+   to: /code/rest/index.html
+ - from: /docs/getting_started/design_principles.html
+   to: /docs/api/getting_started/design_principles/index.html
+ - from: docs/api/index.html
+   to: /docs/api/getting_started/design_principles/index.html
+ - from: docs/api/
+   to: /docs/api/getting_started/design_principles/index.html
+ - from: /docs/getting_started/getting_a_token.html
+   to: /docs/api/getting_started/getting_a_token/index.html
+ - from: /docs/getting_started/design_principles
+   to: /docs/api/getting_started/rate-limits/index.html
+ - from: /docs/api/
+   to: /docs/api/resources/apps/index.html
+ - from: /docs/api/resources/
+   to: /docs/api/resources/apps/index.html
+ - from: /docs/api/reference/
+   to: /docs/api/resources/apps/index.html
+ - from: /docs/api/reference/index.html
+   to: /docs/api/resources/apps/index.html
+ - from: /docs/api/rest/apps.html
+   to: /docs/api/resources/apps/index.html
+ - from: /docs/api/rest/authn.html
+   to: /docs/api/resources/authn/index.html
+ - from: /docs/api/resources/index.html
+   to: /docs/api/resources/authn/index.html
+ - from: /docs/api/resources/
+   to: /docs/api/resources/authn/index.html
+ - from: /docs/api/rest/events.html
+   to: /docs/api/resources/events/index.html
+ - from: /docs/getting_started/factor_admin.html
+   to: /docs/api/resources/factor_admin/index.html
+ - from: /docs/api/rest/factors.html
+   to: /docs/api/resources/factors/index.html
+ - from: /docs/api/rest/groups.html
+   to: /docs/api/resources/groups/index.html
+ - from: docs/api/rest/idps.html
+   to: /docs/api/resources/idps/index.html
+ - from: /docs/api/rest/oauth-clients.html
+   to: /docs/api/resources/oauth-clients/index.html
+ - from: /docs/api/resources/oauth2
+   to: /docs/api/resources/oidc/index.html
+ - from: /docs/how-to/beta-auth-service/api-access-management-troubleshooting
+   to: /docs/api/resources/oidc/index.html
+ - from: /standards/OIDC/
+   to: /docs/api/resources/oidc/index.html
+ - from: /standards/OAuth/
+   to: /docs/api/resources/oidc/index.html
+ - from: /reference/authentication_reference
+   to: /docs/api/resources/oidc/index.html
+ - from: /docs/getting_started/policy.html
+   to: /docs/api/resources/policy/index.html
+ - from: /docs/api/rest/templates.html
+   to: /docs/api/resources/templates/index.html
+ - from: /docs/api/rest/sessions.html
+   to: /docs/api/resources/sessions/index.html
+ - from: /docs/getting_started/tokens.html
+   to: /docs/api/resources/tokens/index.html
+ - from: /docs/api/rest/users.html
+   to: /docs/api/resources/users/index.html
+ - from: /docs/api/resources/user
+   to: /docs/api/resources/users/index.html
+ - from: /docs/platform-release-notes/platform-release-notes/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-23/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-24/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-25/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-26/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-27/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-28/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-29/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-30/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-31/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-33/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-34/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-35/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-36/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-37/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-39/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-40/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-43/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-41/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-45/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-46/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-47/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-49/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-50/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-index/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-52/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2016-51/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-02/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-03/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-04/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-05/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-09/index.html
+   to: /docs/change-log/
+ - from: /docs/how-to/inbound-saml-with-oidc
+   to: /authentication-guide/saml-login/index.html
+ - from: /docs/platform-release-notes/platform-release-notes2017-10/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-12/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-15/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-18/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-16/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-17/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-19/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-20/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-21/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-22/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-23/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-24/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-25/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-26/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-27/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-28/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-29/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-30/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-31/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-32/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-33/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-34/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-35/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-38/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-36/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-40/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-41/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-42/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-43/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-44/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-45/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-46/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-47/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-49/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-50/index.html
+   to: /docs/change-log/
+ - from: /docs/platform-release-notes/platform-release-notes2017-index/index.html
+   to: /docs/change-log/
+ - from: /code/dotnet/okta-oauth-spa-authjs-osw
+   to: /code/dotnet/index.html
+ - from: /docs/api/getting_started/error_codes
+   to: /reference/error_codes/index.html
+ - from: /docs/getting_started/okta_expression_lang
+   to: /reference/okta_expression_language/index.html
+ - from: /docs/api/getting_started/okta_expression_lang
+   to: /reference/okta_expression_language/index.html
+ - from: /docs/guides/scim_guidance.html
+   to: /reference/scim/index.html
+ - from: /docs/guides/scim_developer_program.html
+   to: /reference/scim/index.html
+ - from: /standards/SAML/index.html
+   to: https://www.okta.com/integrate/documentation/saml/
+ - from: /docs/getting_started/saml_guidance.html
+   to: /standards/SAML/index.html
+ - from: /docs/guides/saml_guidance.html
+   to: /standards/SAML/index.html
+ - from: /docs/guides/setting_up_a_saml_application_in_okta
+   to: /standards/SAML/setting_up_a_saml_application_in_okta/index.html
+ - from: /docs/guides/setting_up_a_saml_application_in_okta.html
+   to: /standards/SAML/setting_up_a_saml_application_in_okta/index.html
+ - from: /docs/examples/configuring_a_saml_application_in_okta
+   to: /standards/SAML/setting_up_a_saml_application_in_okta/index.html
+ - from: /docs/examples/configuring_a_saml_application_in_okta.html
+   to: /standards/SAML/setting_up_a_saml_application_in_okta/index.html
+ - from: /standards/SCIM/index.html
+   to: https://www.okta.com/integrate/documentation/scim/
+ - from: /docs/guides/scim_developer_program.html
+   to: /standards/SCIM/index.html
+ - from: /docs/guides/scim_guidance.html
+   to: /standards/SCIM/index.html
+ - from: /docs/api/resources/resource-server-beta/
+   to: /use_cases/api_access_management/index.html
+ - from: /docs/api/resources/resource-server-beta/required-config-changes-for-auth-server
+   to: /use_cases/api_access_management/index.html
+ - from: /docs/examples/session_cookie.html
+   to: /use_cases/authentication/session_cookie/index.html
+ - from: /use_cases/events-api-deprecation/
+   to: /use_cases/events-api-migration/index.html
+ - from: /use_cases/inline_hooks/api_am_hook/api_am_hook
+   to: /use_cases/inline_hooks/token_hook/token_hook/index.html
+ - from: /use_cases/integrate_with_okta/index.html
+   to: https://www.okta.com/integrate/
+ - from: /docs/api/getting_started/oan_guidance
+   to: /use_cases/integrate_with_okta/index.html
+ - from: /docs/getting_started/error_codes
+   to: /reference/error_codes/index.html
+ - from: /code/dotnet/okta-oauth-aspnet-codeflow
+   to: /code/dotnet/index.html
+ - from: /docs/platform-release-notes/platform-release-notes2017-11/index.html
+   to: /docs/change-log/
+ - from: /docs/guides/oan_guidance
+   to: /use_cases/integrate_with_okta/index.html
+ - from: /use_cases/sso_and_provisioning/draft
+   to: /use_cases/integrate_with_okta/index.html
+ - from: /use_cases/integrate_with_okta/oan-faqs/index.html
+   to: https://www.okta.com/integrate/documentation/oin-faq/
+ - from: /use_cases/integrate_with_okta/promotion/index.html
+   to: https://www.okta.com/integrate/documentation/promotion/
+ - from: /use_cases/integrate_with_okta/provisioning/index.html
+   to: https://www.okta.com/integrate/documentation/provisioning/
+ - from: /use_cases/integrate_with_okta/sso-with-saml/index.html
+   to: https://www.okta.com/integrate/documentation/single-sign-on/
+ - from: /use_cases/isv/security-analytics/index.html
+   to: https://www.okta.com/integrate/documentation/security-enforcement-integrations/security-analytics/
+ - from: /use_cases/isv/embedded-occ/index.html
+   to: https://www.okta.com/integrate/documentation/embedded-okta-cloud-connect/
+ - from: /use_cases/isv/zindex/index.html
+   to: https://www.okta.com/integrate/documentation/isv-partner-integrations/
+ - from: /docs/guides/add_mfa.html
+   to: /use_cases/mfa/index.html
+ - from: /docs/guides/okta_mobile_connect.html
+   to: /use_cases/mobile/okta_mobile_connect/index.html
+ - from: /use_cases/isv/security-enforcement/index.html
+   to: https://www.okta.com/integrate/documentation/security-enforcement-integrations/
+ - from: /use_cases/isv/isv-syslog-references/index.html
+   to: https://www.okta.com/integrate/documentation/security-enforcement-integrations/


### PR DESCRIPTION
This PR addresses 404's because of missing redirects that Jekyll was doing via its magical black box.