### PR TITLE
Table of Contents updates

### DIFF
--- a/packages/@okta/vuepress-plugin-active-header-links/index.js
+++ b/packages/@okta/vuepress-plugin-active-header-links/index.js
@@ -1,10 +1,17 @@
-const { path } = require('@vuepress/shared-utils')
+const { path, extractHeaders } = require('@vuepress/shared-utils')
 
-module.exports = (options) => ({
+module.exports = (options, context) => ({
   clientRootMixin: path.resolve(__dirname, 'clientRootMixin.js'),
   define: {
     AHL_SIDEBAR_LINK_SELECTOR: options.sidebarLinkSelector || '.sidebar-link',
     AHL_HEADER_ANCHOR_SELECTOR: options.headerAnchorSelector || '.header-anchor',
     AHL_HEADER_TOP_OFFSET: options.headerTopOffset || 90
+  },
+  extendPageData ($page) {
+    $page.fullHeaders = extractHeaders(
+      $page._strippedContent,
+      ['h2', 'h3', 'h4'],
+      context.markdown
+    )
   }
 })

--- a/packages/@okta/vuepress-theme-default/components/Page.vue
+++ b/packages/@okta/vuepress-theme-default/components/Page.vue
@@ -9,27 +9,18 @@
     <!-- End Content -->
 
     <!-- Begin Table Of Contents -->
-    <TableOfContents v-if="showToc" class="TableOfContents" :items="toc"></TableOfContents>
+    <TableOfContents v-if="showToc" class="TableOfContents"></TableOfContents>
     <!-- End Table Of Contents -->
   </section>
 </template>
 
 <script>
-import { resolveHeaders } from '../util/index'
 export default {
   components: {
     TableOfContents: () => import('./TableOfContents.vue'),
     Sidebar: () => import('./Sidebar.vue')
   },
 
-  data() {
-    return {
-      toc: []
-    }
-  },
-  mounted() {
-    window.addEventListener("load", this.getAllHeaders)
-  },
   computed: {
     showToc () {
       if (this.$page.frontmatter.showToc === false) {
@@ -42,23 +33,6 @@ export default {
 
       return true;
     }
-  },
-  methods: {
-    getAllHeaders(event) {
-      let headers = document.querySelectorAll('.PageContent-main>h1, .PageContent-main>h2, .PageContent-main>h3, .PageContent-main>h4.api.api-operation, .PageContent-main>h4:not(.api)')
-      this.toc = Array.from(headers).map(header => {
-        return  {
-          level: header.localName.split('h')[1] == '1' ? '2': header.localName.split('h')[1],
-          title: header.innerText,
-          href: '#'+header.id,
-          node: header,
-          display: ''
-        }
-      })
-    }
-  },
-  beforeDestroy() {
-    window.removeEventListener('load', this.getAllHeaders);
   }
 }
 </script>

--- a/tests/selenium/spec/table-of-contents-spec.js
+++ b/tests/selenium/spec/table-of-contents-spec.js
@@ -21,7 +21,6 @@ describe('table of contents navigation spec', () => {
   it('has basic table of contents in the test page', util.itHelper(async () => {
     expect(await tocPage.getLevelOneItemText()).to.equal('Test Page');
     expect(await tocPage.getLevelTwoItemsText()).to.include.members([
-      'Overview',
       'First Section',
       'Second Section',
       'Third Section',


### PR DESCRIPTION
This updates the way table of contents is created. 

It uses the active header links plugin to build the headers and place them onto the `$page` object to be used. This removes a whole lot of complexity in the process and makes it function much quicker and more reliable.