### PR TITLE
Set max-width on QuickStart bodies

### DIFF
--- a/packages/@okta/vuepress-theme-default/assets/css/okta/pages/quickstarts.scss
+++ b/packages/@okta/vuepress-theme-default/assets/css/okta/pages/quickstarts.scss
@@ -50,7 +50,7 @@
 
 // Disable the margin width determined by the parent CSS.
 .PageContent-main#quickstart-body {
-  max-width: none;
+  max-width: 1050px;
   padding: 64px 0;
 }
 


### PR DESCRIPTION
Prevents long URLs in code snippets from causing this entire div to overflow