### PR TITLE
Guides overview self link

### DIFF
--- a/packages/@okta/vuepress-theme-default/layouts/Guides.vue
+++ b/packages/@okta/vuepress-theme-default/layouts/Guides.vue
@@ -68,7 +68,7 @@
 
         if(!lang) { 
           lang = findMainLanguagesOfGuide({ guide, pages })[0];
-          if(window) { 
+          if(window && guide) { 
             window.location.hash = makeGuideHash({ guide, lang, sectionNum });
           }
         }


### PR DESCRIPTION
"undefined" unexpectedly uncovered in url is understandably undesired