### PR TITLE
Py okta 217213 new oauth2 rate limits second try

### DIFF
--- a/packages/@okta/vuepress-site/docs/api/getting_started/rate-limits/index.md
+++ b/packages/@okta/vuepress-site/docs/api/getting_started/rate-limits/index.md
@@ -42,7 +42,7 @@ Note that limits for more specific endpoints override the limits for less specif
 | Action and Okta API Endpoint                                                                                 | Developer (free) | Developer (paid) | One App | Enterprise | Workforce Identity |
 | ------------------------------------------------------------------------------------------------------------ | ---------------- | ---------------- | ------- | ---------- | ------------------ |
 | **Authenticate different end users:**<br>`/api/v1/authn`                                                     | 100              | 300              | 300*    | 600*       | 500                |
-| **Verify a factor:**<br>`/api/v1/authn/factors/{id}/verify` only                                             | 100              | 300              | 300*    | 600*       | - (Shared with `/api/v1/authn`)                |
+| **Verify a factor:**<br>`/api/v1/authn/factors/{id}/verify` only                                             | 100              | 300              | 300*    | 600*       | shared with `/api/v1/authn`                |
 | **Create or list applications:**<br>`/api/v1/apps` except `/api/v1/apps/{id}`                                | 20               | 25               | 25      | 50         | 100                |
 | **Get, update, or delete an application by ID:**<br>`/api/v1/apps/{id}` only                                 | 100              | 300              | 300*    | 600*       | 500                |
 | **Create or list groups:**<br>`/api/v1/groups` except `/api/v1/groups/{id}`                                  | 100              | 300              | 300     | 600        | 500                |
@@ -51,12 +51,14 @@ Note that limits for more specific endpoints override the limits for less specif
 | **Get a user by ID or login:**<br>Only `GET` to `/api/v1/users/{idOrLogin}`                                  | 100              | 300              | 300*    | 1000*      | 2000               |
 | **Update or delete a user by ID:**<br>Only `POST`, `PUT` or `DELETE` to `/api/v1/users/{id}`                 | 100              | 300              | 300*    | 600*       | 600                |
 | **Get System Log data:**<br>`/api/v1/logs`                                                                   | 20               | 25               | 25      | 50         | 120                |
-| **Get System Log data:**<br>`/api/v1/events`                                                                 | 20               | 25               | 25      | 50         | - (Shared with `/api/v1`)               |
+| **Get System Log data:**<br>`/api/v1/events`                                                                 | 20               | 25               | 25      | 50         | shared with `/api/v1`               |
 | **Get session information:**<br>`/api/v1/sessions`                                                           | 100              | 300              | 300*    | 600*       | 750                |
 | **Create an organization:**<br>`/api/v1/orgs`                                                                | N/A              | N/A              | N/A     | 50         | 50                 |
-| **Authorize request to a custom Authorization Server:**<br>`/oauth2/{authServerId}/v1/authorize`             | 100              | 300              | 300*    | 600*       | 10000              |
-| **Token request to a custom Authorization Server:**<br>`/oauth2/{authServerId}/v1/token`                     | 100              | 300              | 300*    | 600*       | 10000              |
-| **All other actions:**<br>`/api/v1`                                                                         | 100              | 300              | 300*    | 600*       | 1000               |
+| **OAuth2 requests for Custom Authorization Servers:**<br>`/oauth2/{authorizationServerId}/v1`                | 300              | 600              | 600*    | 1200*      | 2000               |
+| **OAuth2 requests for the Org Authorization Server:**<br>`/oauth2/v1` except `/oauth2/v1/clients`            | 300              | 600              | 600*    | 1200*      | 2000               |
+| **OAuth2 client configuration requests:**<br>`/oauth2/v1/clients`                                            | 25               | 50               | 50      | 100        | 100                |
+| **All other OAuth2 requests:**<br>`/oauth2`                                                                  | 100              | 300              | 300     | 600        | 600                |
+| **All other actions:**<br>`/api/v1/`                                                                         | 100              | 300              | 300*    | 600*       | 1200               |
 
 These rate limits apply to all new Okta organizations. For orgs created before 2018-05-17, the [previous rate limits](#previous-rate-limits) still apply.
 
@@ -110,9 +112,9 @@ The following are the high capacity rate limits per minute that apply across the
 
 | Endpoint                                                                   | One App   | Enterprise   |
 | -------------------------------------------------------------------------- | --------- | ------------ |
+| `/oauth2/{authorizationServerId}/v1`                                       | 3000      | 6000         |
+| `/oauth2/v1` except `/oauth2/v1/clients`                                   | 3000      | 6000         |
 | `/api/v1`                                                                  | 1500      | 3000         |
-| `/oauth2/{authorizationServerId}/v1/token`                                 | 1500      | 3000         |
-| `/oauth2/{authorizationServerId}/v1/authorize`                             | 1500      | 3000         |
 | `/api/v1/sessions`                                                         | 1500      | 3000         |
 | `/app/template_saml_2_0/{key}/sso/saml`                                    | 1500      | 3000         |
 | `/app/{app}/{key}/sso/saml`                                                | 1500      | 3000         |


### PR DESCRIPTION
## Description:
Update rate limit documentation regarding OAuth2 APIs
![Screen Shot 2019-03-29 at 1 13 49 PM](https://user-images.githubusercontent.com/11844341/55260141-cd68ab80-5224-11e9-89bc-f946034b2cd5.png)
![Screen Shot 2019-03-29 at 1 13 55 PM](https://user-images.githubusercontent.com/11844341/55260142-cd68ab80-5224-11e9-834f-5f178f0529b1.png)
![Screen Shot 2019-03-29 at 1 13 58 PM](https://user-images.githubusercontent.com/11844341/55260143-cd68ab80-5224-11e9-9ca5-ea312b420021.png)
![Screen Shot 2019-03-29 at 1 14 09 PM](https://user-images.githubusercontent.com/11844341/55260144-ce014200-5224-11e9-8ea1-f1ae98184ba3.png)


- **Is this PR related to a Monolith release?** April major release

### Resolves:
* [OKTA-217213](https://oktainc.atlassian.net/browse/OKTA-217213)
