### PR TITLE
feat(guides): Switches to using path instead of hash routes for guides

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/enhanceApp.js
+++ b/packages/@okta/vuepress-site/.vuepress/enhanceApp.js
@@ -1,7 +1,13 @@
 var redirectsJson = require('./redirects.json');
 import pageComponents from '@internal/page-components'
+import Guides from '@okta/vuepress-theme-default/layouts/Guides.vue';
 
 export default ({ router, Vue }) => {
-  router.addRoutes(redirectsJson)
-
+  router.addRoutes(redirectsJson);
+  router.addRoutes([
+    {
+      path: '/guides/:guide?/:framework?/:section?',
+      component: Guides,
+    },
+  ]);
 }

--- a/packages/@okta/vuepress-site/guides/protect-your-api/index.md
+++ b/packages/@okta/vuepress-site/guides/protect-your-api/index.md
@@ -1,3 +1,5 @@
 ---
 title: Protect Your API Endpoints
+excerpt: Learn how to add authentication and validate requests on your back-end API endpoints using Okta's APIs and libraries.
+layout: Guides
 ---

--- a/packages/@okta/vuepress-site/guides/sign-into-mobile-app/index.md
+++ b/packages/@okta/vuepress-site/guides/sign-into-mobile-app/index.md
@@ -1,5 +1,6 @@
 ---
 title: Sign Users into Your Mobile App
 excerpt: Learn how to add authentication to your mobile apps and sign users in using Okta's APIs and libraries.
+layout: Guides
 ---
 

--- a/packages/@okta/vuepress-site/guides/sign-into-spa/index.md
+++ b/packages/@okta/vuepress-site/guides/sign-into-spa/index.md
@@ -1,4 +1,5 @@
 ---
 title: Sign Users into Your Single-Page Application
 excerpt: Learn how to sign users into your JavaScript front-end applications and require authentication using Okta's APIs and libraries.
+layout: Guides
 ---

--- a/packages/@okta/vuepress-site/guides/sign-into-your-web-app/index.md
+++ b/packages/@okta/vuepress-site/guides/sign-into-your-web-app/index.md
@@ -1,3 +1,5 @@
 ---
 title: Sign Users into Your Web Application
+excerpt: Learn how to add authentication to your web applications and sign users in using Okta's APIs and libraries.
+layout: Guides
 ---

--- a/packages/@okta/vuepress-site/guides/sign-users-out/index.md
+++ b/packages/@okta/vuepress-site/guides/sign-users-out/index.md
@@ -1,3 +1,5 @@
 ---
 title: Sign Users Out
+excerpt: Learn how to sign users out of your applications that use Okta's APIs.
+layout: Guides
 ---

--- a/packages/@okta/vuepress-theme-default/components/FeaturedGuide.vue
+++ b/packages/@okta/vuepress-theme-default/components/FeaturedGuide.vue
@@ -1,5 +1,5 @@
 <template>
-  <a :href="guideInfo.link" class="guide-featured">
+  <router-link :to="guideInfo.link" class="guide-featured">
     <header>
       <section>
         <h1 class="title">
@@ -12,14 +12,14 @@
     </section>
     <footer>
       <section class="icons">
-        <FrameworkIconBlock :frameworks="mainLanguagesOfGuide"/>
+        <FrameworkIconBlock :frameworks="mainFrameworksOfGuide"/>
       </section>
     </footer>
-  </a>
+  </router-link>
 </template>
 
 <script>
-  import { findGuides, findMainLanguagesOfGuide } from '../util/guides';
+  import { findGuides, findMainFrameworksOfGuide } from '../util/guides';
 
   export default {
     name: 'FeaturedGuide',
@@ -28,8 +28,8 @@
       guideInfo() { 
         return findGuides({ pages: this.$site.pages }).find( g => g.name === this.guide );
       },
-      mainLanguagesOfGuide() { 
-        return findMainLanguagesOfGuide({ guide: this.guide, pages: this.$site.pages });
+      mainFrameworksOfGuide() { 
+        return findMainFrameworksOfGuide({ guide: this.guide, pages: this.$site.pages });
       },
     },
   }

--- a/packages/@okta/vuepress-theme-default/components/GuideDetails.vue
+++ b/packages/@okta/vuepress-theme-default/components/GuideDetails.vue
@@ -3,7 +3,7 @@
     <GuidesNavigation
       :sections="sections"
       :section="section"
-      :lang="lang"
+      :framework="framework"
       :guide="guide" 
     />
     <Content :pageKey="componentKey" id="guide_content" />
@@ -13,7 +13,7 @@
 <script>
   export default {
     name: 'GuideDetails',
-    props: [ 'componentKey', 'sections', 'guide', 'lang', 'section' ],
+    props: [ 'componentKey', 'sections', 'guide', 'framework', 'section' ],
     components: {
       GuidesNavigation: () => import('../components/GuidesNavigation.vue'),
     },

--- a/packages/@okta/vuepress-theme-default/components/GuidesNavigation.vue
+++ b/packages/@okta/vuepress-theme-default/components/GuidesNavigation.vue
@@ -2,13 +2,13 @@
   <aside class="guides-navigation">
     <ul class="guides">
       <li :class="{ overview: true, active: !guide }">
-        <a href="/guides/">Overview</a>
+        <router-link to="/guides/">Overview</router-link>
       </li>
       <li v-for="someGuide in guides" :class="{ active: someGuide.name === guide}">
-        <a :href="someGuide.link" class="guide">{{someGuide.title}}</a>
+        <router-link :to="someGuide.link" class="guide">{{someGuide.title}}</router-link>
         <ol v-if="someGuide.name === guide" class="sections">
           <li v-for="sec in sections" :class="{section: true, active: sec.name === section.name}">
-            <div class="highlight"><a :href="sec.makeLink(lang)">{{sec.title}}</a></div>
+            <div class="highlight"><router-link :to="sec.makeLink(framework)">{{sec.title}}</router-link></div>
           </li>
         </ol>
       </li>
@@ -20,7 +20,7 @@
   import { findGuides } from '../util/guides';
   export default {
     name: 'GuidesNavigation',
-    props: [ 'sections', 'lang', 'section', 'guide' ],
+    props: [ 'sections', 'framework', 'section', 'guide' ],
     computed: { 
       guides() { 
         return findGuides({ pages: this.$site.pages });

--- a/packages/@okta/vuepress-theme-default/components/StackSelector.vue
+++ b/packages/@okta/vuepress-theme-default/components/StackSelector.vue
@@ -2,8 +2,8 @@
   <div class="stack-selector">
     <nav class="tabs">
       <ul>
-        <li v-for="opt in options" :class="{ current: opt.lang === lang }" >
-          <a :href="opt.link"><i :class="opt.css"></i><span class="framework">{{opt.title}}</span></a>
+        <li v-for="opt in options" :class="{ current: opt.framework === framework }" >
+          <router-link :to="opt.link"><i :class="opt.css"></i><span class="framework">{{opt.title}}</span></router-link>
         </li>
       </ul>
     </nav>
@@ -19,15 +19,15 @@
     name: 'StackSelector',
     props: [ 'snippet' ],
     computed: { 
-      lang() { 
-        // Default to first available language
-        return findOnAncestor({ find: 'lang', node: this }) || this.options[0].name;
+      framework() { 
+        // Default to first available framework
+        return findOnAncestor({ find: 'framework', node: this }) || this.options[0].name;
       },
       guide() { return findOnAncestor({ find: 'guide', node: this }); },
       section() { return findOnAncestor({ find: 'section', node: this }); },
       options() { return findStackSnippets({ section: this.section, snippet: this.snippet, pages: this.$site.pages }); },     
       snippetComponentKey() { 
-        const option = this.options.find( option => option.lang === this.lang );
+        const option = this.options.find( option => option.framework === this.framework );
         return (option ? option.key : '');
       },
     },

--- a/packages/@okta/vuepress-theme-default/layouts/Guides.vue
+++ b/packages/@okta/vuepress-theme-default/layouts/Guides.vue
@@ -10,7 +10,7 @@
           :sections="sections" 
           :section="section"
           :guide="guide" 
-          :lang="lang"
+          :framework="framework"
         />
         <GuidesOverview v-else :featured="featured"/>
       </div>
@@ -22,11 +22,11 @@
 
 <script>
   import { 
-    guideFromHash,
-    makeGuideHash,
+    guideFromPath,
+    makeGuidePath,
     findGuides,
     findGuideSections,
-    findMainLanguagesOfGuide
+    findMainFrameworksOfGuide
   } from '../util/guides';
   export default {
     components: {
@@ -39,10 +39,10 @@
     data() { 
       return {
         guide: null,
-        lang: null,
+        framework: null,
         section: null,
         sections: [],
-        currentHash: null,
+        currentPath: null,
       };    
     },
     computed: { 
@@ -51,36 +51,36 @@
       },
     },
     methods: { 
-      updateHash() { 
-        this.currentHash = window.location.hash = window.location.hash || '';
+      updatePath() { 
+        this.currentPath = window.location.pathname; 
       },
     },
     beforeMount() {
-      this.updateHash();
+      this.updatePath();
     },
     
     watch: {
-      currentHash() {
-        let { guide, lang, sectionNum } = guideFromHash(this.currentHash);
+      currentPath() {
+        let { guide, framework, sectionNum } = guideFromPath(this.currentPath);
         const pages = this.$site.pages;
         const sections = findGuideSections({ guide, pages });
         const section = sections[sectionNum-1 || 0];
 
-        if(!lang) { 
-          lang = findMainLanguagesOfGuide({ guide, pages })[0];
+        if(!framework) { 
+          framework = findMainFrameworksOfGuide({ guide, pages })[0];
           if(window && guide) { 
-            window.location.hash = makeGuideHash({ guide, lang, sectionNum });
+            window.location.pathname = makeGuidePath({ guide, framework, sectionNum });
           }
         }
 
         this.sections = sections;
         this.section = section;
         this.guide = guide;
-        this.lang = lang;
+        this.framework = framework;
       },
 
       '$route' (to, from) {  
-        this.updateHash();
+        this.updatePath();
       },
     }
   }

--- a/packages/@okta/vuepress-theme-default/util/guides.js
+++ b/packages/@okta/vuepress-theme-default/util/guides.js
@@ -5,17 +5,17 @@ const FRAGMENTS = '/guides/';
 const DEFAULT_FRAMEWORK = '-'; 
 const DEFAULT_SECTION = 1;
 
-export const guideFromHash = hash => {
+export const guideFromPath = path => {
   const parts = {};
 
-  [, parts.guide, parts.lang, parts.sectionNum] = hash.match(`#${PATH_LIKE}${PATH_LIKE}${PATH_LIKE}`) || [];
-  parts.lang = parts.lang === DEFAULT_FRAMEWORK ? '' : parts.lang; // Drop useless default
+  [, parts.guide, parts.framework, parts.sectionNum] = path.match(`${FRAGMENTS}${PATH_LIKE}${PATH_LIKE}${PATH_LIKE}`) || [];
+  parts.framework = parts.framework === DEFAULT_FRAMEWORK ? '' : parts.framework; // Drop useless default
   parts.sectionNum = parts.sectionNum || DEFAULT_SECTION; // default is useable here
   return parts;
 };
 
-export const makeGuideHash = ({ guide, lang, sectionNum }) => {
-  return `#${guide}/${lang || DEFAULT_FRAMEWORK}/${sectionNum || DEFAULT_SECTION}`;
+export const makeGuidePath = ({ guide, framework, sectionNum }) => {
+  return `${FRAGMENTS}${guide}/${framework || DEFAULT_FRAMEWORK}/${sectionNum || DEFAULT_SECTION}`;
 };
 
 export const alphaSortBy = prop => (a,b) => a[prop] > b[prop] ? 1 : a[prop] < b[prop] ? -1 : 0;
@@ -38,12 +38,12 @@ export const findGuides = ({ pages }) => {
   return pages.filter( page => page.regularPath.match(section) )
     .map( page => { 
       const name = page.regularPath.match(section)[1];
-      const lang = findMainLanguagesOfGuide({ guide: name, pages })[0];
+      const framework = findMainFrameworksOfGuide({ guide: name, pages })[0];
       return { 
         name,
         title: page.frontmatter.title || name,
         excerpt: page.frontmatter.excerpt || '',
-        link: makeGuideHash({ guide: name, lang }),
+        link: makeGuidePath({ guide: name, framework }),
         key: page.key,
         page
       };
@@ -58,19 +58,19 @@ export const findStackSnippets = ({ section, snippet, pages }) => {
   return [ ...pages        
     .filter( page => page.regularPath.match(prefix) )
     .map( page => {
-      const lang = page.regularPath.match(prefix)[1];
-      const name = commonify(lang);
+      const framework = page.regularPath.match(prefix)[1];
+      const name = commonify(framework);
       const title = fancify(name);
       return { 
-        lang,
+        framework,
         name, 
         title,
         css: cssForIcon(name),
-        link: makeGuideHash({ guide: section.guide, lang, sectionNum: section.sectionNum }),
+        link: makeGuidePath({ guide: section.guide, framework, sectionNum: section.sectionNum }),
         key: page.key,
         page
       };
-    })].sort( alphaSortBy('lang') );
+    })].sort( alphaSortBy('framework') );
 };
 
 export const findGuideSections = ({ guide, pages }) => { 
@@ -85,7 +85,7 @@ export const findGuideSections = ({ guide, pages }) => {
       return { 
         name,
         title: page.frontmatter.title || name,
-        makeLink: lang => makeGuideHash({ guide, lang, sectionNum }),
+        makeLink: framework => makeGuidePath({ guide, framework, sectionNum }),
         index, 
         guide,
         sectionNum,
@@ -96,13 +96,13 @@ export const findGuideSections = ({ guide, pages }) => {
   });
 }; 
 
-export const findMainLanguagesOfGuide = ({ guide, pages }) => {
+export const findMainFrameworksOfGuide = ({ guide, pages }) => {
   // Note: assumes sections are all directories named `sectionNN`
   const prefix = new RegExp(`${FRAGMENTS}${guide}/${PATH_LIKE}${PATH_LIKE}.*?.html$`);
   return Object.keys( 
-    // Pull all known langages for the given guide, reduce to unique list
+    // Pull all known frameworks for the given guide, reduce to unique list
     pages.filter( page => page.regularPath.match(prefix) )
       .map( page => page.regularPath.match(prefix)[2] )
-      .reduce( (all, lang) => ({ ...all, [lang]: true }), {} )
+      .reduce( (all, framework) => ({ ...all, [framework]: true }), {} )
   ).sort();
 };


### PR DESCRIPTION
Updates the urls from `/guides/#sign-into-mobile/react/1` to `/guides/sign-into-mobile/react/1` for SEO purposes (a change in those parts is also forthcoming to improve SEO)

This means we lose built-in behaviors:

* everything now scrolls to the top now (to be addressed in a scrolling PR)
* links now default to loading a new page (links here are switched to use <router-link to="/link">)

On the up-side, we gain relative links between pages in guides (that will still load a new page unless we use <router-link>)