### PR TITLE
Table format fix for /docs/

### DIFF
--- a/packages/@okta/vuepress-site/docs/api/resources/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/apps/index.md
@@ -1023,7 +1023,6 @@ Adds an OAuth 2.0 client application. This application is only available to the 
 
 * Different application types have different valid values for the corresponding grant type:
 
-|-------------------+---------------------------------------------------------------+-----------------------------------------------------------------------------------|
 | Application Type  | Valid Grant Type                                              | Requirements                                                                      |
 | ----------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------- |
 | `web`             | `authorization_code`, `implicit`, `refresh_token`             | Must have at least `authorization_code`                                           |

--- a/packages/@okta/vuepress-site/docs/api/resources/authorization-servers/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/authorization-servers/index.md
@@ -1487,7 +1487,6 @@ Example from a Policy Object
 
 #### Credentials Properties
 
-| -------------   | ------------------------------------------------------------------------------------------------------------------------   | ----------   | ----------   | ---------- |
 | Property        | Description                                                                                                                | DataType     | Required     | Updatable  |
 | :-------------- | :------------------------------------------------------------------------------------------------------------------------- | :----------- | :----------- | :--------- |
 | kid             | The ID of the JSON Web Key used for signing tokens issued by the authorization server.                                     | String       | FALSE        | FALSE      |

--- a/packages/@okta/vuepress-site/docs/api/resources/factors/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/factors/index.md
@@ -431,12 +431,10 @@ Enumerates all available security questions for a user's `question` factor
 
 Array of Questions
 
-|---------------+---------------------------+-----------+----------+--------+----------|
 | Property      | Description               | DataType  | Nullable | Unique  | Readonly |
 | ------------- | ------------------------- | --------- | -------- | ------- | -------- |
 | question      | unique key for question   | String    | FALSE    | TRUE    | TRUE     |
 | questionText  | display text for question | String    | FALSE    | FALSE   | TRUE     |
-|---------------+---------------------------+-----------+----------+--------+----------|
 
 #### Request Example
 
@@ -3088,7 +3086,6 @@ curl -v -X POST \
 
 Factors have the following properties:
 
-|----------------+------------------------------------------------------------------+--------------------------------------------------------------------------------+----------+--------+----------|
 | Property       | Description                                                       | DataType                                                                       | Nullable | Unique | Readonly |
 | -------------- | ----------------------------------------------------------------  | ------------------------------------------------------------------------------ | -------- | ------ | -------- |
 | id             | unique key for factor, a 20 character long system generated id    | String                                                                         | FALSE    | TRUE   | TRUE     |
@@ -3101,7 +3098,6 @@ Factors have the following properties:
 | verify         | optional verification  for factor enrollment                      | [Factor Verification Object](#factor-verification-object)                      | TRUE     | FALSE  | FALSE    |
 | _links         | [discoverable resources](#links-object) related to the factor     | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)                 | TRUE     | FALSE  | TRUE     |
 | _embedded      | [embedded resources](#embedded-resources) related to the factor   | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)                 | TRUE     | FALSE  | TRUE     |
-|----------------+------------------------------------------------------------------+--------------------------------------------------------------------------------+----------+--------+----------|
 
 > `id`, `created`, `lastUpdated`, `status`, `_links`, and `_embedded` are only available after a factor is enrolled.
 
@@ -3109,7 +3105,6 @@ Factors have the following properties:
 
 The following factor types are supported:
 
-|-----------------------+---------------------------------------------------------------------------------------------------------------------|
 | Factor Type           | Description                                                                                                         |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------  |
 | `push`                | Out-of-band verification via push notification to a device and transaction verification with digital signature      |
@@ -3120,13 +3115,11 @@ The following factor types are supported:
 | `token:hardware`      | Hardware one-time password [OTP](http://en.wikipedia.org/wiki/One-time_password) device                             |
 | `question`            | Additional knowledge based security question                                                                        |
 | `web`                 | HTML inline frame (iframe) for embedding verification from a 3rd party                                              |
-|-----------------------+---------------------------------------------------------------------------------------------------------------------|
 
 #### Provider Type
 
 The following providers are supported:
 
-|------------+-------------------------------|
 | Provider   | Description                   |
 | ---------- | ----------------------------- |
 | `OKTA`     | Okta                          |
@@ -3135,13 +3128,11 @@ The following providers are supported:
 | `GOOGLE`   | Google                        |
 | `DUO`      | Duo Security                  |
 | `YUBICO`   | Yubico                        |
-|------------+-------------------------------|
 
 #### Supported Factors for Providers
 
 Each provider supports a subset of a factor types.  The following table lists the factor types supported for each provider:
 
-|------------+------------------------|
 | Provider   | Factor Type           |
 | ---------- | --------------------- |
 | `OKTA`     | `push`                |
@@ -3155,7 +3146,6 @@ Each provider supports a subset of a factor types.  The following table lists th
 | `RSA`      | `token`               |
 | `DUO`      | `web`                 |
 | `YUBICO`   | `token:hardware`      |
-|------------+------------------------|
 
 ### Factor Profile Object
 
@@ -3165,13 +3155,11 @@ Profiles are specific to the [factor type](#factor-type).
 
 Specifies the profile for a `question` factor
 
-|---------------+---------------------------+-----------+---------+---------+----------|
 | Property      | Description                         | DataType  | Nullable | Unique  | Readonly |
 | ------------- | -------------------------           | --------- | -------- | ------- | -------- |
 | question      | unique key for question             | String    | FALSE    | TRUE    | TRUE     |
 | questionText  | display text for question           | String    | FALSE    | FALSE   | TRUE     |
 | answer        | answer to question, min 4 char long | String    | TRUE     | FALSE   | FALSE    |
-|---------------+---------------------------+-----------+---------+---------+----------|
 
 ```json
 {
@@ -3186,11 +3174,9 @@ Specifies the profile for a `question` factor
 
 Specifies the profile for a `sms` factor
 
-|---------------+-------------------------------+-----------------------------------------------------------------+----------+---------+----------|
 | Property      | Description                                     | DataType                                                        | Nullable | Unique  | Readonly |
 | ------------- | -----------------------------                   | --------------------------------------------------------------- | -------- | ------- | -------- |
 | phoneNumber   | phone number of mobile device, max 15 char long | String [E.164 formatted](http://en.wikipedia.org/wiki/E.164)    | FALSE    | TRUE    | FALSE    |
-|---------------+-------------------------------+-----------------------------------------------------------------+----------+---------+----------|
 
 ```json
 {
@@ -3208,12 +3194,10 @@ For example, to convert a US phone number (415 599 2671) to E.164 format, one wo
 
 Specifies the profile for a `call` factor
 
-|---------------+-------------------------------+-----------------------------------------------------------------+----------+---------+----------|
 | Property       | Description                                  | DataType                                                        | Nullable | Unique  | Readonly |
 | -------------  | -----------------------------                | --------------------------------------------------------------- | -------- | ------- | -------- |
 | phoneNumber    | phone number of the device, max 15 char long | String [E.164 formatted](http://en.wikipedia.org/wiki/E.164)    | FALSE    | TRUE    | FALSE    |
 | phoneExtension | extension of the device, max 15 char long    | String                                                          | TRUE     | FALSE   | FALSE    |
-|---------------+-------------------------------+-----------------------------------------------------------------+----------+---------+----------|
 
 ```json
 {
@@ -3234,11 +3218,9 @@ PhoneExtension is optional.
 
 Specifies the profile for a `token`, `token:hardware`, `token:software`, or `token:software:totp` factor
 
-|---------------+--------------------+-----------+----------+---------+----------|
 | Property      | Description        | DataType  | Nullable | Unique  | Readonly |
 | ------------- | ------------------ | --------- | -------- | ------- | -------- |
 | credentialId  | id for credential  | String    | FALSE    | FALSE   | TRUE     |
-|---------------+--------------------+-----------+----------+---------+----------|
 
 ```json
 {
@@ -3252,11 +3234,9 @@ Specifies the profile for a `token`, `token:hardware`, `token:software`, or `tok
 
 Specifies the profile for a `web` factor
 
-|---------------+--------------------+-----------+----------+---------+----------|
 | Property      | Description        | DataType  | Nullable | Unique  | Readonly |
 | ------------- | ------------------ | --------- | -------- | ------- | -------- |
 | credentialId  | id for credential  | String    | FALSE    | FALSE   | TRUE     |
-|---------------+--------------------+-----------+----------+---------+----------|
 
 ```json
 {
@@ -3270,11 +3250,9 @@ Specifies the profile for a `web` factor
 
 Specifies the profile for a `email` factor
 
-|---------------+-------------------------------+-----------------------------------------------------------------+----------+---------+----------|
 | Property      | Description                                  | DataType                                                        | Nullable | Unique  | Readonly |
 | ------------- | -----------------------------                | --------------------------------------------------------------- | -------- | ------- | -------- |
 | email         | email address of the user, max 100 char long | String                                                          | FALSE    | TRUE    | FALSE    |
-|---------------+-------------------------------+-----------------------------------------------------------------+----------+---------+----------|
 
 ```json
 {
@@ -3296,12 +3274,10 @@ Email factor can be used
 
 Specifies additional verification data for `token` or `token:hardware` factors
 
-|---------------+----------------------------+-----------+----------+---------+----------|
 | Property      | Description                 | DataType  | Nullable | Unique  | Readonly |
 | ------------- | --------------------------  | --------- | -------- | ------- | -------- |
 | passCode      | OTP for current time window | String    | FALSE    | FALSE   | FALSE    |
 | nextPassCode  | OTP for next time window    | String    | TRUE     | FALSE   | FALSE    |
-|--------------+-----------------------------+-----------+----------+---------+----------|
 
 ```json
 {
@@ -3316,7 +3292,6 @@ Specifies additional verification data for `token` or `token:hardware` factors
 
 Specifies link relations (See [Web Linking](http://tools.ietf.org/html/rfc5988)) available for the current status of a factor using the [JSON Hypertext Application Language](http://tools.ietf.org/html/draft-kelly-json-hal-06) specification.  This object is used for dynamic discovery of related resources and lifecycle operations.
 
-|--------------------+--------------------------------------------------------------------------------- |
 | Link Relation Type | Description                                                                      |
 | ------------------ | -------------------------------------------------------------------------------- |
 | self               | The actual factor                                                                |
@@ -3326,7 +3301,6 @@ Specifies link relations (See [Web Linking](http://tools.ietf.org/html/rfc5988))
 | send               | List of delivery options to send an activation or factor challenge               |
 | resend             | List of delivery options to resend activation or factor challenge                |
 | poll               | Polls factor for completion of activation of verification                        |
-|--------------------+--------------------------------------------------------------------------------- |
 
 > The Links Object is **read-only**.
 
@@ -3336,7 +3310,6 @@ Specifies link relations (See [Web Linking](http://tools.ietf.org/html/rfc5988))
 
 TOTP factors when activated have an embedded activation object which describes the [TOTP](http://tools.ietf.org/html/rfc6238) algorithm parameters.
 
-|----------------+---------------------------------------------------+----------------------------------------------------------------+----------+--------+----------|
 | Property       | Description                                       | DataType                                                       | Nullable | Unique | Readonly |
 | -------------- | ------------------------------------------------- | -------------------------------------------------------------- | -------- | ------ | -------- |
 | timeStep       | time-step size for TOTP                           | String                                                         | FALSE    | FALSE  | TRUE     |
@@ -3344,7 +3317,6 @@ TOTP factors when activated have an embedded activation object which describes t
 | encoding       | encoding of `sharedSecret`                        | `base32` or `base64`                                           | FALSE    | FALSE  | TRUE     |
 | keyLength      | number of digits in an HOTP value                 | Number                                                         | FALSE    | FALSE  | TRUE     |
 | _links         | discoverable resources related to the activation  | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06) | TRUE     | FALSE  | TRUE     |
-|----------------+---------------------------------------------------+----------------------------------------------------------------+----------+--------+----------|
 
 ```json
 {
@@ -3361,13 +3333,11 @@ TOTP factors when activated have an embedded activation object which describes t
 
 Push factors must complete activation on the device by scanning the QR code or visiting activation link sent via email or sms.
 
-|----------------+---------------------------------------------------+----------------------------------------------------------------+----------+--------+----------|
 | Property       | Description                                       | DataType                                                       | Nullable | Unique | Readonly |
 | -------------- | ------------------------------------------------- | -------------------------------------------------------------- | -------- | ------ | -------- |
 | expiresAt      | lifetime of activation                            | Date                                                           | FALSE    | FALSE  | TRUE     |
 | factorResult   | result of a factor activation                     | `WAITING`, `CANCELLED`, `TIMEOUT`, or `ERROR`                  | FALSE    | FALSE  | TRUE     |
 | _links         | discoverable resources related to the activation  | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06) | FALSE    | FALSE  | TRUE     |
-|----------------+---------------------------------------------------+----------------------------------------------------------------+----------+--------+----------|
 
 ```json
 {
@@ -3408,30 +3378,25 @@ Push factors must complete activation on the device by scanning the QR code or v
 
 Specifies link relations (See [Web Linking](http://tools.ietf.org/html/rfc5988)) available for the push factor activation object using the [JSON Hypertext Application Language](http://tools.ietf.org/html/draft-kelly-json-hal-06) specification.  This object is used for dynamic discovery of related resources and operations.
 
-|--------------------+------------------------------------------------------------------------------------|
 | Link Relation Type | Description                                                                        |
 | ------------------ | ---------------------------------------------------------------------------------- |
 | qrcode             | QR code that encodes the push activation code needed for enrollment on the device  |
 | send               | Sends an activation link via `email` or `sms` for users who can't scan the QR code |
-|--------------------+------------------------------------------------------------------------------------|
 
 
 ### Factor Verify Result Object
 
 Describes the outcome of a factor verification request
 
-|---------------+---------------------------------------------------+---------------------------------+----------+--------+----------|
 | Property      | Description                                       | DataType                        | Nullable | Unique | Readonly |
 | ------------- | ------------------------------------------------- | ------------------------------- | -------- | ------ | -------- |
 | factorResult  | result of a factor verification                   | [Factor Result](#factor-result) | FALSE    | FALSE  | TRUE     |
 | factorMessage | optional display message for factor verification  | String                          | TRUE     | FALSE  | TRUE     |
-|---------------+---------------------------------------------------+---------------------------------+----------+--------+----------|
 
 #### Factor Result
 
 Specifies the status of a factor verification attempt
 
-|------------------------+-------------------------------------------------------------------------------------------------------------------------------------|
 | Result                 | Description                                                                                                                                |
 | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------         |
 | `SUCCESS`              | The factor was successfully verified.                                                                                                      |
@@ -3444,4 +3409,3 @@ Specifies the status of a factor verification attempt
 | `TIME_WINDOW_EXCEEDED` | The factor was successfully verified but outside of the computed time window.  Another verification is required in current time window.    |
 | `PASSCODE_REPLAYED`    | The factor was previously verified within the same time window.  The user must wait another time window and retry with a new verification. |
 | `ERROR`                | An unexpected server error occurred verifying factor.                                                                                      |
-|------------------------+-------------------------------------------------------------------------------------------------------------------------------------|

--- a/packages/@okta/vuepress-site/docs/api/resources/groups/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/groups/index.md
@@ -1785,7 +1785,6 @@ Link: <https://{yourOktaDomain}/api/v1/groups/00g1fanEFIQHMQQJMHZP/apps?after=0o
 
 All groups have the following properties:
 
-|-----------------------+--------------------------------------------------------------+----------------------------------------------------------------+----------|--------|----------|-----------|-----------+------------|
 | Property              | Description                                                  | DataType                                                       | Nullable | Unique | Readonly | MinLength | MaxLength | Validation |
 | --------------------- | ------------------------------------------------------------ | -------------------------------------------------------------- | -------- | ------ | -------- | --------- | --------- | ---------- |
 | id                    | unique key for group                                         | String                                                         | FALSE    | TRUE   | TRUE     |           |           |            |
@@ -1797,7 +1796,6 @@ All groups have the following properties:
 | profile               | the group's profile properties                               | [Profile Object](#profile-object)                              | FALSE    | FALSE  | FALSE    |           |           |            |
 | _links                | [discoverable resources](#links-object) related to the group | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06) | TRUE     | FALSE  | TRUE     |           |           |            |
 | _embedded             | embedded resources related to the group                      | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06) | TRUE     | FALSE  | TRUE     |           |           |            |
-|-----------------------+--------------------------------------------------------------+----------------------------------------------------------------+----------|--------|----------|-----------|-----------+------------|
 
 > `id`, `created`, `lastUpdated`, `lastMembershipUpdated`, `objectClass`, `type`, and `_links` are only available after a group is created
 
@@ -1805,13 +1803,11 @@ All groups have the following properties:
 
 Okta supports several types of groups that constrain how the group's profile and memberships are managed.
 
-|--------------+-----------------------------------------------------------------------------------------------------------------+
 | Type         | Description                                                                                                     |
 | ------------ | --------------------------------------------------------------------------------------------------------------- |
 | `OKTA_GROUP` | Group profile and memberships are directly managed in Okta via static assignments or indirectly via group rules |
 | `APP_GROUP`  | Group profile and memberships are imported and must be managed within the application that imported the group   |
 | `BUILT_IN`   | Group profile and memberships are managed by Okta and cannot be modified                                        |
-|--------------+-----------------------------------------------------------------------------------------------------------------+
 
 > Active Directory and LDAP groups will also have `APP_GROUP` type
 
@@ -1823,12 +1819,10 @@ Specifies required and optional properties for a group.  The `objectClass` of gr
 
 Profile for any group that is **not** imported from Active Directory
 
-|-------------+--------------------------+----------+----------+----------+-----------+-----------+------------|
 | Property    | Description              | DataType | Nullable | Readonly | MinLength | MaxLength | Validation |
 | ----------- | ------------------------ | -------- | -------- | -------- | --------- | --------- | ---------- |
 | name        | name of the group        | String   | FALSE    | FALSE    | 1         | 255       |            |
 | description | description of the group | String   | TRUE     | FALSE    | 0         | 1024      |            |
-|-------------+--------------------------+----------+----------+----------+-----------+-----------+------------|
 
 ```json
 {
@@ -1881,7 +1875,6 @@ The Group Rules API is currently a <ApiLifecycle access="beta" /> release.
 
 Profile for a group that is imported from Active Directory
 
-|----------------------------+--------------------------------------------------------+----------+-----------+----------+-----------+-----------+------------|
 | Property                   | Description                                            | DataType | Nullable  | Readonly | MinLength | MaxLength | Validation |
 | -------------------------- | ------------------------------------------------------ | -------- | --------- | -------- | --------- | --------- | ---------- |
 | name                       | name of the windows group                              | String   | FALSE     | TRUE     |           |           |            |
@@ -1890,7 +1883,6 @@ Profile for a group that is imported from Active Directory
 | dn                         | the distinguished name of the windows group            | String   | FALSE     | TRUE     |           |           |            |
 | windowsDomainQualifiedName | fully-qualified name of the windows group              | String   | FALSE     | TRUE     |           |           |            |
 | externalId                 | base-64 encoded GUID (objectGUID) of the windows group | String   | FALSE     | TRUE     |           |           |            |
-|----------------------------+--------------------------------------------------------+----------+-----------+----------+-----------+-----------+------------|
 
 ```json
 {
@@ -1909,13 +1901,12 @@ Profile for a group that is imported from Active Directory
 
 Specifies link relations (See [Web Linking](http://tools.ietf.org/html/rfc5988)) available for the group using the [JSON Hypertext Application Language](http://tools.ietf.org/html/draft-kelly-json-hal-06) specification.  This object is used for dynamic discovery of related resources and lifecycle operations.
 
-|--------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+
 | Link Relation Type | Description                                                                                                                                                     |
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | self               | The primary URL for the group                                                                                                                                   |
 | logo               | Provides links to logo images for the group if available                                                                                                        |
 | users              | Provides [group member operations](#group-member-operations) for the group                                                                                      |
 | apps               | Lists all [applications](apps#application-model) that are assigned to the group. See [Application Group Operations](apps#application-group-operations)          |
-|--------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 
 > The Links Object is read only.

--- a/packages/@okta/vuepress-site/docs/api/resources/oidc/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/oidc/index.md
@@ -1040,7 +1040,6 @@ OpenID Connect uses scope values to specify what access privileges are being req
 The scopes associated with access tokens determine which claims are available when they are used
 to access the OIDC `/userinfo` [endpoint](/docs/api/resources/oidc#userinfo). The following scopes are supported:
 
-| -------------    | -------------------------------------------------------------------------------                                 | -------------- |
 | Property         | Description                                                                                                     | Required       |
 | :--------------- | :-------------------------------------------------------------------------------------------------------------- | :------------- |
 | openid           | Identifies the request as an OpenID Connect request.                                                            | Yes            |

--- a/packages/@okta/vuepress-site/docs/api/resources/sessions/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/sessions/index.md
@@ -676,7 +676,6 @@ HTTP/1.1 204 No Content
 
 Sessions have the following properties:
 
-|-------------------------------------------+-----------------------------------------------------------------------------------------------+-------------------------------------------+----------+--------+----------|
 | Property                                  | Description                                                                                   | DataType                                  | Nullable | Unique | Readonly |
 | ----------------------------------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------- | -------- | ------ | -------- |
 | id                                        | unique key for the session                                                                    | String                                    | FALSE    | TRUE   | TRUE     |
@@ -689,7 +688,6 @@ Sessions have the following properties:
 | amr                                       | authentication method reference                                                               | [AMR Object](#amr-object)                 | FALSE    | FALSE  | TRUE     |
 | idp                                       | identity provider used to authenticate the user                                               | [IDP Object](#idp-object)                 | FALSE    | FALSE  | TRUE     |
 | mfaActive                                 | indicates whether the user has [enrolled an MFA factor](factors#list-enrolled-factors)        | Boolean                                   | FALSE    | FALSE  | TRUE     |
-|-------------------------------------------+-----------------------------------------------------------------------------------------------+-------------------------------------------+----------+--------+----------|
 
 > The `mfaActive` parameter is a <ApiLifecycle access="deprecated" /> feature. Use the `lastFactorVerification` attribute in conjunction with `amr` to understand if the user has performed MFA for the current session. Use the [Factors API](factors#list-enrolled-factors) to query the factor enrollment status for a given user.
 
@@ -697,12 +695,10 @@ Sessions have the following properties:
 
 The [Create Session](#create-session-with-session-token) operation can optionally return the following properties when requested.
 
-|-----------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Property                                      | Description                                                                                                                                                                       |
 | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | cookieToken                                   | Another one-time token which can be used to obtain a session cookie by visiting either an application's embed link or a session redirect URL.                                     |
 | cookieTokenUrl                                | URL for a a transparent 1x1 pixel image which contains a one-time session token which when visited sets the session cookie in your browser for your organization.                 |
-|-----------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 
 > The `cookieToken` is a <ApiLifecycle access="deprecated" /> property. Instead, use the [Authentication API](authn), which supports the full user authentication pipeline and produces a `sessionToken` which can be used in this API.
 
@@ -720,7 +716,6 @@ The following values are defined for the status of a session:
 
 The [authentication methods reference](https://tools.ietf.org/html/draft-ietf-oauth-amr-values-01) ("AMR") specifies which authentication methods were used to establish the session. The value is a JSON array with one or more of the following values:
 
-|----------+-------------------------------------------------------+---------------------------------------------------------------------------|
 | Value    | Description                                            | Example                                                                                                |
 | -------- | ------------------------------------------------------ | -------------------------------------------------------------------------                              |
 | `pwd`    | Password authentication                                | Standard password-based login                                                                          |
@@ -734,18 +729,15 @@ The [authentication methods reference](https://tools.ietf.org/html/draft-ietf-oa
 | `kba`    | Knowledge-based authentication                         | Security Question factor                                                                               |
 | `mfa`    | Multiple-factor authentication                         | This value is present whenever any MFA factor verification is performed.                               |
 | `mca`    | Multiple-channel authentication                        | Authentication requires communication over more than one channel, such as Internet and mobile network. |
-|----------+-------------------------------------------------------+---------------------------------------------------------------------------|
 
 ### IDP Object
 
 Specifies the identity provider used to authentication the user.
 
-|-------------+---------------------------------------------------------------+-----------+--------+----------+-----------+-----------+------------|
 | Property     | DataType                                                      | Nullable  | Unique  | Readonly | MinLength | MaxLength | Validation |
 | ------------ | ------------------------------------------------------------- | --------- | ------- | -------- | --------- | --------- | ---------- |
 | id           | String                                                        | FALSE     | FALSE   | TRUE     |           |           |            |
 | type         | `OKTA`, `ACTIVE_DIRECTORY`, `LDAP`, `FEDERATION`, or `SOCIAL` | FALSE     | FALSE   | TRUE     |           |           |            |
-|-------------+---------------------------------------------------------------+-----------+--------+----------+-----------+-----------+------------|
 
 > The `id` will be the org id if the type is `OKTA`; otherwise it will be the IDP instance id.
 

--- a/packages/@okta/vuepress-site/docs/api/resources/templates/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/templates/index.md
@@ -364,7 +364,6 @@ HTTP/1.1 204 No Content
 
 All templates have the following properties:
 
-|------------------------+--------------------------------------------------------------+----------------------------------------------------------------|----------|-----------|-----------|
 | Property               | Description                                                         | DataType                                                       | Readonly | MinLength | MaxLength |
 | ---------------------- | ------------------------------------------------------------        | -------------------------------------------------------------- | -------- | --------- | --------- |
 | id                     | Unique key for template                                             | String                                                         | TRUE     | 20        | 20        |
@@ -374,7 +373,6 @@ All templates have the following properties:
 | created                | Timestamp when template was created                                 | String (ISO-8601)                                              | TRUE     | N/A       | N/A       |
 | lastUpdated            | Timestamp when template was last updated                            | String (ISO-8601)                                              | TRUE     | N/A       | N/A       |
 | translations           | Array of [translations](#translation-attributes)                    | Array                                                          | N/A      | N/A       | N/A       |
-|------------------------+--------------------------------------------------------------+----------------------------------------------------------------|----------|-----------|-----------|
 
 > NOTE: The final length of your SMS message cannot exceed 160 characters. If the verification code portion of the message falls outside of the 160-character limit, your message will not be sent.
 
@@ -396,19 +394,15 @@ The key portion is a two-letter country code conforming to [ISO 639-1](https://e
 
 ### SMS Template Types
 
-|-------------------+--------------------------------------------------------------------------------------------------+
 | Type              | Description                                                                                      |
 | ----------------- | ------------------------------------------------------------------------------------------------ |
 | `SMS_VERIFY_CODE` | This template is used when the SMS for code verification is sent.                                |
-|-------------------+--------------------------------------------------------------------------------------------------+
 
 ### SMS Template Macros
 
 Currently only two macros are supported for SMS templates.
 
-|-------------------+--------------------------------------------------------------------------------------------------+
 | Type              | Description                                                                                      |
 | ----------------- | ------------------------------------------------------------------------------------------------ |
 | `${code}`         | The one-time verification code that is required for login.                                       |
 | `${org.name}`     | The name of the Okta organization that the user is trying to authenticate into.                  |
-|-------------------+--------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Reviewed /docs/ pages and removed the extra lines when generating tables for the following files

/docs/api/resources/apps/index.md
/docs/api/resources/authorization-servers/index.md
/docs/api/resources/factors/index.md
/docs/api/resources/groups/index.md
/docs/api/resources/oidc/index.md
/docs/api/resources/sessions/index.md
/docs/api/resources/templates/index.md