### PR TITLE
Wrap items in backticks

### DIFF
--- a/packages/@okta/vuepress-site/reference/okta_expression_language/index.md
+++ b/packages/@okta/vuepress-site/reference/okta_expression_language/index.md
@@ -98,20 +98,20 @@ The following <ApiLifecycle access="deprecated" /> functions perform some of the
 
 ### Array Functions
 
-| Function                         | Return Type                         | Example                                             | Output           |
-| --------                         | ---------                           | ---------                                           | --------         |
+| Function                         | Return Type                         | Example                                             | Output             |
+| --------                         | ---------                           | ---------                                           | --------           |
 | `Arrays.add(array, value)`       | Array                               | `Arrays.add({10, 20, 30}, 40)`                      | `{10, 20, 30, 40}` |
 | `Arrays.remove(array, value)`    | Array                               | `Arrays.remove({10, 20, 30}, 20)`                   | `{10, 30}`         |
 | `Arrays.clear(array)`            | Array                               | `Arrays.clear({10, 20, 30})`                        | `{ }`              |
-| `Arrays.get(array, position)`    | -                                   | `Arrays.get({0, 1, 2}, 0)`                          | 0                |
+| `Arrays.get(array, position)`    | -                                   | `Arrays.get({0, 1, 2}, 0)`                          | 0                  |
 | `Arrays.flatten(list of values)` | Array                               | `Arrays.flatten(10, {20, 30}, 40)`                  | `{10, 20, 30, 40}` |
-| `Arrays.contains(array, value)`  | Boolean                             | `Arrays.contains({10, 20, 30}, 10)`                 | true             |
-|                                  | `Arrays.contains({10, 20, 30}, 50)` | false                                               |                  |
-| `Arrays.size(array)`             | Integer                             | `Arrays.size({10, 20, 30})`                         | 3                |
-|                                  | `Arrays.size(NULL)`                 | 0                                                   |                  |
-| `Arrays.isEmpty(array)`          | Boolean                             | `Arrays.isEmpty({10, 20})`                          | false            |
-|                                  | `Arrays.isEmpty(NULL)`              | true                                                |                  |
-| `Arrays.toCsvString(array)`      | String                              | `Arrays.toCsvString({"This", "is", " a ", "test"})` | This,is, a ,test |
+| `Arrays.contains(array, value)`  | Boolean                             | `Arrays.contains({10, 20, 30}, 10)`                 | true               |
+|                                  | `Arrays.contains({10, 20, 30}, 50)` | false                                               |                    |
+| `Arrays.size(array)`             | Integer                             | `Arrays.size({10, 20, 30})`                         | 3                  |
+|                                  | `Arrays.size(NULL)`                 | 0                                                   |                    |
+| `Arrays.isEmpty(array)`          | Boolean                             | `Arrays.isEmpty({10, 20})`                          | false              |
+|                                  | `Arrays.isEmpty(NULL)`              | true                                                |                    |
+| `Arrays.toCsvString(array)`      | String                              | `Arrays.toCsvString({"This", "is", " a ", "test"})` | This,is, a ,test   |
 
 
 ### Conversion Functions

--- a/packages/@okta/vuepress-site/reference/okta_expression_language/index.md
+++ b/packages/@okta/vuepress-site/reference/okta_expression_language/index.md
@@ -100,11 +100,11 @@ The following <ApiLifecycle access="deprecated" /> functions perform some of the
 
 | Function                         | Return Type                         | Example                                             | Output           |
 | --------                         | ---------                           | ---------                                           | --------         |
-| `Arrays.add(array, value)`       | Array                               | `Arrays.add({10, 20, 30}, 40)`                      | {10, 20, 30, 40} |
-| `Arrays.remove(array, value)`    | Array                               | `Arrays.remove({10, 20, 30}, 20)`                   | {10, 30}         |
-| `Arrays.clear(array)`            | Array                               | `Arrays.clear({10, 20, 30})`                        | { }              |
+| `Arrays.add(array, value)`       | Array                               | `Arrays.add({10, 20, 30}, 40)`                      | `{10, 20, 30, 40}` |
+| `Arrays.remove(array, value)`    | Array                               | `Arrays.remove({10, 20, 30}, 20)`                   | `{10, 30}`         |
+| `Arrays.clear(array)`            | Array                               | `Arrays.clear({10, 20, 30})`                        | `{ }`              |
 | `Arrays.get(array, position)`    | -                                   | `Arrays.get({0, 1, 2}, 0)`                          | 0                |
-| `Arrays.flatten(list of values)` | Array                               | `Arrays.flatten(10, {20, 30}, 40)`                  | {10, 20, 30, 40} |
+| `Arrays.flatten(list of values)` | Array                               | `Arrays.flatten(10, {20, 30}, 40)`                  | `{10, 20, 30, 40}` |
 | `Arrays.contains(array, value)`  | Boolean                             | `Arrays.contains({10, 20, 30}, 10)`                 | true             |
 |                                  | `Arrays.contains({10, 20, 30}, 50)` | false                                               |                  |
 | `Arrays.size(array)`             | Integer                             | `Arrays.size({10, 20, 30})`                         | 3                |


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?**  Wraps response items in table in backticks.  This is necessary anytime a string has json in it.  ie. `{10, 20, 30, 40}` or `Arrays.add({10, 20, 30}, 40)`
- **Is this PR related to a Monolith release?**  NO

### Resolves:

resolves #180
