### PR TITLE
fix(guides): Unblocks build from running; Shifts global components to…

### DIFF
--- a/packages/@okta/vuepress-theme-default/enhanceApp.js
+++ b/packages/@okta/vuepress-theme-default/enhanceApp.js
@@ -1,7 +1,0 @@
-import StackSelector from './components/StackSelector';
-import NextSectionLink from './components/NextSectionLink';
-
-export default ({ Vue }) => {
-  Vue.component('StackSelector', StackSelector); // Force global register
-  Vue.component('NextSectionLink', NextSectionLink); // Force global register
-};

--- a/packages/@okta/vuepress-theme-default/global-components/NextSectionLink.vue
+++ b/packages/@okta/vuepress-theme-default/global-components/NextSectionLink.vue
@@ -14,6 +14,9 @@
       guide() { return getGuidesInfo({pages: this.$site.pages}).byName[this.guideName]; },
       section() { return this.guide.sectionByName[this.sectionName]; },
       nextSection() { 
+        if(!this.guide) { 
+          return '';
+        }
         const thisIndex = this.guide.order.indexOf(this.sectionName);
         return this.guide.sections[thisIndex + 1];
       },

--- a/packages/@okta/vuepress-theme-default/global-components/StackSelector.vue
+++ b/packages/@okta/vuepress-theme-default/global-components/StackSelector.vue
@@ -31,10 +31,14 @@
       },
     },
     created () {
-      window.addEventListener('scroll', this.handleScroll);
+      if(typeof window !== "undefined") { 
+        window.addEventListener('scroll', this.handleScroll);
+      }
     },
     destroyed () {
-      window.removeEventListener('scroll', this.handleScroll);
+      if(typeof window !== "undefined") { 
+        window.removeEventListener('scroll', this.handleScroll);
+      }
     },
     computed: { 
       framework() { 
@@ -42,7 +46,7 @@
         return findOnAncestor({ find: 'framework', node: this }) || this.options[0].name;
       },
       section() { return findOnAncestor({ find: 'section', node: this }); },
-      options() { return this.section.snippetByName[this.snippet].frameworks; },
+      options() { return this.section ? this.section.snippetByName[this.snippet].frameworks : []; },
       snippetComponentKey() { 
         const option = this.options.find( option => option.framework === this.framework );
         return (option ? option.componentKey : '');


### PR DESCRIPTION
## Description:
- **What's changed?** 
  - Guards browser-only code to allow SSR build to run (Guides are not yet SSR)
  - Moves guides global components to global-components
  - Removes now-unneeded enhanceApp.js
- **Is this PR related to a Monolith release?** 
  - No
