### PR TITLE
Remove Beta flag and Beta reference for GA feature

### DIFF
--- a/packages/@okta/vuepress-site/reference/scim/index.md
+++ b/packages/@okta/vuepress-site/reference/scim/index.md
@@ -686,9 +686,7 @@ Accept-Encoding: gzip,deflate
 
 ##### Create Group: POST /Groups
 
-<ApiLifecycle access="beta" />
-
-With Group Push Beta, Okta now supports creation of a Group along with its user memberships in the downstream SCIM enabled application if your SCIM 2.0 API supports it. The caveat is that the users must already be provisioned in your SCIM enabled application.
+Okta supports creation of a Group along with its user memberships in the downstream SCIM enabled application if your SCIM 2.0 API supports it. The caveat is that the users must already be provisioned in your SCIM enabled application.
 
 ###### SCIM 1.1
 


### PR DESCRIPTION
Removed Beta flag and Beta reference for SCIM method "Create Group: POST /Groups"

The Group APIs are all now public/GA.

<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
- **Is this PR related to a Monolith release?** <!-- If so, which one? Remember that PRs intended to go out with a particular release should be targeted at that release branch and NOT at the Master branch -->

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
