### PR TITLE
Fixed the link to the OIDC library

### DIFF
--- a/packages/@okta/vuepress-site/use_cases/api_access_management/index.md
+++ b/packages/@okta/vuepress-site/use_cases/api_access_management/index.md
@@ -159,7 +159,7 @@ Okta provides the API Access Management Administrator role to make managing auth
 * A client secret is a password and should be treated and protected as such. Therefore, it should not be embedded in mobile applications, frontend JavaScript applications, or any other scenario where an attacker could access it.
 * Avoid using the resource owner password grant type (`password`) except in legacy application or transitional scenarios. The authorization code, implicit, or hybrid grant types are recommended in most scenarios.
 * For mobile applications, using the authorization code grant type with PKCE is the best practice. The implicit or hybrid grant type is the next best option.
-* For Android or iOS applications, use [Okta OIDC iOS](https://github.com/okta/okta-oidc-js/) or [AppAuth for Android](https://github.com/okta/okta-sdk-appauth-android/).
+* For Android or iOS applications, use [Okta OIDC iOS](https://github.com/okta/okta-oidc-ios) or [AppAuth for Android](https://github.com/okta/okta-sdk-appauth-android/).
 * When an application successfully validates an access token, cache the result until the expiration time (`exp`). Do this for validation that is either [local](/authentication-guide/tokens/validating-access-tokens) or via the [introspection endpoint](/docs/api/resources/oidc/#introspect).
 * When an application retrieves the JWKS (public keys) to validate a token, it should cache the result until a new or unknown key is referenced in a token.
 


### PR DESCRIPTION
## Description:
- **What's changed?** The link claimed to be the iOS OIDC library but linked to the JS library instead. I updated it to the iOS library as that was the context.
- **Is this PR related to a Monolith release?** No

### Resolves:

* n/a
