### PR TITLE
Removes "edit page" link and extra empty item in list

### DIFF
--- a/packages/@okta/vuepress-site/3rd_party_notices/index.md
+++ b/packages/@okta/vuepress-site/3rd_party_notices/index.md
@@ -1,6 +1,8 @@
 ---
 layout: Layout
 showToc: false
+editLink: false
+excludeInList: true
 ---
 
-<CategoryLinks linkPrefix="3rd_party_notices"/>
+<CategoryLinks linkPrefix="3rd_party_notices" where_exp="excludeInList"/>


### PR DESCRIPTION
## Description:
- **What's changed?** Removes "edit page" link and extra empty item in list in 3rd party notices page.

- **Is this PR related to a Monolith release?** No

### Resolves:

* No jira yet. But can create one if needed.

### Screenshots

**After**

<img width="1364" alt="Screen Shot 2019-04-22 at 10 18 32 PM" src="https://user-images.githubusercontent.com/24683447/56556491-03136280-654d-11e9-96a0-f74acfce0d6f.png">

**Before**

<img width="1333" alt="Screen Shot 2019-04-22 at 9 37 10 PM" src="https://user-images.githubusercontent.com/24683447/56556492-03136280-654d-11e9-8ee6-ad7e0b4bd5fc.png">

