### PR TITLE
Update response startIndex in pagination example

### DIFF
--- a/packages/@okta/vuepress-site/reference/scim/index.md
+++ b/packages/@okta/vuepress-site/reference/scim/index.md
@@ -592,7 +592,7 @@ $ curl 'https://scim-server.example.com/scim/v2/Users?count=1&startIndex=1'
   "schemas": [
     "urn:ietf:params:scim:api:messages:2.0:ListResponse"
   ],
-  "startIndex": 0,
+  "startIndex": 1,
   "totalResults": 1
 }
 ```


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** 
Update response startIndex in pagination example.  Request is made to `/Users?count=1&startIndex=1` but response shows `startIndex: 0`.  As SCIM uses 1-based indexing for both the request and response, the response should show `startIndex: 1`.

