### PR TITLE
Specified that the parameter `client_id` is only applicable to Okta Org Authorization Server for the /keys endpoint

### DIFF
--- a/packages/@okta/vuepress-site/docs/api/resources/oidc/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/oidc/index.md
@@ -516,6 +516,8 @@ These keys can be used to locally validate JWTs returned by Okta. Standard open-
 | :---------- | :---------------------------- | :----------- | :--------- | :--------- | :------ |
 | client_id   | Your app's client ID.         | Query        | String     | FALSE      | null    |
 
+>Note that the request parameter `client_id` is only applicable for Okta Org Authorization Server. See [Composing Your Base URL](/docs/api/resources/oidc/#composing-your-base-url) for more information regarding Okta Org Authorization Server.
+
 #### Response Properties
 JWKS properties can be found [here](/docs/api/resources/authorization-servers#key-properties).
 
@@ -568,7 +570,7 @@ Content-Type: application/json;charset=UTF-8
 #### Key Rotation
 The keys that are used to sign tokens are periodically changed. Okta automatically rotates your authorization server's keys on a regular basis.
 
-Clients can opt-out of automatic key rotation by changing the client sign-in mode. In this case, passing the `client_id` with your request retrieves the keys for that specific client.
+Clients can opt-out of automatic key rotation by changing the client sign-in mode for Okta Org Authorization Server. In this case, passing the `client_id` with your request retrieves the keys for that specific client.
 
 Key rotation behaves differently with Custom Authorization Servers. For more information about key rotation with Custom Authorization Servers, see the [Authorization Servers API page](/docs/api/resources/authorization-servers#rotate-authorization-server-keys).
 

--- a/packages/@okta/vuepress-site/docs/api/resources/oidc/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/oidc/index.md
@@ -516,7 +516,7 @@ These keys can be used to locally validate JWTs returned by Okta. Standard open-
 | :---------- | :---------------------------- | :----------- | :--------- | :--------- | :------ |
 | client_id   | Your app's client ID.         | Query        | String     | FALSE      | null    |
 
->Note that the request parameter `client_id` is only applicable for Okta Org Authorization Server. See [Composing Your Base URL](/docs/api/resources/oidc/#composing-your-base-url) for more information regarding Okta Org Authorization Server.
+>Note that the request parameter `client_id` is only applicable for the Okta Org Authorization Server. See [Composing Your Base URL](/docs/api/resources/oidc/#composing-your-base-url) for more information regarding Okta Org Authorization Server.
 
 #### Response Properties
 JWKS properties can be found [here](/docs/api/resources/authorization-servers#key-properties).
@@ -570,7 +570,7 @@ Content-Type: application/json;charset=UTF-8
 #### Key Rotation
 The keys that are used to sign tokens are periodically changed. Okta automatically rotates your authorization server's keys on a regular basis.
 
-Clients can opt-out of automatic key rotation by changing the client sign-in mode for Okta Org Authorization Server. In this case, passing the `client_id` with your request retrieves the keys for that specific client.
+Clients can opt-out of automatic key rotation by changing the client sign-in mode for  the Okta Org Authorization Server. In this case, passing the `client_id` with your request retrieves the keys for that specific client.
 
 Key rotation behaves differently with Custom Authorization Servers. For more information about key rotation with Custom Authorization Servers, see the [Authorization Servers API page](/docs/api/resources/authorization-servers#rotate-authorization-server-keys).
 

--- a/packages/@okta/vuepress-site/docs/api/resources/oidc/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/oidc/index.md
@@ -570,7 +570,7 @@ Content-Type: application/json;charset=UTF-8
 #### Key Rotation
 The keys that are used to sign tokens are periodically changed. Okta automatically rotates your authorization server's keys on a regular basis.
 
-Clients can opt-out of automatic key rotation by changing the client sign-in mode for  the Okta Org Authorization Server. In this case, passing the `client_id` with your request retrieves the keys for that specific client.
+Clients can opt-out of automatic key rotation by changing the client sign-in mode for the Okta Org Authorization Server. In this case, passing the `client_id` with your request retrieves the keys for that specific client.
 
 Key rotation behaves differently with Custom Authorization Servers. For more information about key rotation with Custom Authorization Servers, see the [Authorization Servers API page](/docs/api/resources/authorization-servers#rotate-authorization-server-keys).
 


### PR DESCRIPTION
## Description:
- **What's changed?** 
- Specified that the parameter `client_id` is only applicable to Okta Org Authorization Server for the /keys endpoint
- The response examples from the .well-known endpoints in the docs are already correct, i.e. they do not include the client_id as a parameter to the jwks endpoint.

- **Is this PR related to a Monolith release?** Yes, 2019.04.2

### Relates to:

* [OKTA-217289](https://oktainc.atlassian.net/browse/OKTA-217289)

### Reviewers:
@yuliu-okta 
