### PR TITLE
Guides relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,27 +139,37 @@ The framework names in the directories should be lowercased and without special 
 * react
 * vue
 * go
+* node
 * java
 * php
 * python
 * spring
 * dotnet
-* netcore
-* osx
+* dotnetcore
+* aspnet
+* aspnetcore
 
 ### Linking between sections and guides
 
 **Always** have a trailing slash at the end of your guides link.  (Example: `/guides/NAME-OF-GUIDE/-/NAME-OF-SECTION/`)
 
-When linking between sections in the same guide, simply use a relative link to the appropriate section name, which will be one directory back. (Example: `../OTHER-SECTION/`)  This will preserve whatever framework the user currently has selected.
+Links and Guides have some complications because of the "magic" nature of the selected framework.  For links within or between guides, follow these examples:
 
-When linking between different guides, use `-` in place of the framework name - this will default the framework to the first option in the StackSelector for that guide.  Example: `/guides/NAME-OF-GUIDE/-/NAME-OF-SECTION/`
-
-To link to another guide you can, but do not need to, link to a specific section.  If you link to just the guide, it will redirect the user to the first section using the default (first) framework option in the StackSelector.
-
-Within the content of a guide the `<NextSectionLink>` component is available to link to different sections:
-
-* `<NextSectionLink/>` - Provides a "button" link to the next section
-* `<NextSectionLink>Some Example Text</NextSectionLink>` - Provides the "button" with different text
-* `<NextSectionLink name="next-steps"/>` - Provides the "button" to link to the named section of the guide (doesn't have to be the "next" section)
+- Linking to a different section of the same guide: 
+  - Use `<GuideLink>` and always go "up" one directory
+  - `<GuideLink link="../NAME-OF-SECTION">Text to show</GuideLink>`
+  - This will maintain the selected framework
+- Linking to a different guide: 
+  - Normal markdown links work
+  - `[Text to Show](/guides/NAME-OF-GUIDE/)`
+  - This will select the first framework and first section and update the url to match.
+- Linking to a specific section of a different guide:
+  - Normal markdown links work
+  - use `-` in place of a framework if you aren't linking to a specific framework
+  - `[Text to Show](/guides/NAME-OF-GUIDE/-/NAME-OF-SECTION/)`
+  - This will select the first framework and update the url to match
+- Linking to another section as part of the guide navigation
+  - `<NextSectionLink/>` - Provides a "button" link to the next section
+  - `<NextSectionLink>Some Example Text</NextSectionLink>` - Provides the "button" with different text
+  - `<NextSectionLink name="next-steps"/>` - Provides the "button" to link to the named section of the guide (doesn't have to be the "next" section)
 

--- a/packages/@okta/vuepress-site/guides/sign-into-spa/create-okta-application/index.md
+++ b/packages/@okta/vuepress-site/guides/sign-into-spa/create-okta-application/index.md
@@ -12,7 +12,7 @@ Start by signing in to the Okta Developer Console:
 
 2. Add the **Base URI** of your application during local development, such as `http://localhost:8080`. Also, add any base URIs where your application runs in production, such as `https://app.example.com`.
 
-3. Next, enter values for the **Login redirect URI**. This is the callback explained in the [previous step](../-/define-callback-route/). Add values for local development (such as `http://localhost:8080/authorization-code/callback`) and production (such as `https://app.example.com/authorization-code/callback`).
+3. Next, enter values for the **Login redirect URI**. This is the callback explained in the <GuideLink link="../define-callback-route/">previous step</GuideLink>. Add values for local development (such as `http://localhost:8080/authorization-code/callback`) and production (such as `https://app.example.com/authorization-code/callback`).
 
 4. Click **Done** to finish creating the Okta Application. You need to copy some values into your code later, so leave the Developer Console open.
 

--- a/packages/@okta/vuepress-theme-default/global-components/GuideLink.vue
+++ b/packages/@okta/vuepress-theme-default/global-components/GuideLink.vue
@@ -1,0 +1,15 @@
+<template>
+  <router-link :to="target"><span><slot>link</slot></span></router-link>
+</template>
+
+<script>
+  export default { 
+    name: 'GuideLink',
+    props: ['link'],
+    computed: { 
+      target() { 
+        return this.link;
+      },
+    },
+  };
+</script>


### PR DESCRIPTION
## Description:
- **What's changed?** 
  - Adds GuideLink component (Vuepress doesn't handle relative links for pseudo-pages like Guides.  This component is a workaround for that to allow linking between guide sections while maintaining the current selected framework in the url.
  - Updates README to reflect above.

- **Is this PR related to a Monolith release?** 
  - No

### Resolves:

* [OKTA-https://oktainc.atlassian.net/browse/OKTA-224075] https://oktainc.atlassian.net/browse/OKTA-224075)
* [OKTA-https://oktainc.atlassian.net/browse/OKTA-220261] https://oktainc.atlassian.net/browse/OKTA-220261)

