### PR TITLE
Fix Nim changes to guides css

### DIFF
--- a/packages/@okta/vuepress-theme-default/assets/css/okta/components/Button.scss
+++ b/packages/@okta/vuepress-theme-default/assets/css/okta/components/Button.scss
@@ -22,6 +22,10 @@
 		color: $black;
 		text-decoration: none;
 	}
+
+	&:visited {
+		@include color('black');
+	}
 }
 
 .Button {
@@ -33,6 +37,10 @@
 	&:hover {
 		border-color: mix(get-color('accent'), get-color('white'), 75%);
 		color: mix(get-color('accent'), get-color('white'), 75%);
+	}
+
+	&:visited {
+		color: get-color('accent');
 	}
 }
 
@@ -72,6 +80,10 @@
 		border-color: $navy-blue;
 		color: get-color('white');
 	}
+
+	&:visited {
+		color: get-color('white');
+	}
 }
 
 .Button--blueOutline {
@@ -81,6 +93,10 @@
 	&:active,
 	&:hover {
 		border-color: get-color('blue-bright');
+		color: get-color('blue-bright');
+	}
+
+	&:visited {
 		color: get-color('blue-bright');
 	}
 }
@@ -97,6 +113,10 @@
 		border-color: get-color('green-dark-hover');
 		color: get-color('white');
 	}
+
+	&:visited {
+		color: get-color('white');
+	}
 }
 
 .Button--greenOutline {
@@ -106,6 +126,10 @@
 	&:active,
 	&:hover {
 		border-color: get-color('green-dark');
+		color: get-color('green-dark');
+	}
+
+	&:visited {
 		color: get-color('green-dark');
 	}
 }
@@ -120,6 +144,10 @@
 		border-color: get-color('white');
 		color: get-color('blue-bright');
 	}
+
+	&:visited {
+		color: get-color('blue-bright');
+	}
 }
 
 .Button--whiteOutline {
@@ -129,6 +157,10 @@
 	&:active,
 	&:hover {
 		border-color: get-color('white');
+		color: get-color('white');
+	}
+
+	&:visited {
 		color: get-color('white');
 	}
 }
@@ -141,6 +173,22 @@
 	&:active,
 	&:hover {
 		border-color: get-color('white');
+		color: get-color('white');
+	}
+}
+
+.Button--red {
+	@extend %Button;
+
+	&,
+	&:active,
+	&:hover {
+		background-color: get-color('cerise');
+		border-color: get-color('cerise');
+		color: get-color('white');
+	}
+
+	&:visited {
 		color: get-color('white');
 	}
 }

--- a/packages/@okta/vuepress-theme-default/assets/css/okta/pages/guides.scss
+++ b/packages/@okta/vuepress-theme-default/assets/css/okta/pages/guides.scss
@@ -187,12 +187,10 @@ $big-spacing: 3rem;
 
   /* reduce icons to 24px */
   .icon[class*='-32'] {
-    &:before {
-      font-size: 24px;
-    }
-
+    &:before,
     &:after {
       font-size: 24px;
+      line-height: 24px;
     }
   }
 

--- a/packages/@okta/vuepress-theme-default/layouts/Guides.vue
+++ b/packages/@okta/vuepress-theme-default/layouts/Guides.vue
@@ -86,5 +86,7 @@
 <style lang="scss">
   @import '../assets/css/okta';
   @import '~prismjs/themes/prism-solarizedlight.css';
+  .icon.outbound {
+    display: none !important
+  }
 </style>
-


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:

Some CSS fixes to compensate for Nim changes in Guides.
- Stack selector language icon position
- Visited button text color
- Override Vuepress outbound link icon

<img width="848" alt="stack" src="https://user-images.githubusercontent.com/26014482/57256962-c8e99c80-6ff3-11e9-9864-ae23e216a604.png">
