### PR TITLE
fix(guides): Updates Guides content to be full (avail) width

### DIFF
--- a/packages/@okta/vuepress-theme-default/assets/css/okta/pages/guides.scss
+++ b/packages/@okta/vuepress-theme-default/assets/css/okta/pages/guides.scss
@@ -33,6 +33,10 @@ $big-spacing: 3rem;
   display: flex;
 }
 
+.guide-content { 
+  width: 100%;
+}
+
 .guide-featured {
   transition: box-shadow 200ms linear;
   border: 0;

--- a/packages/@okta/vuepress-theme-default/assets/css/okta/pages/guides.scss
+++ b/packages/@okta/vuepress-theme-default/assets/css/okta/pages/guides.scss
@@ -35,6 +35,7 @@ $big-spacing: 3rem;
 
 .guide-content { 
   width: 100%;
+  max-width: 890px;
 }
 
 .guide-featured {

--- a/packages/@okta/vuepress-theme-default/components/GuideDetails.vue
+++ b/packages/@okta/vuepress-theme-default/components/GuideDetails.vue
@@ -7,7 +7,7 @@
         :framework="framework"
         :guideName="guideName" 
       />
-      <div id="guide-content">
+      <div class="guide-content">
         <h1>{{ section.title }}</h1>
         <Content :pageKey="componentKey"/>
       </div>


### PR DESCRIPTION
## Description:
- **What's changed?** 
  - Guides will now fill the available width, so switching frameworks will not cause any horizontal display changes
- **Is this PR related to a Monolith release?** 
- No
### Resolves:

* [OKTA-221547](https://oktainc.atlassian.net/browse/OKTA-221547)

![guidewidth](https://user-images.githubusercontent.com/492300/57398010-ded99780-7182-11e9-8186-a9f4bc6a2fc1.gif)
![guidewidth-small](https://user-images.githubusercontent.com/492300/57398241-658e7480-7183-11e9-87ec-8bc370b02986.gif)
