### PR TITLE
Fix broken link to "SAML Guidance" #2

### DIFF
--- a/packages/@okta/vuepress-site/code/python/pysaml2/index.md
+++ b/packages/@okta/vuepress-site/code/python/pysaml2/index.md
@@ -194,8 +194,9 @@ example, on a production system, the contents of the
 `metadata_url_for` dictionary cannot be hard coded, but must come
 from a dynamic datastore.
 
-If you want to learn more about SAML and what to consider when writing a SAML implementation, Okta's
-in-depth [SAML Guidance](/docs/guides/saml_guidance)
+If you want to learn more about SAML and what to consider when writing a
+SAML implementation, Okta's in-depth
+[SAML Guidance](https://www.okta.com/integrate/documentation/single-sign-on/)
 is a great place to learn more.
 
 Finally, if you got this far in this guide and still have questions,

--- a/packages/@okta/vuepress-site/code/python/pysaml2/index.md
+++ b/packages/@okta/vuepress-site/code/python/pysaml2/index.md
@@ -195,8 +195,8 @@ example, on a production system, the contents of the
 from a dynamic datastore.
 
 If you want to learn more about SAML and what to consider when writing a SAML implementation, Okta's
-in-depth [SAML guidance](/docs/getting_started/saml_guidance)
+in-depth [Setting up a SAML Application in Okta](/standards/SAML/setting_up_a_saml_application_in_okta)
 is a great place to learn more.
 
 Finally, if you got this far in this guide and still have questions,
-please reach out to me at: joel.franusic@okta.com.
+please reach out to us at: developer@okta.com.

--- a/packages/@okta/vuepress-site/code/python/pysaml2/index.md
+++ b/packages/@okta/vuepress-site/code/python/pysaml2/index.md
@@ -195,8 +195,8 @@ example, on a production system, the contents of the
 from a dynamic datastore.
 
 If you want to learn more about SAML and what to consider when writing a SAML implementation, Okta's
-in-depth [Setting up a SAML Application in Okta](/standards/SAML/setting_up_a_saml_application_in_okta)
+in-depth [SAML Guidance](/docs/guides/saml_guidance)
 is a great place to learn more.
 
 Finally, if you got this far in this guide and still have questions,
-please reach out to us at: developer@okta.com.
+please reach out to us at: [developers@okta.com](mailto:developers@okta.com)


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
SAML guidance link has been moved and the existing link is broken. 

New link should be: https://www.okta.com/integrate/documentation/single-sign-on/

- **Is this PR related to a Monolith release?**
No

### Resolves:

* no JIRA, manually found and fixed this issue.
