### PR TITLE
Removing extra comma.

### DIFF
--- a/packages/@okta/vuepress-site/use_cases/inline_hooks/registration_hook/registration_hook/index.md
+++ b/packages/@okta/vuepress-site/use_cases/inline_hooks/registration_hook/registration_hook/index.md
@@ -210,7 +210,7 @@ If you do not return any value for that `errorCauses` object, but deny the user'
             "action":"DENY"
          }
       }
-   ],
+   ]
 }
 ```
 ```json


### PR DESCRIPTION
## Description:
- **What's changed?** There was a typo--an extra comma--in the JSON listing in the 'Sample JSON Payload of Response' section of the 'Registration Inline Hook' page.
- **Is this PR related to a Monolith release?** No.

