### PR TITLE
OKTA-226324: Filters out beta event types.

### DIFF
--- a/packages/@okta/vuepress-theme-default/global-components/EventTypes.vue
+++ b/packages/@okta/vuepress-theme-default/global-components/EventTypes.vue
@@ -36,7 +36,7 @@
 
   export default {
     created() {
-      this.eventTypes = eventTypes.versions[1].eventTypes
+      this.eventTypes = eventTypes.versions[1].eventTypes.filter(eventType => !eventType.beta)
       this.releases = _.chain(this.eventTypes)
         .map(eventType => eventType.info)
         .map(info => info.release)


### PR DESCRIPTION

## Description:
- **What's changed?** Filters out `beta` event types.
- **Is this PR related to a Monolith release?**  No
### Resolves:

* [OKTA-226324](https://oktainc.atlassian.net/browse/OKTA-226324)
