### PR TITLE
External icons for buttons

### DIFF
--- a/packages/@okta/vuepress-theme-default/README.md
+++ b/packages/@okta/vuepress-theme-default/README.md
@@ -8,9 +8,9 @@ Contributions are welcome!
 First, you'll need the site running locally. Start with the `okta-developer-docs` root readme.
 
 ### Dependencies
-Okta's design system, [Nim](https://github.com/okta/okta-ui/tree/master/packages/nim) (private repo), is  imported as a foundation. See [Nim's documentation](https://design-docs.trexcloud.com) for usage guidelines.
+Okta's design system, [Nim](https://github.com/okta/nim), is imported as a foundation. See [Nim's documentation](https://design-docs.trexcloud.com) for usage guidelines.
 
-This theme uses [stylelint](https://stylelint.io) for SCSS linting. A plugin is likely available for your favorite text editor! Linting rules ([source](https://github.com/okta/okta-ui/blob/master/packages/nim/.stylelintrc.json)) are defined in `.stylelintrc`, and require supporting configuration files to be installed. (Most of our SCSS fails linting today; please clean what you touch.)
+This theme uses [stylelint](https://stylelint.io) for SCSS linting. A plugin is likely available for your favorite text editor! Linting rules ([source](https://github.com/okta/nim/blob/master/.stylelintrc.json)) are defined in `.stylelintrc`, and require supporting configuration files to be installed. (Most of our SCSS fails linting today; please clean what you touch.)
 
 These dependencies should automatically be installed by a root `yarn install`. If not:
 - Open a terminal in this package (`vuepress-theme-default`)

--- a/packages/@okta/vuepress-theme-default/assets/css/okta/components/Button.scss
+++ b/packages/@okta/vuepress-theme-default/assets/css/okta/components/Button.scss
@@ -192,3 +192,11 @@
 		color: get-color('white');
 	}
 }
+
+.Button--blue,
+.Button--red {
+	&[target='_blank']:not([href^='mailto:'])::after {
+		margin-bottom: 0.25em;
+		background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2216%22%20height%3D%2216%22%20viewBox%3D%220%200%2016%2016%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%3Cpath%20d%3D%22M13.5%2010.5V13C13.5%2013.3%2013.3%2013.5%2013%2013.5H3C2.7%2013.5%202.5%2013.3%202.5%2013V3C2.5%202.7%202.7%202.5%203%202.5H5.5%22%20stroke%3D%22%23FFFFFF%22%20stroke-miterlimit%3D%2210%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%2F%3E%0A%3Cpath%20d%3D%22M8%208L14%202%22%20stroke%3D%22%23FFFFFF%22%20stroke-miterlimit%3D%2210%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%2F%3E%0A%3Cpath%20d%3D%22M9.5%201.5H14.5%22%20stroke%3D%22%23FFFFFF%22%20stroke-miterlimit%3D%2210%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%2F%3E%0A%3Cpath%20d%3D%22M14.5%206.5V1.5%22%20stroke%3D%22%23FFFFFF%22%20stroke-miterlimit%3D%2210%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%2F%3E%0A%3C%2Fsvg%3E%0A");
+	}
+}


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- For buttons that open a link in a new window, changes the external icon color to be visible.
- Applies to `blue` and `red` buttons, which should be the only ones in use.
- Also tweaks theme readme to link to newly open-source Nim.

<img width="364" alt="external-button" src="https://user-images.githubusercontent.com/26014482/57500821-96080880-7280-11e9-9347-01be11fafafe.png">


### Resolves:

* #312 