### PR TITLE
Removing redirect frontmatter, since VuePress doesn't use it

### DIFF
--- a/packages/@okta/vuepress-site/3rd_party_notices/Okta_Cloud_Provisioning_Connector_Tool/index.md
+++ b/packages/@okta/vuepress-site/3rd_party_notices/Okta_Cloud_Provisioning_Connector_Tool/index.md
@@ -1,7 +1,6 @@
 ---
 showToc: false
 title: Okta Cloud Provisioning Connector Tool product
-redirect_from: /3rd_party_notices/Okta_Rum_Tool
 ---
 
 This document contains third party open source licenses and notices for

--- a/packages/@okta/vuepress-site/authentication-guide/implementing-authentication/set-up-authz-server/index.md
+++ b/packages/@okta/vuepress-site/authentication-guide/implementing-authentication/set-up-authz-server/index.md
@@ -11,17 +11,11 @@ If you have an [Okta Developer Edition](https://developer.okta.com/signup/) acco
 
 If you only need one Authorization Server, but you'd like to know more about customizing it, you can skip ahead and find out how to:
 
-- [Overview](#overview)
-  - [Create an Authorization Server](#create-an-authorization-server)
-  - [Create Access Policies](#create-access-policies)
-  - [Create Rules for Each Access Policy](#create-rules-for-each-access-policy)
-    - [Rule Usage](#rule-usage)
-  - [Create Scopes (Optional)](#create-scopes-optional)
-  - [Create Claims (Optional)](#create-claims-optional)
-  - [Test Your Authorization Server Configuration](#test-your-authorization-server-configuration)
-    - [OpenID Connect Configuration](#openid-connect-configuration)
-    - [Custom Scopes and Claims](#custom-scopes-and-claims)
-    - [Testing an OpenID Connect Flow](#testing-an-openid-connect-flow)
+- [Create Access Policies](#create-access-policies)
+- [Create Rules for your Access Policies](#create-rules-for-each-access-policy)
+- [Create Scopes](#create-scopes-optional)
+- [Create Claims](#create-claims-optional)
+- [Test your Authorization Server](#test-your-authorization-server-configuration
 
 > NOTE: For a high-level explanation of OAuth 2.0 and OpenID Connect see our [OAuth 2.0 Overview](/authentication-guide/auth-overview/).
 

--- a/packages/@okta/vuepress-site/authentication-guide/implementing-authentication/set-up-authz-server/index.md
+++ b/packages/@okta/vuepress-site/authentication-guide/implementing-authentication/set-up-authz-server/index.md
@@ -15,7 +15,7 @@ If you only need one Authorization Server, but you'd like to know more about cus
 - [Create Rules for your Access Policies](#create-rules-for-each-access-policy)
 - [Create Scopes](#create-scopes-optional)
 - [Create Claims](#create-claims-optional)
-- [Test your Authorization Server](#test-your-authorization-server-configuration
+- [Test your Authorization Server](#test-your-authorization-server-configuration)
 
 > NOTE: For a high-level explanation of OAuth 2.0 and OpenID Connect see our [OAuth 2.0 Overview](/authentication-guide/auth-overview/).
 

--- a/packages/@okta/vuepress-site/authentication-guide/implementing-authentication/set-up-authz-server/index.md
+++ b/packages/@okta/vuepress-site/authentication-guide/implementing-authentication/set-up-authz-server/index.md
@@ -1,8 +1,6 @@
 ---
 title: Customizing Your Authorization Server
 excerpt: How to set up a custom authorization server in Okta
-redirect_from:
-  - /docs/how-to/set-up-auth-server.html
 ---
 
 # Overview
@@ -13,11 +11,17 @@ If you have an [Okta Developer Edition](https://developer.okta.com/signup/) acco
 
 If you only need one Authorization Server, but you'd like to know more about customizing it, you can skip ahead and find out how to:
 
-- [Create Access Policies](#create-access-policies)
-- [Create Rules for your Access Policies](#create-rules-for-each-access-policy)
-- [Create Scopes](#create-scopes-optional)
-- [Create Claims](#create-claims-optional)
-- [Test your Authorization Server](#test-your-authorization-server-configuration)
+- [Overview](#overview)
+  - [Create an Authorization Server](#create-an-authorization-server)
+  - [Create Access Policies](#create-access-policies)
+  - [Create Rules for Each Access Policy](#create-rules-for-each-access-policy)
+    - [Rule Usage](#rule-usage)
+  - [Create Scopes (Optional)](#create-scopes-optional)
+  - [Create Claims (Optional)](#create-claims-optional)
+  - [Test Your Authorization Server Configuration](#test-your-authorization-server-configuration)
+    - [OpenID Connect Configuration](#openid-connect-configuration)
+    - [Custom Scopes and Claims](#custom-scopes-and-claims)
+    - [Testing an OpenID Connect Flow](#testing-an-openid-connect-flow)
 
 > NOTE: For a high-level explanation of OAuth 2.0 and OpenID Connect see our [OAuth 2.0 Overview](/authentication-guide/auth-overview/).
 

--- a/packages/@okta/vuepress-site/authentication-guide/saml-login/index.md
+++ b/packages/@okta/vuepress-site/authentication-guide/saml-login/index.md
@@ -1,7 +1,5 @@
 ---
 title: SAML Authentication with OIDC
-redirect_from:
-  - /docs/how-to/inbound-saml-with-oidc
 ---
 
 # Authenticating Against an External SAML IdP

--- a/packages/@okta/vuepress-site/authentication-guide/social-login/index.md
+++ b/packages/@okta/vuepress-site/authentication-guide/social-login/index.md
@@ -1,7 +1,5 @@
 ---
 title: Social Login Overview
-redirect_from:
-  - /docs/api/resources/social_authentication
 ---
 
 # Social Login

--- a/packages/@okta/vuepress-site/code/dotnet/aspnetcore/index.md
+++ b/packages/@okta/vuepress-site/code/dotnet/aspnetcore/index.md
@@ -2,8 +2,6 @@
 title: Add Identity Management to Your ASP.NET Core App
 language: .NET
 integration: back-end
-redirect_from:
-  - /code/dotnet/
 component: Code
 ---
 

--- a/packages/@okta/vuepress-site/code/dotnet/sample_application/index.md
+++ b/packages/@okta/vuepress-site/code/dotnet/sample_application/index.md
@@ -5,7 +5,6 @@ excerpt: >-
   The Okta Music Store is a sample application written in .NET and is a
   demonstration of how to add Okta as an identity provider for an existing
   application.
-redirect_from: /docs/examples/dotnet_sample_application.html
 component: Code
 ---
 

--- a/packages/@okta/vuepress-site/code/ios/index.md
+++ b/packages/@okta/vuepress-site/code/ios/index.md
@@ -2,8 +2,6 @@
 title: Add Identity Management to Your iOS App
 language: iOS
 integration: mobile
-redirect_from:
-  - /code/swift/
 component: Code
 ---
 

--- a/packages/@okta/vuepress-site/code/java/spring_security_saml/index.md
+++ b/packages/@okta/vuepress-site/code/java/spring_security_saml/index.md
@@ -4,9 +4,6 @@ language: Java
 excerpt: >-
   Guidance on how to SAML-enable your application using open source Spring
   Security library.
-redirect_from:
-  - /docs/examples/spring_security_saml.html
-  - /docs/guides/spring_security_saml.html
 component: Code
 ---
 

--- a/packages/@okta/vuepress-site/code/javascript/okta_auth_sdk/index.md
+++ b/packages/@okta/vuepress-site/code/javascript/okta_auth_sdk/index.md
@@ -2,8 +2,6 @@
 title: Okta Auth SDK Guide
 language: JavaScript
 excerpt: A JavaScript wrapper for Okta's Authentication APIs.
-redirect_from:
-  - /docs/guides/okta_auth_sdk.html
 component: Code
 ---
 

--- a/packages/@okta/vuepress-site/code/javascript/okta_auth_sdk_ref/index.md
+++ b/packages/@okta/vuepress-site/code/javascript/okta_auth_sdk_ref/index.md
@@ -3,9 +3,6 @@ title: Okta Auth SDK Reference
 language: JavaScript
 hide_from_layout: 0
 excerpt: Reference information for customizing the Okta Auth SDK.
-redirect_from:
-  - /code/javascript/okta_auth_sdk_external_ref.html
-redirect_to: 'https://github.com/okta/okta-auth-js'
 component: Code
 ---
 

--- a/packages/@okta/vuepress-site/code/javascript/okta_sign-in_widget/index.md
+++ b/packages/@okta/vuepress-site/code/javascript/okta_sign-in_widget/index.md
@@ -2,8 +2,6 @@
 title: Okta Sign-In Widget Guide
 language: JavaScript
 excerpt: A drop-in widget with custom UI capabilities to power sign-in with Okta.
-redirect_from:
-  - /docs/guides/okta_sign-in_widget.html
 component: Code
 ---
 

--- a/packages/@okta/vuepress-site/code/javascript/okta_sign-in_widget_ref/index.md
+++ b/packages/@okta/vuepress-site/code/javascript/okta_sign-in_widget_ref/index.md
@@ -3,10 +3,6 @@ title: Okta Sign-In Widget Reference
 language: JavaScript
 hide_from_layout: 0
 excerpt: Reference information for customizing the Okta Sign-In Widget.
-redirect_from:
-  - /code/javascript/okta_sign-in_widget_external_ref.html
-  - /docs/api/resources/okta_signin_widget.html
-redirect_to: 'https://github.com/okta/okta-signin-widget'
 component: Code
 ---
 

--- a/packages/@okta/vuepress-site/code/php/simplesamlphp/index.md
+++ b/packages/@okta/vuepress-site/code/php/simplesamlphp/index.md
@@ -2,8 +2,6 @@
 title: SimpleSAMPphp
 language: PHP
 excerpt: How to use SimpleSAMLphp to add support for Okta via SAML.
-redirect_from:
-  - /docs/guides/simplesamlphp.html
 component: Code
 ---
 
@@ -112,7 +110,7 @@ PHP, reconfiguring Apache, and creating some symbolic links.
    $ brew install php56-mcrypt
    ```
 
-2. Edit `httpd.conf` to use the new version of PHP that you installed with homebrew.
+3. Edit `httpd.conf` to use the new version of PHP that you installed with homebrew.
 
    ```
    $ sudo $EDITOR /etc/apache2/httpd.conf
@@ -130,13 +128,13 @@ PHP, reconfiguring Apache, and creating some symbolic links.
    LoadModule php5_module /usr/local/Cellar/php56/5.6.7/libexec/apache2/libphp5.so
    ```
 
-2. Find the `DocumentRoot` for your setup of Apache.
+4. Find the `DocumentRoot` for your setup of Apache.
 
    ```
    $ grep ^DocumentRoot /etc/apache2/httpd.conf
    ```
 
-3. `cd` to the `DocumentRoot` directory.
+5. `cd` to the `DocumentRoot` directory.
 
    Assuming that the command above returned `DocumentRoot "/Library/WebServer/Documents"`,
    then `cd` to that directory
@@ -145,7 +143,7 @@ PHP, reconfiguring Apache, and creating some symbolic links.
    $ cd /Library/WebServer/Documents
    ```
 
-4. Add symbolic links from `DocumentRoot` to your `simplesamlphp` and `okta-simplesamlphp-example` directories.
+6. Add symbolic links from `DocumentRoot` to your `simplesamlphp` and `okta-simplesamlphp-example` directories.
 
    ```
    $ sudo ln -s ~/simplesamlphp/simplesamlphp .

--- a/packages/@okta/vuepress-site/code/python/pysaml2/index.md
+++ b/packages/@okta/vuepress-site/code/python/pysaml2/index.md
@@ -4,9 +4,6 @@ language: Python
 excerpt: >-
   Guidance on how to SAML-enable your Python application using open source
   PySAML2.
-redirect_from:
-  - /docs/examples/pysaml2.html
-  - /docs/guides/pysaml2.html
 component: Code
 ---
 
@@ -65,7 +62,7 @@ section we use the "Identity Provider metadata" link from the
 section above to configure PySAML2. After completing
 the following steps, you will have a working example of connecting Okta to a sample Python application using PySAML2.
 
-0.  Install platform-dependent prerequisites:
+1.  Install platform-dependent prerequisites:
 
     > Note: These instructions assume that you are running on a recent version of your operating system.
 
@@ -81,25 +78,25 @@ the following steps, you will have a working example of connecting Okta to a sam
     sudo yum install libffi-devel xmlsec1 xmlsec1-openssl
     ```
 
-1.  Download the example application for Python:
+2.  Download the example application for Python:
 
     ```bash
     $ git clone git@github.com:jpf/okta-pysaml2-example.git
     ```
 
-2.  `cd` to the `okta-pysaml2-example` directory.
+3.  `cd` to the `okta-pysaml2-example` directory.
 
     ```bash
     $ cd okta-pysaml2-example
     ```
 
-3.  Open the `app.py` file in your favorite text editor.
+4.  Open the `app.py` file in your favorite text editor.
 
     ```bash
     $ $EDITOR app.py
     ```
 
-4.  After opening the `app.py` file, modify the contents of the `metadata_url_for` dictionary as shown below.
+5.  After opening the `app.py` file, modify the contents of the `metadata_url_for` dictionary as shown below.
 
     ``` python
     metadata_url_for = {
@@ -107,14 +104,14 @@ the following steps, you will have a working example of connecting Okta to a sam
     }
     ```
 
-5.  Be sure to replace the contents of `${metdata_url}` with the link
+6.  Be sure to replace the contents of `${metdata_url}` with the link
     that you copied in step \#10 of the
     "[Setting up a SAML application in Okta](/authentication-guide/implementing-authentication/set-up-authz-server/)"
     instructions that you followed above!
 
     Note: The contents of `${metadata_url}` should look similar to: `https://{yourOktaDomain}/app/a0b1c2deFGHIJKLMNOPQ/sso/saml/metadata`
 
-6.  Install the dependencies; for example, Python SAML SP:
+7.  Install the dependencies; for example, Python SAML SP:
 
     ```bash
     $ virtualenv venv
@@ -122,7 +119,7 @@ the following steps, you will have a working example of connecting Okta to a sam
     $ pip install -r requirements.txt
     ```
 
-7.  Start the Python example:
+8.  Start the Python example:
 
     ```bash
     $ python app.py

--- a/packages/@okta/vuepress-site/code/rest/index.md
+++ b/packages/@okta/vuepress-site/code/rest/index.md
@@ -2,11 +2,6 @@
 title: Get Started with the Okta REST APIs
 language: rest
 integration: back-end
-redirect_from:
-  - /docs/getting_started/api_test_client.html
-  - /docs/api/getting_started/api_test_client.html
-  - /docs/api/getting_started/index.html
-  - /docs/api/getting_started/
 component: Code
 ---
 

--- a/packages/@okta/vuepress-site/docs/api/getting_started/design_principles/index.md
+++ b/packages/@okta/vuepress-site/docs/api/getting_started/design_principles/index.md
@@ -1,9 +1,5 @@
 ---
 title: Design Principles
-redirect_from:
-  - /docs/getting_started/design_principles.html
-  - docs/api/index.html
-  - docs/api/
 ---
 
 # Versioning

--- a/packages/@okta/vuepress-site/docs/api/getting_started/getting_a_token/index.md
+++ b/packages/@okta/vuepress-site/docs/api/getting_started/getting_a_token/index.md
@@ -1,6 +1,5 @@
 ---
 title: Getting a Token
-redirect_from: /docs/getting_started/getting_a_token.html
 ---
 
 # Create an API Token

--- a/packages/@okta/vuepress-site/docs/api/getting_started/rate-limits/index.md
+++ b/packages/@okta/vuepress-site/docs/api/getting_started/rate-limits/index.md
@@ -1,7 +1,5 @@
 ---
 title: Rate Limits at Okta
-redirect_from:
-  - /docs/getting_started/design_principles
 excerpt: >-
   Understand rate limits at Okta and learn how to design for efficient use of
   resources

--- a/packages/@okta/vuepress-site/docs/api/resources/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/apps/index.md
@@ -1,12 +1,6 @@
 ---
 title: Apps
 category: management
-redirect_from:
-  - /docs/api/
-  - /docs/api/resources/
-  - /docs/api/reference/
-  - /docs/api/reference/index.html
-  - /docs/api/rest/apps.html
 ---
 
 # Apps API

--- a/packages/@okta/vuepress-site/docs/api/resources/authn/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/authn/index.md
@@ -2,10 +2,6 @@
 title: Authentication
 category: authentication
 excerpt: Control user access to Okta.
-redirect_from:
-  - /docs/api/rest/authn.html
-  - /docs/api/resources/index.html
-  - /docs/api/resources/
 ---
 
 # Authentication API

--- a/packages/@okta/vuepress-site/docs/api/resources/events/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/events/index.md
@@ -2,7 +2,6 @@
 title: Events
 category: management
 deprecated: true
-redirect_from: /docs/api/rest/events.html
 ---
 
 # Events API
@@ -53,11 +52,11 @@ The most reliable method to ingest all events from Okta is to use a [pagination]
 The general sequence of steps to leverage the `after` parameter:
 
 1. Issue an initial request using `startDate` with a value set to some date in the last 90 days
-1. Retrieve the next page of events through the [`Link` response header](/docs/api/getting_started/design_principles#link-header) value with the `next` link relation
-1. Optionally include a `filter` parameter to narrow the returned results
-1. Issue the paginated request
-1. Retrieve the next page of events through the `Link` response header value with the `next` link relation
-1. Pause and repeat the previous step
+2. Retrieve the next page of events through the [`Link` response header](/docs/api/getting_started/design_principles#link-header) value with the `next` link relation
+3. Optionally include a `filter` parameter to narrow the returned results
+4. Issue the paginated request
+5. Retrieve the next page of events through the `Link` response header value with the `next` link relation
+6. Pause and repeat the previous step
 
 Note that if no data is returned, this typically indicates you have caught up with the event stream. To avoid issues with [rate limiting](/docs/api/getting_started/rate-limits), ensure your polling frequency is sufficiently long.
 

--- a/packages/@okta/vuepress-site/docs/api/resources/events/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/events/index.md
@@ -52,11 +52,11 @@ The most reliable method to ingest all events from Okta is to use a [pagination]
 The general sequence of steps to leverage the `after` parameter:
 
 1. Issue an initial request using `startDate` with a value set to some date in the last 90 days
-2. Retrieve the next page of events through the [`Link` response header](/docs/api/getting_started/design_principles#link-header) value with the `next` link relation
-3. Optionally include a `filter` parameter to narrow the returned results
-4. Issue the paginated request
-5. Retrieve the next page of events through the `Link` response header value with the `next` link relation
-6. Pause and repeat the previous step
+1. Retrieve the next page of events through the [`Link` response header](/docs/api/getting_started/design_principles#link-header) value with the `next` link relation
+1. Optionally include a `filter` parameter to narrow the returned results
+1. Issue the paginated request
+1. Retrieve the next page of events through the `Link` response header value with the `next` link relation
+1. Pause and repeat the previous step
 
 Note that if no data is returned, this typically indicates you have caught up with the event stream. To avoid issues with [rate limiting](/docs/api/getting_started/rate-limits), ensure your polling frequency is sufficiently long.
 

--- a/packages/@okta/vuepress-site/docs/api/resources/factor_admin/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/factor_admin/index.md
@@ -2,7 +2,6 @@
 title: Factors Administration
 beta: true
 category: management
-redirect_from: /docs/getting_started/factor_admin.html
 ---
 
 # Factors Administration API

--- a/packages/@okta/vuepress-site/docs/api/resources/factors/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/factors/index.md
@@ -1,7 +1,6 @@
 ---
 title: Factors
 category: management
-redirect_from: /docs/api/rest/factors.html
 ---
 
 # Factors API

--- a/packages/@okta/vuepress-site/docs/api/resources/groups/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/groups/index.md
@@ -1,7 +1,6 @@
 ---
 title: Groups
 category: management
-redirect_from: /docs/api/rest/groups.html
 ---
 
 # Groups API

--- a/packages/@okta/vuepress-site/docs/api/resources/idps/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/idps/index.md
@@ -1,7 +1,6 @@
 ---
 title: Identity Providers
 category: management
-redirect_from: docs/api/rest/idps.html
 ---
 
 # Identity Providers API

--- a/packages/@okta/vuepress-site/docs/api/resources/oauth-clients/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/oauth-clients/index.md
@@ -1,7 +1,6 @@
 ---
 title: Dynamic Client Registration
 category: management
-redirect_from: /docs/api/rest/oauth-clients.html
 excerpt: >-
   Operations to register and manage client applications for use with Okta's
   OAuth 2.0 and OpenID Connect endpoints

--- a/packages/@okta/vuepress-site/docs/api/resources/oidc/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/oidc/index.md
@@ -2,12 +2,6 @@
 title: OpenID Connect & OAuth 2.0 API
 category: authentication
 excerpt: Control user access to your applications.
-redirect_from:
-  - /docs/api/resources/oauth2
-  - /docs/how-to/beta-auth-service/api-access-management-troubleshooting
-  - /standards/OIDC/
-  - /standards/OAuth/
-  - /reference/authentication_reference
 ---
 
 # OpenID Connect & OAuth 2.0 API

--- a/packages/@okta/vuepress-site/docs/api/resources/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/policy/index.md
@@ -1,7 +1,6 @@
 ---
 title: Policy
 category: management
-redirect_from: /docs/getting_started/policy.html
 ---
 
 # Policy API

--- a/packages/@okta/vuepress-site/docs/api/resources/sessions/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/sessions/index.md
@@ -1,7 +1,6 @@
 ---
 title: Sessions
 category: management
-redirect_from: /docs/api/rest/sessions.html
 ---
 
 # Sessions API

--- a/packages/@okta/vuepress-site/docs/api/resources/templates/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/templates/index.md
@@ -1,7 +1,6 @@
 ---
 title: Templates
 category: management
-redirect_from: /docs/api/rest/templates.html
 ---
 
 # Custom Templates API

--- a/packages/@okta/vuepress-site/docs/api/resources/tokens/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/tokens/index.md
@@ -1,8 +1,6 @@
 ---
 title: Tokens
-beta: true
 category: management
-redirect_from: /docs/getting_started/tokens.html
 ---
 
 # Overiew

--- a/packages/@okta/vuepress-site/docs/api/resources/users/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/users/index.md
@@ -1,9 +1,6 @@
 ---
 title: Users
-category: management
-redirect_from:
-  - /docs/api/rest/users.html
-  - /docs/api/resources/user
+category: managemen
 ---
 
 # Users API

--- a/packages/@okta/vuepress-site/docs/api/resources/users/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/users/index.md
@@ -1,6 +1,6 @@
 ---
 title: Users
-category: managemen
+category: management
 ---
 
 # Users API

--- a/packages/@okta/vuepress-site/reference/error_codes/index.md
+++ b/packages/@okta/vuepress-site/reference/error_codes/index.md
@@ -1,9 +1,6 @@
 ---
 title: Error Codes
 excerpt: Understand Okta API errors.
-redirect_from:
-  - /docs/getting_started/error_codes
-  - /reference/error_codes/
 ---
 
 # Overview

--- a/packages/@okta/vuepress-site/reference/okta_expression_language/index.md
+++ b/packages/@okta/vuepress-site/reference/okta_expression_language/index.md
@@ -1,9 +1,6 @@
 ---
 title: Okta Expression Language
 excerpt: Read and transform attributes in our APIs and admin UI.
-redirect_from:
-  - /docs/getting_started/okta_expression_lang
-  - /reference/okta_expression_language/
 ---
 
 # Overview

--- a/packages/@okta/vuepress-site/reference/scim/index.md
+++ b/packages/@okta/vuepress-site/reference/scim/index.md
@@ -2,9 +2,6 @@
 title: SCIM Protocol
 excerpt: Enable SCIM-based provisioning from Okta to your application.
 icon: /assets/img/icons/scim.svg
-redirect_from:
-  - /docs/guides/scim_guidance.html
-  - /docs/guides/scim_developer_program.html
 ---
 
 # SCIM Protocol

--- a/packages/@okta/vuepress-site/standards/SAML/setting_up_a_saml_application_in_okta/index.md
+++ b/packages/@okta/vuepress-site/standards/SAML/setting_up_a_saml_application_in_okta/index.md
@@ -19,11 +19,11 @@ If you see **Developer Console** in the top left, click it and select **Classic 
     privileges. If you don't have an Okta organization, you can create a free Okta
     <a href="https://developer.okta.com/signup/" target="_blank">Developer Edition organization</a>.
 
-2.  Click on the Applications link in the upper navigation bar
+1.  Click on the Applications link in the upper navigation bar
 
-3.  Click on the green **Create New App** button
+1.  Click on the green **Create New App** button
 
-4.  In the dialog that opens, select the "SAML 2.0" option, then click
+1.  In the dialog that opens, select the "SAML 2.0" option, then click
     the green "Create" button. If you do not see this option, make sure you are in the Classic UI (see Note above).
 ![Create a New Application Integration](/img/okta-admin-ui-create-new-application-integration.png "Create a New Application Integration")
 

--- a/packages/@okta/vuepress-site/standards/SAML/setting_up_a_saml_application_in_okta/index.md
+++ b/packages/@okta/vuepress-site/standards/SAML/setting_up_a_saml_application_in_okta/index.md
@@ -1,10 +1,5 @@
 ---
 title: Setting up a SAML application in Okta
-redirect_from:
-  - /docs/guides/setting_up_a_saml_application_in_okta
-  - /docs/guides/setting_up_a_saml_application_in_okta.html
-  - /docs/examples/configuring_a_saml_application_in_okta
-  - /docs/examples/configuring_a_saml_application_in_okta.html
 ---
 
 # Setting Up a SAML Application in Okta
@@ -24,11 +19,11 @@ If you see **Developer Console** in the top left, click it and select **Classic 
     privileges. If you don't have an Okta organization, you can create a free Okta
     <a href="https://developer.okta.com/signup/" target="_blank">Developer Edition organization</a>.
 
-1.  Click on the Applications link in the upper navigation bar
+2.  Click on the Applications link in the upper navigation bar
 
-1.  Click on the green **Create New App** button
+3.  Click on the green **Create New App** button
 
-1.  In the dialog that opens, select the "SAML 2.0" option, then click
+4.  In the dialog that opens, select the "SAML 2.0" option, then click
     the green "Create" button. If you do not see this option, make sure you are in the Classic UI (see Note above).
 ![Create a New Application Integration](/img/okta-admin-ui-create-new-application-integration.png "Create a New Application Integration")
 

--- a/packages/@okta/vuepress-site/standards/SCIM/index.md
+++ b/packages/@okta/vuepress-site/standards/SCIM/index.md
@@ -2,9 +2,5 @@
 title: SCIM Provisioning with Lifecycle Management
 excerpt: Enable SCIM-based provisioning from Okta to your application.
 icon: /assets/img/icons/scim.svg
-redirect_to: 'https://www.okta.com/integrate/documentation/scim/'
-redirect_from:
-  - /docs/guides/scim_guidance.html
-  - /docs/guides/scim_developer_program.html
 ---
 

--- a/packages/@okta/vuepress-site/use_cases/api_access_management/index.md
+++ b/packages/@okta/vuepress-site/use_cases/api_access_management/index.md
@@ -1,10 +1,6 @@
 ---
 title: API Access Management
 excerpt: Secure your APIs with Okta's implementation of the OAuth 2.0 standard.
-redirect_from:
-  - /docs/api/resources/resource-server-beta/
-  - >-
-    /docs/api/resources/resource-server-beta/required-config-changes-for-auth-server
 ---
 
 ## API Access Management with Okta
@@ -100,12 +96,20 @@ Okta API Products refers to all the resources and tools that Okta makes availabl
 
 ### Recommendations
 
-* [API Access Management Administrator Role](#api-access-management-administrator-role)
-* [OAuth Client](#oauth-client)
-* [Authorization Server](#authorization-server)
-* [API Gateway (optional)](#api-gateway-optional)
-* [Securing Applications](#securing-applications)
-* [Resource (API) Servers](#resource-api-servers)
+- [Benefits of API Access Management](#benefits-of-api-access-management)
+- [Putting the Pieces Together](#putting-the-pieces-together)
+  - [Tokens and Scopes](#tokens-and-scopes)
+  - [Custom Claims](#custom-claims)
+- [Getting Started with API Access Management](#getting-started-with-api-access-management)
+  - [Recommended Practices for API Access Management](#recommended-practices-for-api-access-management)
+    - [Definitions](#definitions)
+    - [Recommendations](#recommendations)
+      - [API Access Management Administrator Role](#api-access-management-administrator-role)
+      - [OAuth Client](#oauth-client)
+      - [Authorization Server](#authorization-server)
+      - [API Gateway (optional)](#api-gateway-optional)
+      - [Securing Applications](#securing-applications)
+      - [Resource (API) Servers](#resource-api-servers)
 
 #### API Access Management Administrator Role
 

--- a/packages/@okta/vuepress-site/use_cases/api_access_management/index.md
+++ b/packages/@okta/vuepress-site/use_cases/api_access_management/index.md
@@ -94,23 +94,6 @@ An API Product is a group of API endpoints offered together to satisfy a particu
 
 Okta API Products refers to all the resources and tools that Okta makes available.
 
-### Recommendations
-
-- [Benefits of API Access Management](#benefits-of-api-access-management)
-- [Putting the Pieces Together](#putting-the-pieces-together)
-  - [Tokens and Scopes](#tokens-and-scopes)
-  - [Custom Claims](#custom-claims)
-- [Getting Started with API Access Management](#getting-started-with-api-access-management)
-  - [Recommended Practices for API Access Management](#recommended-practices-for-api-access-management)
-    - [Definitions](#definitions)
-    - [Recommendations](#recommendations)
-      - [API Access Management Administrator Role](#api-access-management-administrator-role)
-      - [OAuth Client](#oauth-client)
-      - [Authorization Server](#authorization-server)
-      - [API Gateway (optional)](#api-gateway-optional)
-      - [Securing Applications](#securing-applications)
-      - [Resource (API) Servers](#resource-api-servers)
-
 #### API Access Management Administrator Role
 
 Okta provides the API Access Management Administrator role to make managing authorization servers. A user with this role can perform the following tasks:

--- a/packages/@okta/vuepress-site/use_cases/authentication/session_cookie/index.md
+++ b/packages/@okta/vuepress-site/use_cases/authentication/session_cookie/index.md
@@ -1,7 +1,5 @@
 ---
 title: Session Cookie
-redirect_from:
-  - /docs/examples/session_cookie.html
 ---
 
 # Overview

--- a/packages/@okta/vuepress-site/use_cases/events-api-migration/index.md
+++ b/packages/@okta/vuepress-site/use_cases/events-api-migration/index.md
@@ -1,7 +1,6 @@
 ---
 title: Events API Migration
 excerpt: How to migrate from the Events API to its System Log API replacement.
-redirect_from: /use_cases/events-api-deprecation/
 ---
 
 # Events API Migration

--- a/packages/@okta/vuepress-site/use_cases/inline_hooks/token_hook/token_hook/index.md
+++ b/packages/@okta/vuepress-site/use_cases/inline_hooks/token_hook/token_hook/index.md
@@ -1,8 +1,6 @@
 ---
 title: Token Inline Hook
 excerpt: Customize tokens returned by the Okta API Access Management process flow.
-redirect_from:
-  - /use_cases/inline_hooks/api_am_hook/api_am_hook
 ---
 
 # Token Inline Hook
@@ -307,15 +305,15 @@ You then need to associate the registered inline hook with a Custom Authorizatio
 
 1. Go to **API > Authorization Servers**.
 
-1. Select a Custom Authorization Server from the list.
+2. Select a Custom Authorization Server from the list.
 
-1. Select the Access Policies tab and and select a policy to use with the hook. In most cases, just pick the Default Policy.
+3. Select the Access Policies tab and and select a policy to use with the hook. In most cases, just pick the Default Policy.
 
-1. One of the policy's rules needs to trigger the inline hook. Click the pencil icon for a rule to edit it. If you only have one rule, edit the Default Policy Rule.
+4. One of the policy's rules needs to trigger the inline hook. Click the pencil icon for a rule to edit it. If you only have one rule, edit the Default Policy Rule.
 
-1. Click the **Use this inline hook** dropdown menu. Any inline hooks you have registered will be listed. Select the hook you would like to use.
+5. Click the **Use this inline hook** dropdown menu. Any inline hooks you have registered will be listed. Select the hook you would like to use.
 
-1. Click **Update Rule**.
+6. Click **Update Rule**.
 
 > Note: Only one inline hook can be associated with each rule.
 

--- a/packages/@okta/vuepress-site/use_cases/inline_hooks/token_hook/token_hook/index.md
+++ b/packages/@okta/vuepress-site/use_cases/inline_hooks/token_hook/token_hook/index.md
@@ -305,15 +305,15 @@ You then need to associate the registered inline hook with a Custom Authorizatio
 
 1. Go to **API > Authorization Servers**.
 
-2. Select a Custom Authorization Server from the list.
+1. Select a Custom Authorization Server from the list.
 
-3. Select the Access Policies tab and and select a policy to use with the hook. In most cases, just pick the Default Policy.
+1. Select the Access Policies tab and and select a policy to use with the hook. In most cases, just pick the Default Policy.
 
-4. One of the policy's rules needs to trigger the inline hook. Click the pencil icon for a rule to edit it. If you only have one rule, edit the Default Policy Rule.
+1. One of the policy's rules needs to trigger the inline hook. Click the pencil icon for a rule to edit it. If you only have one rule, edit the Default Policy Rule.
 
-5. Click the **Use this inline hook** dropdown menu. Any inline hooks you have registered will be listed. Select the hook you would like to use.
+1. Click the **Use this inline hook** dropdown menu. Any inline hooks you have registered will be listed. Select the hook you would like to use.
 
-6. Click **Update Rule**.
+1. Click **Update Rule**.
 
 > Note: Only one inline hook can be associated with each rule.
 

--- a/packages/@okta/vuepress-site/use_cases/integrate_with_okta/index.md
+++ b/packages/@okta/vuepress-site/use_cases/integrate_with_okta/index.md
@@ -1,9 +1,4 @@
 ---
-redirect_from:
-  - /docs/api/getting_started/oan_guidance
-  - /docs/guides/oan_guidance
-  - /use_cases/sso_and_provisioning/draft
-redirect_to: 'https://www.okta.com/integrate/'
 hidden: true
 ---
 

--- a/packages/@okta/vuepress-site/use_cases/mfa/index.md
+++ b/packages/@okta/vuepress-site/use_cases/mfa/index.md
@@ -3,7 +3,6 @@ title: Multi-Factor Authentication
 excerpt: >-
   Using Okta's Multi-Factor Authentication API to add MFA to an existing
   application.
-redirect_from: /docs/guides/add_mfa.html
 ---
 
 # Introduction


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Removing the old `redirect_to` and `redirect_from` frontmatter, since that was a Jekyll-only functionality. Also changed the numbering on a few pages.
- **Is this PR related to a Monolith release?** Nope.

### Resolves:

* Some confusion about how we do redirects now, hopefully.
