### PR TITLE
Correcting registration inline hook DENY example

### DIFF
--- a/packages/@okta/vuepress-site/use_cases/inline_hooks/registration_hook/registration_hook/index.md
+++ b/packages/@okta/vuepress-site/use_cases/inline_hooks/registration_hook/registration_hook/index.md
@@ -144,7 +144,7 @@ For `com.okta.action.update` commands, `value` should be an object containing th
       {
          "type":"com.okta.action.update",
          "value":{
-            "action":"DENY",
+            "registration":"DENY",
          }
       }
    ]
@@ -207,7 +207,7 @@ If you do not return any value for that `errorCauses` object, but deny the user'
       {
          "type":"com.okta.action.update",
          "value":{
-            "action":"DENY"
+            "registration":"DENY"
          }
       }
    ]


### PR DESCRIPTION
`action` should have been `registration` (it's even listed in the above section)