### PR TITLE
Update limit for listing group members endpoint

### DIFF
--- a/packages/@okta/vuepress-site/docs/api/resources/groups/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/groups/index.md
@@ -900,7 +900,7 @@ Enumerates all [users](/docs/api/resources/users/#user-model) that are a member 
 | Parameter | Description                                                | ParamType | DataType | Required | Default |
 | --------- | ---------------------------------------------------------- | --------- | -------- | -------- | ------- |
 | id        | `id` of the group                                          | URL       | String   | TRUE     |         |
-| limit     | Specifies the number of user results in a page             | Query     | Number   | FALSE    | 10000   |
+| limit     | Specifies the number of user results in a page             | Query     | Number   | FALSE    | 1000    |
 | after     | Specifies the pagination cursor for the next page of users | Query     | String   | FALSE    |         |
 
 > The `after` cursor should treated as an opaque value and obtained through the next link relation. See [Pagination](/docs/api/getting_started/design_principles#pagination)


### PR DESCRIPTION
## Description:
- **What's changed?** The maximum limit returned by  /api/v1/groups/${groupId}/users is 1 000, not 10 000. This PR fixes the documentation to mention the correct number.
