### PR TITLE
Update sign users out of Okta instructions in .NET guides

### DIFF
--- a/packages/@okta/vuepress-site/guides/sign-users-out/sign-out-of-okta/aspnet/remotesignout.md
+++ b/packages/@okta/vuepress-site/guides/sign-users-out/sign-out-of-okta/aspnet/remotesignout.md
@@ -25,7 +25,7 @@ using Microsoft.Owin.Security.Cookies;
 using Okta.AspNet;
 ```
 
-After you sign users out of your app and out of Okta, you can also redirect users to a specific location. You need to whitelist the post sign-out URL in your Okta Application settings.
+After you sign users out of your app and out of Okta, you have to redirect users to a specific location in your application. You need to whitelist the post sign-out URL in your Okta Application settings.
 
 Open the Okta Developer Console:
 

--- a/packages/@okta/vuepress-site/guides/sign-users-out/sign-out-of-okta/aspnetcore/remotesignout.md
+++ b/packages/@okta/vuepress-site/guides/sign-users-out/sign-out-of-okta/aspnetcore/remotesignout.md
@@ -34,46 +34,19 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Okta.AspNetCore;
 ```
 
-After you sign users out of your app and out of Okta, you can also redirect users to a specific location. You need to whitelist the post sign-out URL in your Okta Application settings.
-
-Open the Okta Developer Console:
-
-<a href="https://login.okta.com/" target="_blank" class="Button--blue">Go to Console</a>
-
-1. Select **Applications**, and then pick your application.
-
-2. Select **General** and click **Edit**.
-
-3. Add the post sign-out URL in the  **Logout redirect URI** field, for example, `http://localhost:3000/account/postsignout`.
-
-4. Click **Save**.
-
-Then, you have to modify the Okta configuration in your application to also include the **Logout redirect URI**.
-Open the `Startup.cs` file and update the `ConfigureServices` method to include the `PostLogoutRedirectUri` in the Okta configuration:
+After you sign users out of your app and out of Okta, you can also redirect users to a specific location. Modify your `SignOut` action to include the action what you want to redirect to, for example, `Home`:
 
 ```csharp
-public class Startup
+[HttpPost]
+public IActionResult SignOut()
 {
-    public void ConfigureServices(IServiceCollection services)
-    {
-        //...
-        services.AddOktaMvc(new OktaMvcOptions()
+    return new SignOutResult(
+        new[]
         {
-            //...
-            PostLogoutRedirectUri = "http://localhost:3000/Account/PostSignOut",
-        }
-    }
+                OktaDefaults.MvcAuthenticationScheme,
+                CookieAuthenticationDefaults.AuthenticationScheme,
+        },
+        new AuthenticationProperties { RedirectUri = "/Home/" });
 }
+
 ```
-
-Finally, add the desired logic for the post sign-out callback.
-Open the controller where you handle the sign-out process and add a `PostSignOut` method:
-
-```csharp
-public IActionResult PostSignOut()
-{
-    // Return to the home page after sign out
-    return RedirectToAction("Index", "Home");
-}
-```
-

--- a/packages/@okta/vuepress-site/guides/sign-users-out/sign-out-of-okta/aspnetcore/remotesignout.md
+++ b/packages/@okta/vuepress-site/guides/sign-users-out/sign-out-of-okta/aspnetcore/remotesignout.md
@@ -34,7 +34,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Okta.AspNetCore;
 ```
 
-After you sign users out of your app and out of Okta, you can also redirect users to a specific location. Modify your `SignOut` action to include the action what you want to redirect to, for example, `Home`:
+After you sign users out of your app and out of Okta, you can also redirect users to a specific location. Modify your `SignOut` action to include the action that you want to redirect to, for example, `Home`:
 
 ```csharp
 [HttpPost]


### PR DESCRIPTION
## Description:
- **What's changed?** 
* Remove unnecessary instructions for sign users out of Okta in ASP.NET Core guide.
* Minor wording change in instructions for sign users out of Okta in ASP.NET guide.

- **Is this PR related to a Monolith release?**
No.

### Resolves:

* [OKTA-226308](https://oktainc.atlassian.net/browse/OKTA-226308)
