### PR TITLE
OKTA-163567: Clarifies docs for System Log API `q` param with hyphenated tokens

### DIFF
--- a/packages/@okta/vuepress-site/docs/api/resources/system_log/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/system_log/index.md
@@ -681,6 +681,8 @@ The following are some examples of common keyword filtering:
 * Events that mention a specific url: `q=interestingURI.com`
 * Events that mention a specific person: `q=firstName lastName`
 
+> Note: When hyphens are present in an event instance's attribute value they are split and added to the list of matching candidates, in addition to the full hyphenated value. Thus a `q` value of `XOxBw-2JIRnCFd0gG0GjHAAABjY` would match events containing the text `XOxBw`, `2JIRnCFd0gG0GjHAAABjY`, or `XOxBw-2JIRnCFd0gG0GjHAAABjY`.
+
 ###### Datetime Filter
 
 LogEvent objects can be filtered by [`published`](#attributes) attribute value with the following combination of parameters:


### PR DESCRIPTION
## Description:

- **What's changed?** Clarifies docs for System Log `q` param with hyphenated tokens
- **Is this PR related to a Monolith release?** No

![image](https://user-images.githubusercontent.com/25536705/58438705-2a0a0a80-809e-11e9-9da0-7beaea12b59a.png)

### Resolves:

* [OKTA-163567](https://oktainc.atlassian.net/browse/OKTA-163567)
