### PR TITLE
OKTA-215185: Updates `outcome`-object values in System Log API docs.

### DIFF
--- a/packages/@okta/vuepress-site/docs/api/resources/system_log/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/system_log/index.md
@@ -127,7 +127,7 @@ Each LogEvent object describes a single logged action or "event" performed by a 
      "id": String, Optional
 },
 "outcome": { Object, Optional
-     "result": String, one of: SUCCESS, FAILURE, SKIPPED, UNKNOWN, Required
+     "result": String, one of: SUCCESS, FAILURE, SKIPPED, ALLOW, DENY, CHALLENGE, UNKNOWN, Required
      "reason": String, Optional
 },
 "target": [ List of Objects of the form:
@@ -318,7 +318,7 @@ Describes the result of an action and the reason for that result.
 
 | Property   | Description                                                            | DataType        | Nullable | Default | MinLength | MaxLength |
 | ---------- | ---------------------------------------------------------------------- | --------------- | -------- | ------- | --------- | --------- |
-| result     | Result of the action: `SUCCESS`, `FAILURE`, `SKIPPED`, `UNKNOWN`       | String          | FALSE    |         |           |           |
+| result     | Result of the action: `SUCCESS`, `FAILURE`, `SKIPPED`, `ALLOW`, `DENY`, `CHALLENGE`, `UNKNOWN`       | String          | FALSE    |         |           |           |
 | reason     | Reason for the result, for example `INVALID_CREDENTIALS`               | String          | TRUE     |         | 1         | 255       |
 
 ### Transaction Object


### PR DESCRIPTION
## Description:

- **What's changed?** Updates `outcome`-object values in System Log API docs.
- **Is this PR related to a Monolith release?** No.

![image](https://user-images.githubusercontent.com/25536705/58438470-0b574400-809d-11e9-8901-f05236698061.png)

![image](https://user-images.githubusercontent.com/25536705/58438487-2033d780-809d-11e9-95d0-82d834a433c3.png)


### Resolves:

* [OKTA-215185](https://oktainc.atlassian.net/browse/OKTA-215185)
