### PR TITLE
Fixes High Capacity SKU discrepancy for /api/v1/users/{idOrLogin} GET

### DIFF
--- a/packages/@okta/vuepress-site/docs/api/getting_started/rate-limits/index.md
+++ b/packages/@okta/vuepress-site/docs/api/getting_started/rate-limits/index.md
@@ -118,6 +118,7 @@ The following are the high capacity rate limits per minute that apply across the
 | `/app/{app}/{key}/sso/saml`                                                | 1500      | 3000         |
 | `/api/v1/groups/{id}`                                                      | 1500      | 3000         |
 | `/api/v1/users/{id}`                                                       | 1500      | 3000         |
+| `/api/v1/users/{idOrLogin}` (only `GET`)                                   | 1500      | 5000         |
 | `/api/v1/authn`                                                            | 1500      | 3000         |
 | `/api/plugin/{protocolVersion}/form-creds/{appUserIds}/{formSiteOption}`   | 1500      | 3000         |
 | `/api/v1/authn/factors/{factorIdOrFactorType}/verify`                      | 1500      | 3000         |


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
Added High Capacity rate limits for /api/v1/users/{idOrLogin} GET which was missed out
- **Is this PR related to a Monolith release?** 
No <!-- If so, which one? Remember that PRs intended to go out with a particular release should be targeted at that release branch and NOT at the Master branch -->

### Resolves:

* [OKTA-227433](https://oktainc.atlassian.net/browse/OKTA-227433)
