### PR TITLE
Remove the 'EA' designation from the Email Factor sections of the Fac…

### DIFF
--- a/packages/@okta/vuepress-site/docs/api/resources/factors/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/factors/index.md
@@ -1381,8 +1381,6 @@ curl -v -X POST \
 
 #### Enroll Okta Email Factor
 
-<ApiLifecycle access="ea" />
-
 Enrolls a user with an email factor. An email with an OTP is sent to the primary or secondary (depending on which one is enrolled) email address of the user during enrollment. The factor must be [activated](#activate-email-factor) by following the `activate` link relation to complete the enrollment process. An optional `tokenLifetimeSeconds` can be specified as a query parameter to indicate the lifetime of the OTP. The default lifetime is 300 seconds. `tokenLifetimeSeconds` should be in the range 1 to 86400 inclusive.
 
 ##### Request Example
@@ -1963,8 +1961,6 @@ curl -v -X POST \
 ```
 
 #### Activate Email Factor
-
-<ApiLifecycle access="ea" />
 
 Activates an `email` factor by verifying the OTP.
 
@@ -2692,8 +2688,6 @@ curl -v -X POST \
 ```
 
 ### Verify Email Factor
-
-<ApiLifecycle access="ea" />
 
 <span class="api-uri-template api-uri-post"><span class="api-label">POST</span> /api/v1/users/${userId}/factors/${factorId}/verify</span>
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:

Remove the "Early Access" designation from the sections of the Factors API documentation that pertain to Email factor.
This PR is related to Monolith release 2019.06.0, and is based off the release-2019-06.0 branch

### Resolves:

* [OKTA-227491](https://oktainc.atlassian.net/browse/OKTA-227491)
