### PR TITLE
Allow app group deletion

### DIFF
--- a/packages/@okta/vuepress-site/docs/api/resources/groups/index.md
+++ b/packages/@okta/vuepress-site/docs/api/resources/groups/index.md
@@ -849,10 +849,7 @@ curl -v -X PUT \
 
 <ApiOperation method="delete" url="/api/v1/groups/${groupId}" />
 
-Removes a group with `OKTA_GROUP` type from your organization.
-
-> Only groups with `OKTA_GROUP` type can be removed.<br>
-> Application imports are responsible for removing groups with `APP_GROUP` type such as Active Directory groups.
+Removes a group with `OKTA_GROUP` or `APP_GROUP` type from your organization.
 
 ##### Request Parameters
 


### PR DESCRIPTION
## Description:
- **What's changed?** We now allow app group deletion, so this change removes the limitation that 'only groups with OKTA_GROUP type can be removed' from the remove groups documentation.
- **Is this PR related to a Monolith release?** Yes, release 2019.06.0.

Note: this is being DDRR'd, so if it doesn't go into the release, we won't merge this doc change.

### Resolves:

* [OKTA-214275](https://oktainc.atlassian.net/browse/OKTA-214275)
