### PR TITLE
Guides appendchild fix

### DIFF
--- a/packages/@okta/vuepress-theme-default/layouts/Guides.vue
+++ b/packages/@okta/vuepress-theme-default/layouts/Guides.vue
@@ -10,7 +10,9 @@
           :guideName="guideName"
           :framework="framework"
         />
-        <GuidesOverview v-else :featured="featured"/>
+        <div v-else>
+          <GuidesOverview :featured="featured"/>
+        </div>
       </div>
       <!-- END Page Content -->
     </section>


### PR DESCRIPTION
## Description:
- **What's changed?** 
  - Guides without frameworks had JS console error re:appendChild if navigated to directly.  
- **Is this PR related to a Monolith release?** 
  - No
