### PR TITLE
Revert "Adding index dot html to end of guide from url"

### DIFF
--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -751,7 +751,7 @@ redirects:
     to: /docs/reference/api/trusted-origins/
   - from: /docs/api/resources/zones.html
     to: /docs/reference/api/zones/
-  - from: /guides/add-saml-idp/-/configure-oidc-client/index.html
+  - from: /guides/add-saml-idp/-/configure-oidc-client/
     to: /docs/guides/add-saml-idp/-/configure-oidc-client/
   - from: /guides/add-saml-idp/-/configure-saml-idp/
     to: /docs/guides/add-saml-idp/-/configure-saml-idp/


### PR DESCRIPTION
Reverts okta/okta-developer-docs#447

That PR didn't work, and I'd rather not confuse the issue by having a non-existent URL.