### PR TITLE
fix(links): Update guides w/pre-migration links

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app/next-steps/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app/next-steps/index.md
@@ -5,7 +5,7 @@ You should now understand how to sign users in to your mobile applications using
 
 In this guide you signed users in to your app by opening a browser. To learn how to customize the sign-in page displayed in the browser, see [Customize the Hosted Sign-in Page](/docs/guides/custom-hosted-signin/).
 
-To learn how to protect the API endpoints that your mobile app calls, see [Protect Your API Endpoints](/guides/protect-your-api/).
+To learn how to protect the API endpoints that your mobile app calls, see [Protect Your API Endpoints](/docs/guides/protect-your-api/).
 
 ## Sample Applications
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app/use-access-token/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app/use-access-token/index.md
@@ -9,7 +9,7 @@ In your mobile app, make sure that you place the access token in the HTTP `Autho
 Authorization: Bearer {token}
 ```
 
-Your API must check for valid tokens in incoming requests. To learn how to protect your API endpoints and require token authentication, see [Protect Your API Endpoints](/guides/protect-your-api/).
+Your API must check for valid tokens in incoming requests. To learn how to protect your API endpoints and require token authentication, see [Protect Your API Endpoints](/docs/guides/protect-your-api/).
 
 <StackSelector snippet="usetoken"/>
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/redirect-to-sign-in/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/redirect-to-sign-in/index.md
@@ -8,7 +8,7 @@ To sign a user in, your application must redirect the browser to the Okta-hosted
 
 The user is redirected to the hosted sign-in page where they authenticate. After successful authentication, the browser is redirected back to your application along with information about the user.
 
-> Note: To customize the hosted sign-in page, see [Customize the Hosted Sign-in Page](/guides/custom-hosted-signin/).
+> Note: To customize the hosted sign-in page, see [Customize the Hosted Sign-in Page](/docs/guides/custom-hosted-signin/).
 
 You can also define protected routes or areas of your application that will always require authentication.
 


### PR DESCRIPTION


## Description:
- **What's changed?** 
  - Updates guides content that had links in the pre-great-migration style (no /docs/)
- **Is this PR related to a Monolith release?** 
  - No
