### PR TITLE
Fix Header Levels

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
@@ -3834,7 +3834,7 @@ curl -v -X POST \
 
 > If you omit `passCode` in the request a new OTP will be sent to the device, otherwise the request will attempt to verify the `passCode`
 
-#### Response Parameters for Verify SMS Factor
+##### Response Parameters for Verify SMS Factor
 
 
 [Authentication Transaction Object](#authentication-transaction-model) with the current [state](#transaction-state) for the authentication transaction.
@@ -4750,7 +4750,7 @@ curl -v -X POST \
 
 > If you omit `passCode` in the request a new OTP will be sent to the device, otherwise the request will attempt to verify the `passCode`
 
-#### Response Parameters for Verify Call Factor
+##### Response Parameters for Verify Call Factor
 
 
 [Authentication Transaction Object](#authentication-transaction-model) with the current [state](#transaction-state) for the authentication transaction.


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- "Response Parameters for Verify SMS Factor" and "Response Parameters for Verify Call Factor" had the wrong header level, which led to them being shown in the sidebar incorrectly.

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
