### PR TITLE
Release Notes Entry for 2019.07.2 Part 1

### DIFF
--- a/packages/@okta/vuepress-site/docs/release-notes/2019-07-2/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2019-07-2/index.md
@@ -1,0 +1,14 @@
+---
+title: Okta API Products Release Notes
+---
+
+## 2019.07.2
+
+| Change                                                                                             | Expected in Preview Orgs |
+|----------------------------------------------------------------------------------------------------|--------------------------|
+| [Deleting App Groups](#deleting-app-groups) | July 31, 2019             |
+
+### Deleting App Groups
+
+The `DELETE /groups/${groupId}` [endpoint](/docs/reference/api/groups/#remove-group) now supports deleting app groups, in addition to Okta groups. Note, however, that groups configured for group push cannot be deleted. <!-- OKTA-214275 -->
+


### PR DESCRIPTION
## Description:
- **What's changed?** Adding release notes entry, with beginning of content for 2019.07.2. More items might need to be added next week.
- **Is this PR related to a Monolith release?** Yes, 2019.07.2.
