### PR TITLE
Update docs to allow app group deletion

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
@@ -849,10 +849,9 @@ curl -v -X PUT \
 
 <ApiOperation method="delete" url="/api/v1/groups/${groupId}" />
 
-Removes a group with `OKTA_GROUP` type from your organization.
+Removes a group with `OKTA_GROUP` or `APP_GROUP` type from your organization.
 
-> Only groups with `OKTA_GROUP` type can be removed.<br>
-> Application imports are responsible for removing groups with `APP_GROUP` type such as Active Directory groups.
+> Groups with type `APP_GROUP` cannot be removed if they are used in a group push mapping.
 
 ##### Request Parameters
 


### PR DESCRIPTION
## Description:
- **What's changed?** We now allow app group deletion for app groups not used in group push mappings, so this change removes the limitation specified in the docs.
- **Is this PR related to a Monolith release?** Yes, release 2019.07.2

### Resolves:

* [OKTA-214275](https://oktainc.atlassian.net/browse/OKTA-214275)
