### PR TITLE
Add Custom HOTP factor content to the Factors and AuthN API

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
@@ -1893,6 +1893,7 @@ Enrolls a user with a [factor](/docs/reference/api/factors/#supported-factors-fo
 * [Enroll YubiKey Factor](#enroll-yubikey-factor)
 * [Enroll Duo Factor](#enroll-duo-factor)
 * [Enroll U2F Factor](#enroll-u2f-factor)
+* [Enroll Custom HOTP Factor](#enroll-custom-hotp-factor)
 
 > This operation is only available for users that have not previously enrolled a factor and have transitioned to the `MFA_ENROLL` [state](#transaction-state).
 
@@ -2907,6 +2908,9 @@ curl -v -X POST \
   }
 }
 ```
+
+#### Enroll Custom HOTP Factor
+Enrollment via the Authentication API is currently not supported for Custom HOTP Factor.  Please refer to the Factors API documentation [here](/docs/reference/api/factors/#enroll-custom-hotp-factor) if you would like to enroll users for this type of factor.
 
 ### Activate Factor
 
@@ -3989,7 +3993,7 @@ curl -v -X POST \
 
 <ApiOperation method="post" url="/api/v1/authn/factors/${factorId}/verify" />
 
-Verifies an OTP for a `token:software:totp` factor.
+Verifies an OTP for a `token:software:totp` or `token:hotp` factor.
 
 > This API implements [the TOTP standard](https://tools.ietf.org/html/rfc6238), which is used by apps like Okta Verify and Google Authenticator.
 

--- a/packages/@okta/vuepress-site/docs/reference/api/factors/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/factors/index.md
@@ -468,6 +468,7 @@ Enrolls a user with a supported [factor](#list-factors-to-enroll)
 - [Enroll YubiKey Factor](#enroll-yubikey-factor)
 - [Enroll Okta Email Factor](#enroll-okta-email-factor)
 - [Enroll U2F Factor](#enroll-u2f-factor)
+- [Enroll Custom HOTP Factor](#enroll-custom-hotp-factor)
 
 ##### Request Parameters
 
@@ -1541,6 +1542,70 @@ curl -v -X POST \
       "timeoutSeconds":20
     }
   }
+}
+```
+
+#### Enroll Custom HOTP Factor
+
+Enrolls a user for a Custom HMAC-based One-time Password (HOTP) factor. The enrollment process involves passing a factor profile Id and shared secret for a particular token.  
+
+> Note: Currently only auto-activation is supported for Custom HOTP Factor. 
+
+##### Enroll and Auto-Activate Custom HOTP Factor
+
+```bash
+curl -v -X POST \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+-d '{
+  "factorType": "token:hotp",
+  "provider": "CUSTOM",
+  "factorProfileId": "fpr20l2mDyaUGWGCa0g4"
+  "profile": {
+      "sharedSecret": "484f97be3213b117e3a20438e291540a"
+  }
+}' "https://{yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors?activate=true"
+```
+
+##### Enroll Custom HOTP Factor Response Example
+
+```json
+{
+    "id": "chf20l33Ks8U2Zjba0g4",
+    "factorType": "token:hotp",
+    "provider": "CUSTOM",
+    "vendorName": "Entrust Datacard",
+    "status": "ACTIVE",
+    "created": "2019-07-22T23:22:36.000Z",
+    "lastUpdated": "2019-07-22T23:22:36.000Z",
+    "_links": {
+        "self": {
+            "href": "http://rain.okta1.com:1802/api/v1/users/00utf43LCCmTJVcsK0g3/factors/chf20l33Ks8U2Zjba0g4",
+            "hints": {
+                "allow": [
+                    "GET",
+                    "DELETE"
+                ]
+            }
+        },
+        "verify": {
+            "href": "http://rain.okta1.com:1802/api/v1/users/00utf43LCCmTJVcsK0g3/factors/chf20l33Ks8U2Zjba0g4/verify",
+            "hints": {
+                "allow": [
+                    "POST"
+                ]
+            }
+        },
+        "user": {
+            "href": "http://rain.okta1.com:1802/api/v1/users/00utf43LCCmTJVcsK0g3",
+            "hints": {
+                "allow": [
+                    "GET"
+                ]
+            }
+        }
+    }
 }
 ```
 
@@ -2845,7 +2910,7 @@ curl -v -X POST \
 
 <ApiOperation method="post" url="/api/v1/users/${userId}/factors/${factorId}/verify" />
 
-Verifies an OTP for a `token:software:totp` factor
+Verifies an OTP for a `token:software:totp` or `token:hotp` factor
 
 #### Request Parameters
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?**
1. Under the verify section in the AuthN/Factors API, just add a `token:hotp` to indicate that factor type is another factor that can be verified by simply passing a `passCode`.
2.  Add top-level index links to Enroll Custom HOTP in AuthN/Factors API
3.  In AuthN API Enrollment - state that this is not supported and link to the Factors API
4.  In Factors API Enrollment - show sample request/response for how to Enroll in Custom HOTP

For employees only i've sent a Box invite showing what the updated doc pages look like.  .  

- **Is this PR related to a Monolith release?** The changes should be in by the 2019.08.0 CF (this is major release for August)

### Resolves:

* [OKTA-240244](https://oktainc.atlassian.net/browse/OKTA-240244)
