### PR TITLE
Inline Hooks Management API: channel object properties not readOnly

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/inline-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/inline-hooks/index.md
@@ -705,11 +705,11 @@ curl -v -X POST \
 
 ### Channel Object
 
-| Property       | Description                                                                                         | DataType                            | Nullable   | Unique   | ReadOnly   | Validation                                        |
-| -------------- | --------------------------------------------------------------------------------------------------- | ----------------------------------- | ---------- | -------- | ---------- | ------------------------------------------------- |
-| type           | The channel type. Currently the only supported type is `HTTP`.   | channelType                      | FALSE      | FALSE    | TRUE       | Must match a valid channel type.            |
-| version        | Version of the channel. The currently-supported version is "1.0.0".                                 | String                              | FALSE      | FALSE    | TRUE       | Must match a valid version number.                |
-| config | Properties of the communications channel used to contact your external service.                     | [Channel Config object](#config-object)   | FALSE      | FALSE    | FALSE      | Validation is determined by the specific channel. |
+| Property | Description                                                                     | DataType                                | Nullable | Unique | Validation                                        |
+|----------|---------------------------------------------------------------------------------|-----------------------------------------|----------|--------|---------------------------------------------------|
+| type     | The channel type. Currently the only supported type is `HTTP`.                  | channelType                             | FALSE    | FALSE  | TRUE|Must match a valid channel type.             |
+| version  | Version of the channel. The currently-supported version is "1.0.0".             | String                                  | FALSE    | FALSE  | Must match a valid version number.                |
+| config   | Properties of the communications channel used to contact your external service. | [Channel Config object](#config-object) | FALSE    | FALSE  | Validation is determined by the specific channel. |
 
 
 ### Config Object


### PR DESCRIPTION
## Description:
- **What's changed?** Removed the 'readOnly' column from the description of the channel object. Previously, the properties 'type' and 'version' were marked 'readOnly', but this was incorrect. Since nothing is readOnly in this object, removed the readOnly column.
- **Is this PR related to a Monolith release?** No.

### Resolves:

* [OKTA-241061](https://oktainc.atlassian.net/browse/241061)
