### PR TITLE
Updating index.md to refer to system API

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/event-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/event-hooks/index.md
@@ -16,6 +16,9 @@ For general information on event hooks and how to create and use them, see [Even
 
 Explore the Event Hooks API: [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/b02d234a2af183981254)
 
+> **Important:** In the future the Events API will not be tracking new event types added to the System Log API. For this reason we highly recommend migrating to the System Log API.
+<br>
+
 ## Event Hook Operations
 
 ### Create Event Hook


### PR DESCRIPTION
I've added the warning from the event types page to the event hooks page. I was originally looking to use the event hooks to capture information using a webhook pattern. The changes to event types and system log API seem important enough to call out at the beginning of the Event Hooks documentation not a level in when looking at the event types

<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
- **Is this PR related to a Monolith release?** <!-- If so, which one? Remember that PRs intended to go out with a particular release should be targeted at that release branch and NOT at the Master branch -->

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
