### PR TITLE
Inline Hooks troubleshooting via System Log

### DIFF
--- a/packages/@okta/vuepress-site/docs/concepts/inline-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/inline-hooks/index.md
@@ -157,3 +157,9 @@ The total number of Inline Hooks that you can create in an Okta org is limited t
 
 For more information on implementing Inline Hooks, see the documentation for specific Inline Hook types linked to in [Currently-Supported Types](#currently-supported-types).
 
+## Troubleshooting
+
+The [Okta System Log](/docs/reference/api/system-log/) captures events related to Inline Hook setup and execution, which you can use to troubleshoot your implementation. To see the list of relevant event types, query the Event Types catalog with the query parameter `inline_hook`:
+
+<https://developer.okta.com/docs/reference/api/event-types/?q=inline_hook>
+

--- a/packages/@okta/vuepress-site/docs/concepts/inline-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/inline-hooks/index.md
@@ -159,7 +159,7 @@ For more information on implementing Inline Hooks, see the documentation for spe
 
 ## Troubleshooting
 
-The [Okta System Log](/docs/reference/api/system-log/) captures events related to Inline Hook setup and execution, which you can use to troubleshoot your implementation. To see the list of relevant event types, query the Event Types catalog with the query parameter `inline_hook`:
+The [Okta System Log](/docs/reference/api/system-log/) captures events related to Inline Hook setup and execution, which you can use to troubleshoot your implementation. To see descriptions of the relevant event types, query the Event Types catalog with the query parameter `inline_hook`:
 
 <https://developer.okta.com/docs/reference/api/event-types/?q=inline_hook>
 


### PR DESCRIPTION
## Description:
- **What's changed?** Adding troubleshooting section to the Inline Hooks overview, with a link to relevant system log events.
- **Is this PR related to a Monolith release?** No.
### Resolves:

* [OKTA-238414](https://oktainc.atlassian.net/browse/OKTA-238414)
