### PR TITLE
Adds python code pages

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/nav/codePages.js
+++ b/packages/@okta/vuepress-site/.vuepress/nav/codePages.js
@@ -24,6 +24,7 @@ module.exports = [
       { title: 'Java', link: '/code/java/', activeCheck: '/code/java/'},
       { title: 'Node.js', link: '/code/nodejs/', activeCheck: '/code/nodejs/'},
       { title: 'PHP', link: '/code/php/', activeCheck: '/code/php/'},
+      { title: 'Python', link: '/code/python/', activeCheck: '/code/python/'},
       { title: 'REST', link: '/code/rest/', activeCheck: '/code/rest/'},
     ]
   }

--- a/packages/@okta/vuepress-site/code/python/index.md
+++ b/packages/@okta/vuepress-site/code/python/index.md
@@ -1,16 +1,40 @@
 ---
-title: Add Okta authentication to your Python app
+title: Add Identity Management to Your PHP App
 language: Python
-integration: server
+integration: back-end
 component: Code
 ---
 
-# Okta + Python
+# <i class='icon-48 docsPage code-python'></i> Add Identity Management to Your Python App
 
-Okta can support your Python application via our Authentication API or our Management APIs.
+## Get Started with Python + Okta
 
-At this time we do not support official API client libraries (SDKs) for Python. You may fork our [legacy Python SDK](https://github.com/okta/okta-sdk-python) or join the conversation on [this thread](https://devforum.okta.com/t/python-support-feedback/1778) and let us know how you'd like to use Okta from Python applications.
+New to Okta? Our quickstart will walk you through adding user authentication to your Python app in minutes.
 
-## Guides
+<ul class='language-ctas'>
+	<li>
+		<a href='https://developer.okta.com/signup/' class='Button--red' data-proofer-ignore>
+			<span>Create Free Account</span>
+		</a>
+	</li>
+</ul>
 
-<p><a href='pysaml2'>Using PySAML2 to add Okta support (via SAML)</a></p>
+## Python Samples
+
+<ul class="language-libraries">
+	<li>
+		<i class='fa fa-github'></i>
+		<a href="https://github.com/okta/samples-python-flask">
+			<span>Samples for Python + Flask</span>
+		</a>
+	</li>
+</ul>
+
+## Recommended Guides
+
+
+- [Implement the Authorization Code Flow](/docs/guides/implement-auth-code/)
+- [Social Login](/docs/concepts/social-login/)
+- [Validate access tokens](/docs/guides/validate-access-tokens)
+- [Validate ID tokens](/docs/guides/validate-id-tokens)
+

--- a/packages/@okta/vuepress-site/code/python/index.md
+++ b/packages/@okta/vuepress-site/code/python/index.md
@@ -1,5 +1,5 @@
 ---
-title: Add Identity Management to Your PHP App
+title: Add Identity Management to Your Python App
 language: Python
 integration: back-end
 component: Code

--- a/packages/@okta/vuepress-site/code/python/index.md
+++ b/packages/@okta/vuepress-site/code/python/index.md
@@ -9,8 +9,6 @@ component: Code
 
 ## Get Started with Python + Okta
 
-New to Okta? Our quickstart will walk you through adding user authentication to your Python app in minutes.
-
 <ul class='language-ctas'>
 	<li>
 		<a href='https://developer.okta.com/signup/' class='Button--red' data-proofer-ignore>

--- a/packages/@okta/vuepress-site/docs/index.md
+++ b/packages/@okta/vuepress-site/docs/index.md
@@ -32,6 +32,9 @@ languages:
     - name: Go
       link: /code/go/
       icon: code-go-32
+    - name: Python
+      link: /code/python/
+      icon: code-python-32
     - name: java
       link: /code/java/
       icon: code-java-32

--- a/packages/@okta/vuepress-theme-default/assets/css/okta/pages/docsIndex.scss
+++ b/packages/@okta/vuepress-theme-default/assets/css/okta/pages/docsIndex.scss
@@ -11,7 +11,7 @@
   }
 
   .docs-languages {
-    max-width: 860px;
+    max-width: 1024px;
     margin: 40px auto 0;
     text-align: center;
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** 
This PR adds back in the python code page which links out to the samples repo.

- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-235153](https://oktainc.atlassian.net/browse/OKTA-235153)

Updates to the css needed to allow this to show correctly
<img width="1171" alt="Screen Shot 2019-08-12 at 10 55 06 AM" src="https://user-images.githubusercontent.com/1906920/62874881-fb401f80-bcef-11e9-978e-d0f20f28af0f.png">


Code page rendered
<img width="1003" alt="Screen Shot 2019-08-12 at 1 36 16 PM" src="https://user-images.githubusercontent.com/1906920/62885193-33eaf380-bd06-11e9-937a-ae835821c78f.png">


