### PR TITLE
Update the version to use for SIW

### DIFF
--- a/packages/@okta/vuepress-site/code/javascript/okta_sign-in_widget/index.md
+++ b/packages/@okta/vuepress-site/code/javascript/okta_sign-in_widget/index.md
@@ -25,20 +25,10 @@ The first step is to install the Widget. For this, you have two options: linking
 To use the CDN, include this in your HTML:
 
 ```html
-<!-- Latest CDN production Javascript and CSS: 2.16.0 -->
-<script
-  src="https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/2.16.0/js/okta-sign-in.min.js"
-  type="text/javascript"></script>
-<link
-  href="https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/2.16.0/css/okta-sign-in.min.css"
-  type="text/css"
-  rel="stylesheet"/>
+<!-- Latest CDN production Javascript and CSS -->
+<script src="https://global.oktacdn.com/okta-signin-widget/3.1.0/js/okta-sign-in.min.js" type="text/javascript"></script>
 
-<!-- Theme file: Customize or replace this file if you want to override our default styles -->
-<link
-  href="https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/2.16.0/css/okta-theme.css"
-  type="text/css"
-  rel="stylesheet"/>
+<link href="https://global.oktacdn.com/okta-signin-widget/3.1.0/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/> 
 ```
 
 More info, including the latest published version, can be found in the [Widget Documentation](https://github.com/okta/okta-signin-widget#using-the-okta-cdn).


### PR DESCRIPTION
On https://github.com/okta/okta-signin-widget#okta-sign-in-widget we instruct users to use the latest version 3.1.0 whereas this page refers to 2.16.0

This discrepancy is causing issues with customers per an SE: https://okta.slack.com/archives/CD38NQ3SN/p1565818808106200

Definitely need a strong review on this one since I just swapped blocks of code and did not QA any of this.

<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->

On https://github.com/okta/okta-signin-widget#okta-sign-in-widget we instruct users to use the latest version 3.1.0 whereas this page refers to 2.16.0

- **Is this PR related to a Monolith release?** <!-- If so, which one? Remember that PRs intended to go out with a particular release should be targeted at that release branch and NOT at the Master branch -->

No

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
