### PR TITLE
OKTA-184533: Adds Logs API note about `published` restrictions.

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
@@ -643,6 +643,8 @@ The following expressions are supported for events with the `filter` query param
 | `target.id eq ":id"`                         | Events published with a specific target id                                     |
 | `actor.id eq ":id"`                          | Events published with a specific actor id                                      |
 
+> Note that SCIM filter expressions cannot use the `published` attribute since it may conflict with the logic of the `since`, `after`, and `until` query params.
+
 See [Filtering](/docs/reference/api-overview/#filtering) for more information about expressions.
 
 The following are some examples of common filter expressions.


### PR DESCRIPTION
## Description:
- **What's changed?** Adds Logs API note about `published` restrictions.
- **Is this PR related to a Monolith release?** No

### Changes

![image](https://user-images.githubusercontent.com/25536705/63701675-5fd0a380-c7f3-11e9-8314-41af9cbc2c59.png)

### Resolves:

* [OKTA-184533](https://oktainc.atlassian.net/browse/OKTA-184533)
