### PR TITLE
Resolves: OKTA-231059 - add network and app condition to enroll policy

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -962,6 +962,9 @@ Specifies either a general application or specific app instance to match on.
 | Parameter | Description                                           | Data Type | Required |
 | ---       | ---                                                   | ---       | ---      |
 | include   | The list of applications or app instances to match on | Array     | Yes      |
+| exclude   | The list of applications to exclude                   | Array     | Yes      |
+
+> **NOTE:** If both include and exclude are empty, then the condition is met for all applications.
 
 #### Application and App Instance Condition Object Example
 
@@ -1192,6 +1195,10 @@ At present the Policy Factor Consent Terms settings are ignored.
 The following conditions may be applied to Multifactor Policy
 
 [People Condition](#people-condition-object)
+
+[Network Condition](#network-condition-object)
+
+[Application and App Instance Condition](#application-and-app-instance-condition-object)
 
 ### Multifactor Rules Action Data
 

--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -964,7 +964,7 @@ Specifies either a general application or specific app instance to match on.
 | include   | The list of applications or app instances to match on | Array     | Yes      |
 | exclude   | The list of applications to exclude                   | Array     | Yes      |
 
-> **NOTE:** If both include and exclude are empty, then the condition is met for all applications.
+> **NOTE:** If both `include` and `exclude` are empty, then the condition is met for all applications.
 
 #### Application and App Instance Condition Object Example
 


### PR DESCRIPTION
## Description:
- **What's changed?**
  - As part of 2019.10.0 release, the App Condition will be available to be used in the MFA Enroll Policy
  - Also the Network condition has been available for use in MFA Enroll Policy for a long time but network condition link was missing
- **Is this PR related to a Monolith release?**
  - 2019.10.0

How doc looks with changes in this PR
![image](https://user-images.githubusercontent.com/33136962/65918875-ce7fbe80-e3a8-11e9-8b8c-cf497a3b25cd.png)


### Resolves:

* [OKTA-231059](https://oktainc.atlassian.net/browse/OKTA-231059)
