### PR TITLE
OIE Policies Reference Documentation

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -392,9 +392,9 @@ The Unknown User Policy determines whether a user who has not been found to matc
 
 | Property    | Type                                                                         | Description                                                                                        |
 |-------------|------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
-| name        | String                                                                       | Human-readable name for the Policy, configurable during creation or updating.                      |
-| id          | String                                                                       | Unique identifier for this Policy (read-only)                                                      |
-| type        | String                                                                       | Type of the policy. For Identifier Match Rule Objects, this needs to be `Okta:UnknownUser`.        |
+| name        | String                                                                       | Human-readable name for the Rule, configurable during creation or updating.                        |
+| id          | String                                                                       | Unique identifier for this Rule (read-only)                                                        |
+| type        | String                                                                       | Type of the Rule. For Identifier Match Rule Objects, this needs to be `Okta:UnknownUser`.          |
 | priority    | Integer                                                                      | Used to determine which rules take precedence.                                                     |
 | conditions  | Array                                                                        | No conditions are supported for this rule type, so this must be an empty array.                    |
 | action      | String                                                                       | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.                         |

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -104,6 +104,8 @@ This API uses the following objects:
 * [Identifier Match Rule Object](#identifier-match-rule-object)
 * [Unknown User Policy Object](#uknown-user-policy-object)
 * [Unknown User Rule Object](#unknown-user-rule-object)
+* [Sign On Policy Object](#sign-on-policy-object)
+* [Sign On Rule Object](#sign-on-rule-object)
 
 <!-- Add one routing and one rule object for each of the OIE policy types-->
 
@@ -434,12 +436,13 @@ One Unknown User Rule Object is created by default.
 | status      | String                                                                                | `ACTIVE`  or  `INACTIVE`.                                                                                                                               |
 | default     | Boolean                                                                               | `true` for the first instance of this rule, which gets created by default.                                                                 |
 
-#### Unkown User Rule Requirement Object
+#### Unknown User Rule Requirement Object
 
 | Property                                   | Type   | Description                                                                                                                                                            |
 |--------------------------------------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `noUserMatch.action`                       | String | `REGISTER` or `DENY` to determine whether unknown users should be allowed to register.                                                                                 |
 | `noUserMatch.registration.defaultUserType` | String | Valid ID of a User Type. Sets the User Type to enroll unknown users as, if you have allowed unknown users to register. Not required if `noUserMatch.action` is `DENY`. |      
+
 ### Unknown User Rule Object Example
 
 ```json
@@ -462,7 +465,7 @@ One Unknown User Rule Object is created by default.
 
 ## Sign-On Policy Object
 
-This object determines which user profile attributes are used to check for matches between the user and existing user profiles. One Identifier Match Policy object is created by default. You cannot create additional Identifier Match Policy objects.
+This object determines which credentials to prompt users for. One Sign On Policy Object is created by default.
 
 | Property | Type    | Description                                                                             |
 |----------|---------|-----------------------------------------------------------------------------------------|
@@ -523,6 +526,64 @@ This object determines which user profile attributes are used to check for match
                     "GET"
                 ]
             }
+        }
+    }
+}
+```
+
+## Sign On Rule Object
+
+One Sign On Rule Object is created by default.
+
+| Property    | Type                                                                | Description                                                                            |
+|-------------|---------------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| name        | String                                                              | Human-readable name for the Policy, configurable during creation or updating.          |
+| id          | String                                                              | Unique identifier for this Policy (read-only)                                          |
+| type        | String                                                              | Type of the policy. For Identifier Match Rule Objects, this needs to be `Okta:SignOn`. |
+| priority    | Integer                                                             | Used to determine which rules take precedence.                                         |
+| conditions  | Array                                                               | No conditions are supported for this rule type, so this must be an empty array.        |
+| action      | String                                                              | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.             |
+| requirement | [Sign On Rule Requirement Object](#sign-on-rule-requirement-object) | Specifies credentials to prompt user for.                                              |
+| status      | String                                                              | `ACTIVE`  or  `INACTIVE`.                                                              |
+| default     | Boolean                                                             | `true` for the first instance of this rule, which gets created by default.             |
+
+#### Sign On Rule Requirement Object
+
+| Property                  | Type   | Description                                                                                                                            |
+|---------------------------|--------|----------------------------------------------------------------------------------------------------------------------------------------|
+| `verificationMethod.type` | String | `CHAIN` or `ANY_FACTOR` to determine whether users should be prompted for a sequence of credentials or allowed to choose one of a set. |
+| chains                    | Array  | Array specifying the chain of factor types to require. Not required if `verificationMethod.type` is `ANY_FACTOR`.                      |      
+
+### Sign On Rule Object Example
+
+```json
+{
+	"name": "Password THEN Email",
+    "type": "Okta:SignOn",
+    "priority": 0,
+    "conditions": [],
+    "action": "ALLOW",
+    "requirement": {
+        "verificationMethod": {
+            "type": "CHAIN",
+            "chains": [
+                {
+                    "criteria": [
+                        {
+                            "factorType": "password"
+                        }
+                    ],
+                    "next": [
+                        {
+                            "criteria": [
+                                {
+                                    "factorType": "email"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         }
     }
 }

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -1,0 +1,159 @@
+---
+title: Okta Identity Engine Policy API
+---
+
+# Okta Identity Engine Policy API
+
+<ApiLifecycle access="ea" />
+
+Okta Identity Engine adds new Policy objects to the Okta `/policies` API, to control and configure the behavior of the steps of the Okta Identity Engine Pipeline.
+
+During the Limited EA phase, Okta Identity Engine is enabled or disabled for an org as a whole. If Okta Identity Engine is enabled for an org, these new Policies control the pipeline that end users progress through when accessing OpenID Connect apps defined in the org. You cannot mix old Policy and Rule objects with the new Okta Identity Engine objects; old objects will not affect the steps in the new pipeline.
+
+API endpoints for getting or updating Policy and Rules objects function the same way in Okta Identity Engine as they do in the existing Okta `/policies` API. Only the objects used are different, with Okta Identity Engine introducing a set of new Policy and Rule objects to configure the steps that make up the Okta Identity Engine Pipeline. See the [Okta Identity Engine Policy Objects](#okta-identity-enging-policy-objects) section of this document for descriptions of the objects.
+
+## Policies API Operations
+
+The API endpoints support the following operations:
+
+ * [Get Policy](#get-policy)
+ * [List Policies](#list-policies)
+ * [Get Rule](#get-rule)
+ * [List Rules](#list-rules)
+ * [Create Policy](#create-policy)
+ * [Create Rule](#create-rule)
+ * [Update Policy](#update-policy)
+ * [Update Rule](#update-rule)
+ * [Delete Policy](#delete-policy)
+ * [Delete Rule](#delete-rule)
+ 
+### Get Policy
+
+<ApiOperation method="get" url="/policies/${PolicyID}" />
+
+Given a `PolicyID` identifier, returns a [Policy Object](#policy-object).
+
+#### Request Body
+
+| Property   | Type   | Description                          |
+|------------|--------|--------------------------------------|
+| `PolicyID` | String | The unique identifier of the Policy. |
+
+#### Request Query Parameters
+
+None
+
+#### Response Body
+
+A [Policy Object](#policy-object).
+
+#### Usage Example
+
+##### Request
+
+```bash
+curl -v -X GET \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+"https://${yourOktaDomain}/api/v1/policies/${policyId}"
+}'
+```
+##### Response
+
+```json
+{
+    "id": "rs10xzYOyK9ux6v70g4",
+    "name": "Default Policy",
+    "type": "Okta:IdpRouting",
+    "status": "ACTIVE",
+    "default": true,
+    "_links": {
+        "self": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4",
+            "hints": {
+                "allow": [
+                    "GET",
+                    "PUT"
+                ]
+            }
+        },
+        "rules": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4/rules",
+            "hints": {
+                "allow": [
+                    "GET"
+                ]
+            }
+        }
+    }
+}
+```
+
+
+
+## Okta Identity Engine Policy Objects
+
+This API uses the following objects:
+
+* [IdP Routing Policy Object](#idp-routing-policy-object)
+* [IdP Routing Rule Object](#idp-routing-rule-object)
+
+
+
+### IdP Routing Policy Object
+
+Intro.
+
+| Property | Type | Description |
+|----------|------|-------------|
+|          |      |             |
+
+### IdP Routing Object Example
+
+```json
+{
+    "id": "rs10xzYOyK9ux6v70g4",
+    "name": "Default Policy",
+    "type": "Okta:IdpRouting",
+    "status": "ACTIVE",
+    "default": true,
+    "_links": {
+        "self": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4",
+            "hints": {
+                "allow": [
+                    "GET",
+                    "PUT"
+                ]
+            }
+        },
+        "rules": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4/rules",
+            "hints": {
+                "allow": [
+                    "GET"
+                ]
+            }
+        }
+    }
+}
+```
+
+### IdP Routing Rule Object
+
+Intro
+
+| Property | Type | Description |
+|----------|------|-------------|
+|          |      |             |
+|          |      |             |
+|          |      |             |
+ 
+### IdP Routing Rule Object
+
+```json
+{  
+
+}
+```

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -590,3 +590,105 @@ One Sign On Rule Object is created by default.
 }
 ```
 
+## User Profile Policy Object
+
+This object determines which profile attributes to require users to supply prompt users for. One User Profile Policy Object is created by default.
+
+| Property | Type    | Description                                                                         |
+|----------|---------|-------------------------------------------------------------------------------------|
+| id       | String  | Unique identifier for this Policy (read-only).                                      |
+| name     | String  | Human-readable name for the Policy, configurable during creation or updating.       |
+| type     | String  | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:UserProfile`. |
+| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                           |
+| default  | Boolean | `true` for the first instance of this policy, which gets created by default.        |
+
+### User Profile Policy Object Example
+
+```json
+{
+    "id": "rst10y7ftlPBUWJzu0g4",
+    "name": "Default Policy",
+    "type": "Okta:UserProfile",
+    "status": "ACTIVE",
+    "default": true,
+    "_links": {
+        "self": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst10y7ftlPBUWJzu0g4",
+            "hints": {
+                "allow": [
+                    "GET",
+                    "PUT"
+                ]
+            }
+        },
+        "rules": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst10y7ftlPBUWJzu0g4/rules",
+            "hints": {
+                "allow": [
+                    "GET"
+                ]
+            }
+        }
+    }
+}
+
+```
+
+## User Profile Rule Object
+
+One Sign On Rule Object is created by default.
+
+| Property    | Type                                                                | Description                                                                            |
+|-------------|---------------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| name        | String                                                              | Human-readable name for the Policy, configurable during creation or updating.          |
+| id          | String                                                              | Unique identifier for this Policy (read-only)                                          |
+| type        | String                                                              | Type of the policy. For Identifier Match Rule Objects, this needs to be `Okta:SignOn`. |
+| priority    | Integer                                                             | Used to determine which rules take precedence.                                         |
+| conditions  | Array                                                               | No conditions are supported for this rule type, so this must be an empty array.        |
+| action      | String                                                              | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.             |
+| requirement | [Sign On Rule Requirement Object](#sign-on-rule-requirement-object) | Specifies credentials to prompt user for.                                              |
+| status      | String                                                              | `ACTIVE`  or  `INACTIVE`.                                                              |
+| default     | Boolean                                                             | `true` for the first instance of this rule, which gets created by default.             |
+
+#### User Profile Rule Requirement Object
+
+| Property                   | Type   | Description                                                                                                                                                                                                                                     |
+|----------------------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| preRegistrationInlineHooks | String | Optional. The valid ID of an Inline Hook. Sets a Registration Inline Hook to invoke.                                                                                                                                                            |
+| profileAttributes          | Array  | Array specifying the `label` and `name` of each User Profile Attribute that should be collected from the user. `label` is human-readable text that can be displayed to the user in a web form. `name` is the name of a User Profile Attribute.| |   
+
+### User Profile Rule Object Example
+
+```json
+{
+	"name": "New Rule",
+    "type": "Okta:UserProfile",
+    "priority": 1,
+    "action": "ALLOW",
+    "conditions": [],
+    "requirement": {
+        "preRegistrationInlineHooks": [
+            {
+                "inlineHookId": "{{inlineHookId}}"
+            }
+        ],
+        "profileAttributes": [
+            {
+                "label": "First Name",
+                "name": "firstName",
+                "required": true
+            },
+            {
+                "label": "Last Name",
+                "name": "lastName",
+                "required": true
+            },
+            {
+                "label": "Email",
+                "name": "email",
+                "required": true
+            }
+        ]
+    }
+}
+```

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -10,7 +10,7 @@ Okta Identity Engine adds new Policy objects to the Okta `/policies` API, to con
 
 During the Limited EA phase, Okta Identity Engine is enabled or disabled for an org as a whole. If Okta Identity Engine is enabled for an org, these new Policies control the pipeline through which end users progress when accessing OpenID Connect apps. You cannot mix old Policy and Rule objects with new Okta Identity Engine objects; old Policy and Rule objects do not affect the new pipeline.
 
-API endpoints for listing, getting, creating, updating and deleting Policy and Rule objects function the same way in Okta Identity Engine as they do in the existing Okta `/policies` API; only the objects used are different, with Okta Identity Engine introducing a set of new Policy and Rule objects. See the [Okta Identity Engine Policy Objects](#okta-identity-enging-policy-objects) section of this document for descriptions of the objects.
+API endpoints for listing, getting, creating, updating and deleting Policy and Rule objects function the same way in Okta Identity Engine as they do in the existing Okta `/policies` API; only the objects used are different, with Okta Identity Engine introducing a set of new Policy and Rule objects. See the [Okta Identity Engine Policy and Rule Objects](#okta-identity-enging-policy-and-rule-objects) section of this document for descriptions of the objects.
 
 Each Policy object, as well as a Rule for it, needs to exist, in order for Okta Identity Engine to function. One of each is created by default when Okta Identity Engine is enabled for an org.
 
@@ -18,7 +18,7 @@ A `/mappings` endpoint is used to set which Policies apply to which Apps. See th
 
 ## Policies API Operations
 
-API endpoints for creating, getting, and updating Policy and Rule objects function the same way in Okta Identity Engine as they do in the existing Okta `/policies` API. The API endpoints support the following operations:
+API endpoints function the same way in Okta Identity Engine as they do in the existing Okta `/policies` API. The API endpoints support the following operations:
 
  * Get Policy
  * List Policies
@@ -98,7 +98,7 @@ curl -v -X GET \
 
 See <https://developer.okta.com/docs/reference/api/policy/#policy-api-operations> for request syntax for all other operations.
 
-## Okta Identity Engine Policy Objects
+## Okta Identity Engine Policy and Rule Objects
 
 Okta Identity Engine introduces a set of new Policy and Rule objects that are different from the existing Policy and API objects:
 
@@ -113,11 +113,11 @@ Okta Identity Engine introduces a set of new Policy and Rule objects that are di
 * [User Profile Policy Object](#user-profile-policy-object)
 * [User Profile Rule Object](#user-profile-rule-object)
 
-Default instances of each Policy type are created automatically when Okta Identity Engine is enabled for your org. Each of the default Policy objects also has a default Rule that is created automatically.
+Default instances of each Policy type are created automatically when Okta Identity Engine is enabled for your org. Each of the default Policy objects also has a default Rule object that is created automatically.
 
 ### IdP Routing Policy Object
 
-The IdP Routing Policy Object determines which IdP users are routed to. One IdP Routing Policy object is created by default. Additional IdP Routing Policy objects cannot be created. Currently, the only IdP you can configure for use with the Okta Identity Engine Pipeline is the Okta IdP, so that, although this object needs to exist, it cannot change the behavior of the pipeline.
+The IdP Routing Policy object determines which IdP users are routed to. One IdP Routing Policy object is created by default. Additional IdP Routing Policy objects cannot be created. Currently, the only IdP you can configure for use with the Okta Identity Engine Pipeline is the Okta IdP, so that, although this object needs to exist, it cannot change the behavior of the pipeline.
 
 | Property | Type    | Description                                                                             |
 |----------|---------|-----------------------------------------------------------------------------------------|
@@ -229,7 +229,7 @@ The IdP Routing Policy Object determines which IdP users are routed to. One IdP 
 
 ## Identifier Match Policy Object
 
-The Identifier Match Policy Object determines which user profile attributes are used to check for matches between the user entering the Identity Engine Pipeline and existing Okta User Profiles. One Identifier Match Policy object is created by default. You cannot create additional Identifier Match Policy objects.
+The Identifier Match Policy object determines which user profile attributes are used to check for matches between the user entering the Identity Engine Pipeline and existing Okta User Profiles. One Identifier Match Policy object is created by default. You cannot create additional Identifier Match Policy objects.
 
 | Property | Type    | Description                                                                                  |
 |----------|---------|----------------------------------------------------------------------------------------------|
@@ -275,7 +275,7 @@ The Identifier Match Policy Object determines which user profile attributes are 
 |-------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
 | name        | String                                                                                | Human-readable name for the Rule, configurable during creation or updating.                                        |
 | id          | String                                                                                | Unique identifier for this Rule (read-only).                                                                       |
-| type        | String                                                                                | Type of the policy. For Identifier Match Rule Objects, this needs to be `Okta:IdentifierMatch`.                    |
+| type        | String                                                                                | Type of the policy. For Identifier Match Rule objects, this needs to be `Okta:IdentifierMatch`.                    |
 | priority    | Integer                                                                               | Used to determine which Rules take precedence.                                                                     |
 | conditions  | Array                                                                                 | Identifier and App conditions are supported for this Rule type.                                                    |
 | action      | String                                                                                | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.                                         |
@@ -407,7 +407,7 @@ The Unknown User Policy determines whether a user who has not been found to matc
 |-------------|------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
 | name        | String                                                                       | Human-readable name for the Rule, configurable during creation or updating.                        |
 | id          | String                                                                       | Unique identifier for this Rule (read-only)                                                        |
-| type        | String                                                                       | Type of the Rule. For Unknown User Rule Objects, this needs to be `Okta:UnknownUser`.              |
+| type        | String                                                                       | Type of the Rule. For Unknown User Rule objects, this needs to be `Okta:UnknownUser`.              |
 | priority    | Integer                                                                      | Used to determine which Rules take precedence.                                                     |
 | conditions  | Array                                                                        | Identifier and App conditions are supported for this Rule type.                                    |
 | action      | String                                                                       | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.                         |
@@ -457,7 +457,7 @@ The Unknown User Policy determines whether a user who has not been found to matc
 
 ## Sign On Policy Object
 
-The Sign On Policy Object determines which authentication factors to prompt users for, in order to authenticate them. One Sign On Policy Object is created by default.
+The Sign On Policy object determines which authentication factors to prompt users for, in order to authenticate them. One Sign On Policy object is created by default.
 
 | Property | Type    | Description                                                                         |
 |----------|---------|-------------------------------------------------------------------------------------|
@@ -529,7 +529,7 @@ The Sign On Policy Object determines which authentication factors to prompt user
 |-------------|---------------------------------------------------------------------|-----------------------------------------------------------------------------|
 | name        | String                                                              | Human-readable name for the Rule, configurable during creation or updating. |
 | id          | String                                                              | Unique identifier for this Rule (read-only).                                |
-| type        | String                                                              | Type of the Rule. For Sign On Rule Objects, this needs to be `Okta:SignOn`. |
+| type        | String                                                              | Type of the Rule. For Sign On Rule objects, this needs to be `Okta:SignOn`. |
 | priority    | Integer                                                             | Used to determine which Rules take precedence.                              |
 | conditions  | Array                                                               | User Type and Group conditions are supported for this Rule type.            |
 | action      | String                                                              | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.  |
@@ -596,7 +596,7 @@ The Sign On Policy Object determines which authentication factors to prompt user
 
 ## User Profile Policy Object
 
-The User Profile Object determines which user profile attributes to require users to supply. One User Profile Policy Object is created by default.
+The User Profile object determines which user profile attributes to require users to supply. One User Profile Policy object is created by default.
 
 | Property | Type    | Description                                                                               |
 |----------|---------|-------------------------------------------------------------------------------------------|
@@ -644,7 +644,7 @@ The User Profile Object determines which user profile attributes to require user
 |-------------|-------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
 | name        | String                                                                        | Human-readable name for the Rule, configurable during creation or updating.           |
 | id          | String                                                                        | Unique identifier for this Rule (read-only).                                          |
-| type        | String                                                                        | Type of the Rule. For Identifier Match Rule Objects, this needs to be `Okta:SignOn`.  |
+| type        | String                                                                        | Type of the Rule. For Identifier Match Rule objects, this needs to be `Okta:SignOn`.  |
 | priority    | Integer                                                                       | Used to determine which Rules take. precedence.                                       |
 | conditions  | Array                                                                         | UserType, User, Group and various Device conditions are supported for this rule type. |
 | action      | String                                                                        | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.            |

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -8,7 +8,7 @@ title: Okta Identity Engine Policy API
 
 Okta Identity Engine adds new Policy objects to the Okta `/policies` API, to control and configure the behavior of the steps of the Okta Identity Engine Pipeline.
 
-During the Limited EA phase, Okta Identity Engine is enabled or disabled for an org as a whole. If Okta Identity Engine is enabled for an org, these new Policies control the pipeline that end users progress through when accessing OpenID Connect apps. You cannot mix old Policy and Rule objects with new Okta Identity Engine objects; old objects do not affect the new pipeline.
+During the Limited EA phase, Okta Identity Engine is enabled or disabled for an org as a whole. If Okta Identity Engine is enabled for an org, these new Policies control the pipeline end users progress through when accessing OpenID Connect apps. You cannot mix old Policy and Rule objects with new Okta Identity Engine objects; old Policy and Rule objects do not affect the new pipeline.
 
 API endpoints for creating, getting, and updating Policy and Rule objects function the same way in Okta Identity Engine as they do in the existing Okta `/policies` API; only the objects used are different, with Okta Identity Engine introducing a set of new Policy and Rule objects. See the [Okta Identity Engine Policy Objects](#okta-identity-enging-policy-objects) section of this document for descriptions of the objects.
 
@@ -100,19 +100,24 @@ This API uses the following objects:
 
 * [IdP Routing Policy Object](#idp-routing-policy-object)
 * [IdP Routing Rule Object](#idp-routing-rule-object)
+* [Identifier Match Policy Object](#identifier-match-policy-object)
+* [Identifier Match Rule Rule](#identifier-match-rule-object)
 
 <!-- Add one routing and one rule object for each of the OIE policy types-->
 
+Default instances of each Policy type are created automatically when Okta Identity Engine is enabled for your org. Each of those default Policy objects also has a default rule that is created automatically.
+
 ### IdP Routing Policy Object
 
-This object determines which IdP end users are routed to. You need to create one IdP Routing Policy object. Additional IdP Routing Policy objects cannot be created. Currently, only the only IdP you can configure for use with the Okta Identity Engine Pipeline is the Okta IdP, so that, although this object needs to exist, it cannot change the behavior of the pipeline.
+This object determines which IdP end users are routed to. One IdP Routing Policy object is created by default. Additional IdP Routing Policy objects cannot be created. Currently, only the only IdP you can configure for use with the Okta Identity Engine Pipeline is the Okta IdP, so that, although this object needs to exist, it cannot change the behavior of the pipeline.
 
-| Property | Type   | Description                                                                             |
-|----------|--------|-----------------------------------------------------------------------------------------|
-| id       | String | Unique identifier for this Policy (read-only)                                           |
-| name     | String | Human-readable name for the Policy, configurable during creation or updating.           |
-| type     | String | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:IdpRouting`. |
-| status   | String |                                                                                         |
+| Property | Type    | Description                                                                             |
+|----------|---------|-----------------------------------------------------------------------------------------|
+| id       | String  | Unique identifier for this Policy (read-only).                                           |
+| name     | String  | Human-readable name for the Policy, configurable during creation or updating.           |
+| type     | String  | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:IdpRouting`. |
+| status   | String  | 'ACTIVE' or                                                                             |
+| default  | Boolean | `True` for the first instance of this policy, which gets created by default.            |
 
 ### IdP Routing Object Example
 
@@ -147,24 +152,26 @@ This object determines which IdP end users are routed to. You need to create one
 
 ### IdP Routing Rule Object
 
-You need to create at least one IdP Routing Rule Object. Currently, the Okta Identity Provider is the only supported IdP, and the only supported value for the `requirement.type` property of this rule is `okta_idp`.
+One IdP Routing Rule Object is created by default. Currently, the Okta Identity Provider is the only supported IdP, and the only supported value for the `requirement.type` property of this rule is `okta_idp`.
 
-| Property    | Type                                                                        | Description               |
-|-------------|-----------------------------------------------------------------------------|---------------------------|
-| name        | String                                                                      |                           |
-| id          |                                                                             |                           |
-| type        |                                                                             |                           |
-| priority    |                                                                             |                           |
-| conditions  | Array                                                                       |                           |
-| action      | String                                                                      | Either `ALLOW` or `DENY`. |
-| requirement | [IdP Routing Rule Requirement Object](#idp-routing-rule-requirement-object) | Specifies the IdP to use. |
+| Property    | Type                                                                        | Description                                                                             |
+|-------------|-----------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| name        | String                                                                      | Human-readable name for the Policy, configurable during creation or updating.           |
+| id          | String                                                                      | Unique identifier for this Policy (read-only)                                           |
+| type        | String                                                                      | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:IdpRouting`. |
+| priority    | Integer                                                                     | Used to determine which rules take precedence.                                          |
+| conditions  | Array                                                                       | No conditions are supported for this rule type, so this must be an empty array.         |
+| action      | String                                                                      | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.              |
+| requirement | [IdP Routing Rule Requirement Object](#idp-routing-rule-requirement-object) | Specifies the IdP to use.                                                               |
+| status      | String                                                                      | 'ACTIVE' or                                                                             |
+| default     | Boolean                                                                     | `True` for the first instance of this rule, which gets created by default.              |
 
 #### IdP Routing Rule Requirement Object
 
-| Property | Type   | Description |
-|----------|--------|-------------|
-| idpId    | String |             |
-| type     | String |             |
+| Property | Type   | Description         |
+|----------|--------|---------------------|
+| idpId    | String | Must be 'OKTA'.     |
+| type     | String | Must be `okta_idp`. |
  
 ### IdP Routing Rule Object
 
@@ -244,4 +251,124 @@ You need to create at least one IdP Routing Rule Object. Currently, the Okta Ide
         }
     }
 ]
+```
+
+## Identifier Match Policy Object
+
+This object determines which user profile attributes are used to check for matches between the user and existing user progiles. One Identifier Match Policy object is created by default.
+
+| Property | Type    | Description                                                                             |
+|----------|---------|-----------------------------------------------------------------------------------------|
+| id       | String  | Unique identifier for this Policy (read-only).                                           |
+| name     | String  | Human-readable name for the Policy, configurable during creation or updating.           |
+| type     | String  | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:IdpRouting`. |
+| status   | String  | 'ACTIVE' or                                                                             |
+| default  | Boolean | `True` for the first instance of this policy, which gets created by default.            |
+
+### Identifier Match Policy Object Example
+
+```json
+{
+    "id": "rst10y1rmKOjickDM0g4",
+    "name": "Default Policy",
+    "type": "Okta:IdentifierMatch",
+    "status": "ACTIVE",
+    "default": true,
+    "_links": {
+        "self": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst10y1rmKOjickDM0g4",
+            "hints": {
+                "allow": [
+                    "GET",
+                    "PUT"
+                ]
+            }
+        },
+        "rules": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst10y1rmKOjickDM0g4/rules",
+            "hints": {
+                "allow": [
+                    "GET"
+                ]
+            }
+        }
+    }
+}
+```
+## Identifier Match Rule Object
+
+One Identifier Match Rule Object is created by default.
+
+| Property    | Type                                                                                  | Description                                                                                                                                |
+|-------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| name        | String                                                                                | Human-readable name for the Policy, configurable during creation or updating.                                                              |
+| id          | String                                                                                | Unique identifier for this Policy (read-only)                                                                                              |
+| type        | String                                                                                | Type of the policy. For Identifier Match Rule Objects, this needs to be `Okta:IdentifierMatch`.                                            |
+| priority    | Integer                                                                               | Used to determine which rules take precedence.                                                                                             |
+| conditions  | Array                                                                                 | No conditions are supported for this rule type, so this must be an empty array.                                                            |
+| action      | String                                                                                | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.                                                                 |
+| requirement | [Identifier Match Rule Requirement Object](#identifier-match-rule-requirement-object) | Specifies the user profile attributes to match against and the action to take in case of conflict between multiple possible user profiles. |
+| status      | String                                                                                | 'ACTIVE' or                                                                                                                                |
+| default     | Boolean                                                                               | `True` for the first instance of this rule, which gets created by default.                                                                 |
+
+#### Identifier Match Rule Requirement Object
+
+| Property              | Type   | Description                                                                                                                                                       |
+|-----------------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| identifyingAttributes | Array  | User profile attributes to match. For each, you need to specify the ID of the `userType` that the attribute is a part of, as well as the name of the `attribute`. |
+| onConflictingUser     | String | Whether to proceed if more than one match is found. Can be `ALLOW` or `DENY`.                                                                                     |
+ 
+### IdP Routing Rule Object
+
+```json
+{
+    "name": "Catch-all Rule",
+    "id": "rul10y292nt87pGec0g4",
+    "type": "Okta:IdentifierMatch",
+    "priority": 1,
+    "conditions": [],
+    "action": "ALLOW",
+    "requirement": {
+        "identifyingAttributes": [
+            {
+                "userType": "otyt190o2hyJtSHVZ0g3",
+                "attribute": "email"
+            }
+        ],
+        "onConflictingUser": {
+            "action": "DENY"
+        }
+    },
+    "status": "ACTIVE",
+    "default": false,
+    "_links": {
+        "self": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst10y1rmKOjickDM0g4/rules/rul10y292nt87pGec0g4",
+            "hints": {
+                "allow": [
+                    "GET",
+                    "PUT",
+                    "DELETE"
+                ]
+            }
+        },
+        "deactivate": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst10y1rmKOjickDM0g4/rules/rul10y292nt87pGec0g4/lifecycle/deactivate",
+            "hints": {
+                "allow": [
+                    "POST"
+                ]
+            }
+        },
+        "policy": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst10y1rmKOjickDM0g4",
+            "hints": {
+                "allow": [
+                    "GET",
+                    "PUT"
+                ]
+            }
+        }
+    }
+}
 ```

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -497,10 +497,10 @@ The Unknown User Policy determines whether a user who has not been found to matc
 
 #### Unknown User Rule Requirement Object
 
-| Property                                   | Type   | Description                                                                                                                                                            |
-|--------------------------------------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `noUserMatch.action`                       | String | `REGISTER` or `DENY` to determine whether unknown users should be allowed to register.                                                                                 |
-| `noUserMatch.registration.defaultUserType` | String | Valid ID of a User Type. Sets the User Type to enroll unknown users as, if you have allowed unknown users to register. Not required if `noUserMatch.action` is `DENY`. |
+| Property                                   | Type   | Description                                                                                                                                                                                          |
+|--------------------------------------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `noUserMatch.action`                       | String | `REGISTER` or `DENY` to determine whether unknown users should be allowed to register.                                                                                                               |
+| `noUserMatch.registration.defaultUserType` | String | Valid ID of a User Type. Sets the User Type to enroll unknown users as, if you have allowed unknown users to register. `noUserMatch.registration` must be omitted if `noUserMatch.action` is `DENY`. |
 
 ### Unknown User Rule Object Example
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -96,11 +96,11 @@ curl -v -X GET \
 
 ### Syntax for All Other Operations
 
-See <https://developer.okta.com/docs/reference/api/policy/#policy-api-operations> for request syntax for all operations.
+See <https://developer.okta.com/docs/reference/api/policy/#policy-api-operations> for request syntax for all other operations.
 
 ## Okta Identity Engine Policy Objects
 
-Okta Identity Engine introducing a set of new Policy and Rule objects that are different from the existing Policy and API objects. These are the objects:
+Okta Identity Engine introduces a set of new Policy and Rule objects that are different from the existing Policy and API objects:
 
 * [IdP Routing Policy Object](#idp-routing-policy-object)
 * [IdP Routing Rule Object](#idp-routing-rule-object)
@@ -117,7 +117,7 @@ Default instances of each Policy type are created automatically when Okta Identi
 
 ### IdP Routing Policy Object
 
-This object determines which IdP end users are routed to. One IdP Routing Policy object is created by default. Additional IdP Routing Policy objects cannot be created. Currently, only the only IdP you can configure for use with the Okta Identity Engine Pipeline is the Okta IdP, so that, although this object needs to exist, it cannot change the behavior of the pipeline.
+This object determines which IdP end users are routed to. One IdP Routing Policy object is created by default. Additional IdP Routing Policy objects cannot be created. Currently, the only IdP you can configure for use with the Okta Identity Engine Pipeline is the Okta IdP, so that, although this object needs to exist, it cannot change the behavior of the pipeline.
 
 | Property | Type    | Description                                                                             |
 |----------|---------|-----------------------------------------------------------------------------------------|
@@ -159,8 +159,6 @@ This object determines which IdP end users are routed to. One IdP Routing Policy
 ```
 
 ### IdP Routing Rule Object
-
-Currently, the Okta Identity Provider is the only supported IdP.
 
 | Property    | Type                                                                        | Description                                                                             |
 |-------------|-----------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
@@ -263,7 +261,7 @@ Currently, the Okta Identity Provider is the only supported IdP.
 
 ## Identifier Match Policy Object
 
-This object determines which user profile attributes are used to check for matches between the incoming user and existing user profiles. One Identifier Match Policy object is created by default. You cannot create additional Identifier Match Policy objects.
+The Identifier Match Object determines which user profile attributes are used to check for matches between the incoming user and existing Okta User Profiles. One Identifier Match Policy object is created by default. You cannot create additional Identifier Match Policy objects.
 
 | Property | Type    | Description                                                                                  |
 |----------|---------|----------------------------------------------------------------------------------------------|
@@ -381,7 +379,7 @@ This object determines which user profile attributes are used to check for match
 
 ## Unknown User Policy Object
 
-the Unknown User Policy is evaluated if a match was not found with an existing User Profile and determines whether the user is allowed to register and, if so, what User Type they should be assigned.
+The Unknown User Policy is evaluated if a match was not found with an existing User Profile and determines whether the user is allowed to register and, if so, what User Type they should be assigned.
 
 | Property | Type    | Description                                                                              |
 |----------|---------|------------------------------------------------------------------------------------------|
@@ -465,7 +463,7 @@ the Unknown User Policy is evaluated if a match was not found with an existing U
 
 ## Sign On Policy Object
 
-This object determines which credentials to prompt users for. One Sign On Policy Object is created by default.
+The sign on object determines which credentials to prompt users for. One Sign On Policy Object is created by default.
 
 | Property | Type    | Description                                                                         |
 |----------|---------|-------------------------------------------------------------------------------------|
@@ -475,7 +473,7 @@ This object determines which credentials to prompt users for. One Sign On Policy
 | status   | String  | `ACTIVE`  or  `INACTIVE`.                                                           |
 | default  | Boolean | `true` for the first instance of this policy, which gets created by default.        |
 
-### Sign-On Policy Object Example
+### Sign On Policy Object Example
 
 ```json
 {
@@ -589,7 +587,7 @@ This object determines which credentials to prompt users for. One Sign On Policy
 
 ## User Profile Policy Object
 
-This object determines which profile attributes to require users to supply prompt users for. One User Profile Policy Object is created by default.
+The User Profile Object determines which profile attributes to require users to supply prompt users for. One User Profile Policy Object is created by default.
 
 | Property | Type    | Description                                                                               |
 |----------|---------|-------------------------------------------------------------------------------------------|
@@ -696,7 +694,7 @@ Mappings can be used with the following Policy types:
 * Sign On
 * User Profile
 
-Mappings cannot be used with the following Policy types, which apply universally:
+The following Policy types apply universally, and mappings cannot be used with them:
 
 * IdP Routing
 * Identifier Match

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -16,20 +16,20 @@ To enable the Okta Identity Engine Pipeline, you need to create at least one of 
 
 ## Policies API Operations
 
-The API endpoints support the following operations:
+API endpoints for creating, getting, and updating Policy and Rule objects function the same way in Okta Identity Engine as they do in the existing Okta `/policies` API. The API endpoints support the following operations:
 
- * [Get Policy](#get-policy)
- * [List Policies](#list-policies)
- * [Get Rule](#get-rule)
- * [List Rules](#list-rules)
- * [Create Policy](#create-policy)
- * [Create Rule](#create-rule)
- * [Update Policy](#update-policy)
- * [Update Rule](#update-rule)
- * [Delete Policy](#delete-policy)
- * [Delete Rule](#delete-rule)
+ * Get Policy
+ * List Policies
+ * Get Rule
+ * List Rules
+ * Create Policy
+ * Create Rule
+ * Update Policy
+ * Update Rule
+ * Delete Policy
+ * Delete Rule
  
-### Get Policy
+### Sample Operation: Get Policy
 
 <ApiOperation method="get" url="/policies/${PolicyID}" />
 
@@ -61,6 +61,7 @@ curl -v -X GET \
 "https://${yourOktaDomain}/api/v1/policies/${policyId}"
 }'
 ```
+
 ##### Response
 
 ```json
@@ -92,11 +93,13 @@ curl -v -X GET \
 }
 ```
 
-<!-- Add remaining operations. I think it's best to omit the example responses for the remaining operations, would be too cluttered, and just repeats. Enough to just give the curl listing for the request, say that the required parameter is a Policy or Rule ID, and that the response is a Policy or Rule object -->
+### Syntax for All Other Operations
+
+See <https://developer.okta.com/docs/reference/api/policy/#policy-api-operations> for request syntax for all operations.
 
 ## Okta Identity Engine Policy Objects
 
-This API uses the following objects:
+Okta Identity Engine introducing a set of new Policy and Rule objects that are different from the existing Policy and API objects. These are the objects:
 
 * [IdP Routing Policy Object](#idp-routing-policy-object)
 * [IdP Routing Rule Object](#idp-routing-rule-object)
@@ -109,7 +112,7 @@ This API uses the following objects:
 * [User Profile Policy Object](#user-profile-policy-object)
 * [User Profile Rule Object](#user-profile-rule-object)
 
-Default instances of each Policy type are created automatically when Okta Identity Engine is enabled for your org. Each of those default Policy objects also has a default rule that is created automatically.
+Default instances of each Policy type are created automatically when Okta Identity Engine is enabled for your org. Each of the default Policy objects also has a default rule that is created automatically.
 
 ### IdP Routing Policy Object
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -6,7 +6,7 @@ title: Okta Identity Engine Policy API
 
 <ApiLifecycle access="ea" />
 
-Okta Identity Engine adds new Policy objects to the Okta `/policies` API, which control and configure the behavior of the steps of the Okta Identity Engine Pipeline.
+Okta Identity Engine adds new Policy objects to the Okta `/policies` API, to control and configure the behavior of the steps of the Okta Identity Engine Pipeline.
 
 During the Limited EA phase, Okta Identity Engine is enabled or disabled for an org as a whole. If Okta Identity Engine is enabled for an org, these new Policies control the pipeline that end users progress through when accessing OpenID Connect apps. You cannot mix old Policy and Rule objects with new Okta Identity Engine objects; old objects do not affect the new pipeline.
 
@@ -31,7 +31,7 @@ The API endpoints support the following operations:
 
 <ApiOperation method="get" url="/policies/${PolicyID}" />
 
-Given a `PolicyID` identifier, returns a [Policy Object](#policy-object).
+Given a `PolicyID` identifier, returns a [Policy Object](#okta-identity-engine-policy-objects).
 
 #### Request Body
 
@@ -45,7 +45,7 @@ None
 
 #### Response Body
 
-A [Policy Object](#policy-object).
+A [Policy Object](#okta-identity-engine-policy-objects).
 
 #### Usage Example
 
@@ -102,15 +102,14 @@ This API uses the following objects:
 
 ### IdP Routing Policy Object
 
-This object is meant to determine which IdP is used for end users entering the pipeline. One instance of this Policy needs to exist. Additional instances cannot be created. Currently, only one Idp, Okta, can be used with the Okta Identity Engine Pipeline, so that, although this object together with its rule sub-object, needs to exist, this object cannot change the behavior of the pipeline.
+This object is meant to determine which IdP end users are routed to. You need to create one IdP Routing Policy object. Additional IdP Routing Policy objects, beyond the first, cannot be created. Currently, only the Okta Identity Provider can be used with the Okta Identity Engine Pipeline, so that, although this object needs to exist, it cannot change the behavior of the pipeline.
 
-| Property | Type   | Description                                                                    |
-|----------|--------|--------------------------------------------------------------------------------|
-| id       | String | Unique identifier for this Policy (read-only)                                  |
-| name     | String | Human-readable name for the Policy, configurable during creation or updating.  |
-| type     | String | Type of the policy. For IdP Routing Policy objects, this is `Okta:IdpRouting`. |
-| status   | String |                                                                                |
-
+| Property | Type   | Description                                                                             |
+|----------|--------|-----------------------------------------------------------------------------------------|
+| id       | String | Unique identifier for this Policy (read-only)                                           |
+| name     | String | Human-readable name for the Policy, configurable during creation or updating.           |
+| type     | String | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:IdpRouting`. |
+| status   | String |                                                                                         |
 
 ### IdP Routing Object Example
 
@@ -145,7 +144,15 @@ This object is meant to determine which IdP is used for end users entering the p
 
 ### IdP Routing Rule Object
 
-Intro
+You need to create at least one IdP Routing Rule Object. Currently, the Okta Identity Provider is the only supported IdP, and the only supported value for the `requirement` property of this rule is:
+
+```json
+{
+    "idpId": "OKTA",
+    "type": "okta_idp"
+}
+```
+
 
 | Property | Type | Description |
 |----------|------|-------------|
@@ -156,7 +163,79 @@ Intro
 ### IdP Routing Rule Object
 
 ```json
-{  
-
-}
+[
+    {
+        "name": "Catch-all Rule",
+        "id": "rul10y0LatXn0HP2p0g4",
+        "type": "Okta:IdpRouting",
+        "priority": 2,
+        "conditions": [],
+        "action": "ALLOW",
+        "requirement": {
+            "idpId": "OKTA",
+            "type": "okta_idp"
+        },
+        "status": "ACTIVE",
+        "default": false,
+        "_links": {
+            "self": {
+                "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4/rules/rul10y0LatXn0HP2p0g4",
+                "hints": {
+                    "allow": [
+                        "GET",
+                        "PUT",
+                        "DELETE"
+                    ]
+                }
+            },
+            "deactivate": {
+                "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4/rules/rul10y0LatXn0HP2p0g4/lifecycle/deactivate",
+                "hints": {
+                    "allow": [
+                        "POST"
+                    ]
+                }
+            },
+            "policy": {
+                "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4",
+                "hints": {
+                    "allow": [
+                        "GET",
+                        "PUT"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "name": "Default Rule",
+        "id": "default-rule",
+        "type": "Okta:IdpRouting",
+        "priority": -1,
+        "conditions": [],
+        "action": "DENY",
+        "requirement": {},
+        "status": "ACTIVE",
+        "default": true,
+        "_links": {
+            "self": {
+                "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4/rules/default-rule",
+                "hints": {
+                    "allow": [
+                        "GET"
+                    ]
+                }
+            },
+            "policy": {
+                "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4",
+                "hints": {
+                    "allow": [
+                        "GET",
+                        "PUT"
+                    ]
+                }
+            }
+        }
+    }
+]
 ```

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -90,6 +90,7 @@ curl -v -X GET \
 }
 ```
 
+<!-- Add remaining operations. I think it's best to omit the example responses for the remaining operations, would be too cluttered, and just repeats. Enough to just give the curl listing for the request, say that the required parameter is a Policy or Rule ID, and that the response is a Policy or Rule object -->
 
 ## Okta Identity Engine Policy Objects
 
@@ -98,7 +99,7 @@ This API uses the following objects:
 * [IdP Routing Policy Object](#idp-routing-policy-object)
 * [IdP Routing Rule Object](#idp-routing-rule-object)
 
-
+<!-- Add one routing and one rule object for each of the OIE policy types-->
 
 ### IdP Routing Policy Object
 
@@ -154,11 +155,23 @@ You need to create at least one IdP Routing Rule Object. Currently, the Okta Ide
 ```
 
 
-| Property | Type | Description |
-|----------|------|-------------|
-|          |      |             |
-|          |      |             |
-|          |      |             |
+| Property | Type   | Description |
+|----------|--------|-------------|
+| name     | String |             |
+| id       |        |             |
+| type     |        |             |
+| priority |        |             |
+| conditions | Array ||
+| action | String | Either `ALLOW` or `DENY`. |
+| requirement | An [IdP Routing Rule Requirement Object](#idp-routing-rule-requirement-object). |
+
+
+#### IdP Routing Rule Requirement Object
+
+| Property | Type   | Description |
+|----------|--------|-------------|
+| idpId    | String |             |
+| type     |        |             |
  
 ### IdP Routing Rule Object
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -105,7 +105,7 @@ This API uses the following objects:
 
 ### IdP Routing Policy Object
 
-This object is meant to determine which IdP end users are routed to. You need to create one IdP Routing Policy object. Additional IdP Routing Policy objects, beyond the first, cannot be created. Currently, only the Okta Identity Provider can be used with the Okta Identity Engine Pipeline, so that, although this object needs to exist, it cannot change the behavior of the pipeline.
+This object determines which IdP end users are routed to. You need to create one IdP Routing Policy object. Additional IdP Routing Policy objects cannot be created. Currently, only the only IdP you can configure for use with the Okta Identity Engine Pipeline is the Okta IdP, so that, although this object needs to exist, it cannot change the behavior of the pipeline.
 
 | Property | Type   | Description                                                                             |
 |----------|--------|-----------------------------------------------------------------------------------------|

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -285,10 +285,10 @@ The Identifier Match Policy Object determines which user profile attributes are 
 
 #### Identifier Match Rule Requirement Object
 
-| Property              | Type   | Description                                                                                                                                 |
-|-----------------------|--------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| identifyingAttributes | Array  | User profile attributes to match. For each user profile attribute, you need to specify the `userType` ID, as well as the  `attribute` name. |
-| onConflictingUser     | String | Whether to proceed if more than one match is found. Can be `ALLOW` or `DENY`.|                                                              |                                                                       |
+| Property                   | Type   | Description                                                                                                                                 |
+|----------------------------|--------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| identifyingAttributes      | Array  | User profile attributes to match. For each user profile attribute, you need to specify the `userType` ID, as well as the  `attribute` name. |
+| `onConflictingUser.action` | String | Whether to proceed if more than one match is found. Currently, only `DENY` is supported.||                                                  |
  
 ### Identifier Match Rule Object Example
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -149,15 +149,15 @@ This object determines which IdP end users are routed to. You need to create one
 
 You need to create at least one IdP Routing Rule Object. Currently, the Okta Identity Provider is the only supported IdP, and the only supported value for the `requirement.type` property of this rule is `okta_idp`.
 
-| Property    | Type                                                                            | Description               |
-|-------------|---------------------------------------------------------------------------------|---------------------------|
-| name        | String                                                                          |                           |
-| id          |                                                                                 |                           |
-| type        |                                                                                 |                           |
-| priority    |                                                                                 |                           |
-| conditions  | Array                                                                           |                           |
-| action      | String                                                                          | Either `ALLOW` or `DENY`. |
-| requirement | An [IdP Routing Rule Requirement Object](#idp-routing-rule-requirement-object). |                           |
+| Property    | Type                                                                        | Description               |
+|-------------|-----------------------------------------------------------------------------|---------------------------|
+| name        | String                                                                      |                           |
+| id          |                                                                             |                           |
+| type        |                                                                             |                           |
+| priority    |                                                                             |                           |
+| conditions  | Array                                                                       |                           |
+| action      | String                                                                      | Either `ALLOW` or `DENY`. |
+| requirement | [IdP Routing Rule Requirement Object](#idp-routing-rule-requirement-object) | Specifies the IdP to use. |
 
 #### IdP Routing Rule Requirement Object
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -37,9 +37,9 @@ Given a `PolicyID` identifier, returns a [Policy Object](#okta-identity-engine-p
 
 #### Request Body
 
-| Property   | Type   | Description                          |
-|------------|--------|--------------------------------------|
-| `PolicyID` | String | The unique identifier of the Policy. |
+| Property | Type   | Description                          |
+|----------|--------|--------------------------------------|
+| PolicyID | String | The unique identifier of the Policy. |
 
 #### Request Query Parameters
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -313,7 +313,7 @@ This object determines which user profile attributes are used to check for match
 | conditions  | Array                                                                                 | No conditions are supported for this rule type, so this must be an empty array.                                                            |
 | action      | String                                                                                | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.                                                                 |
 | requirement | [Identifier Match Rule Requirement Object](#identifier-match-rule-requirement-object) | Specifies the user profile attributes to match against and the action to take in case of conflict between multiple possible user profiles. |
-| status      | String                                                                                | `ACTIVE`  or  `INACTIVE`.                                                                                                                               |
+| status      | String                                                                                | `ACTIVE`  or  `INACTIVE`.                                                                                                                  |
 | default     | Boolean                                                                               | `true` for the first instance of this rule, which gets created by default.                                                                 |
 
 #### Identifier Match Rule Requirement Object
@@ -382,13 +382,13 @@ This object determines which user profile attributes are used to check for match
 
 the Unknown User Policy is evaluated if a match was not found with an existing User Profile and determines whether the user is allowed to register and, if so, what User Type they should be assigned.
 
-| Property | Type    | Description                                                                             |
-|----------|---------|-----------------------------------------------------------------------------------------|
+| Property | Type    | Description                                                                              |
+|----------|---------|------------------------------------------------------------------------------------------|
 | id       | String  | Unique identifier for this Policy (read-only).                                           |
-| name     | String  | Human-readable name for the Policy, configurable during creation or updating.           |
+| name     | String  | Human-readable name for the Policy, configurable during creation or updating.            |
 | type     | String  | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:UnknownUser`. |
-| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                                            |
-| default  | Boolean | `true` for the first instance of this policy, which gets created by default.            |
+| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                                |
+| default  | Boolean | `true` for the first instance of this policy, which gets created by default.             |
 
 ### Unknown User Policy Object Example
 
@@ -423,24 +423,24 @@ the Unknown User Policy is evaluated if a match was not found with an existing U
 
 ## Unknown User Rule Object
 
-| Property    | Type                                                                                  | Description                                                                                                                                |
-|-------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| name        | String                                                                                | Human-readable name for the Policy, configurable during creation or updating.                                                              |
-| id          | String                                                                                | Unique identifier for this Policy (read-only)                                                                                              |
-| type        | String                                                                                | Type of the policy. For Identifier Match Rule Objects, this needs to be `Okta:UnknownUser`.                                            |
-| priority    | Integer                                                                               | Used to determine which rules take precedence.                                                                                             |
-| conditions  | Array                                                                                 | No conditions are supported for this rule type, so this must be an empty array.                                                            |
-| action      | String                                                                                | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.                                                                 |
+| Property    | Type                                                                         | Description                                                                                        |
+|-------------|------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
+| name        | String                                                                       | Human-readable name for the Policy, configurable during creation or updating.                      |
+| id          | String                                                                       | Unique identifier for this Policy (read-only)                                                      |
+| type        | String                                                                       | Type of the policy. For Identifier Match Rule Objects, this needs to be `Okta:UnknownUser`.        |
+| priority    | Integer                                                                      | Used to determine which rules take precedence.                                                     |
+| conditions  | Array                                                                        | No conditions are supported for this rule type, so this must be an empty array.                    |
+| action      | String                                                                       | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.                         |
 | requirement | [Unknown User Rule Requirement Object](#unknow-user-rule-requirement-object) | Specifies whether to allow an unknown user to register and, if so, what User Type to use for them. |
-| status      | String                                                                                | `ACTIVE`  or  `INACTIVE`.                                                                                                                               |
-| default     | Boolean                                                                               | `true` for the first instance of this rule, which gets created by default.                                                                 |
+| status      | String                                                                       | `ACTIVE`  or  `INACTIVE`.                                                                          |
+| default     | Boolean                                                                      | `true` for the first instance of this rule, which gets created by default.                         |
 
 #### Unknown User Rule Requirement Object
 
 | Property                                   | Type   | Description                                                                                                                                                            |
 |--------------------------------------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `noUserMatch.action`                       | String | `REGISTER` or `DENY` to determine whether unknown users should be allowed to register.                                                                                 |
-| `noUserMatch.registration.defaultUserType` | String | Valid ID of a User Type. Sets the User Type to enroll unknown users as, if you have allowed unknown users to register. Not required if `noUserMatch.action` is `DENY`. |      
+| `noUserMatch.registration.defaultUserType` | String | Valid ID of a User Type. Sets the User Type to enroll unknown users as, if you have allowed unknown users to register. Not required if `noUserMatch.action` is `DENY`. |
 
 ### Unknown User Rule Object Example
 
@@ -549,7 +549,7 @@ This object determines which credentials to prompt users for. One Sign On Policy
 | Property                  | Type   | Description                                                                                                                                         |
 |---------------------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
 | `verificationMethod.type` | String | `CHAIN` or `ANY_FACTOR` to determine whether users should be prompted for a sequence of credentials or allowed to choose one credential from a set. |
-| chains                    | Array  | Array specifying the chain of factor types to require. Not required if `verificationMethod.type` is `ANY_FACTOR`.                                   |                 |      
+| chains                    | Array  | Array specifying the chain of factor types to require. Not required if `verificationMethod.type` is `ANY_FACTOR`.|                                  |      
 
 ### Sign On Rule Object Example
 
@@ -590,13 +590,13 @@ This object determines which credentials to prompt users for. One Sign On Policy
 
 This object determines which profile attributes to require users to supply prompt users for. One User Profile Policy Object is created by default.
 
-| Property | Type    | Description                                                                         |
-|----------|---------|-------------------------------------------------------------------------------------|
-| id       | String  | Unique identifier for this Policy (read-only).                                      |
-| name     | String  | Human-readable name for the Policy, configurable during creation or updating.       |
+| Property | Type    | Description                                                                              |
+|----------|---------|------------------------------------------------------------------------------------------|
+| id       | String  | Unique identifier for this Policy (read-only).                                           |
+| name     | String  | Human-readable name for the Policy, configurable during creation or updating.            |
 | type     | String  | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:UserProfile`. |
-| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                           |
-| default  | Boolean | `true` for the first instance of this policy, which gets created by default.        |
+| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                                |
+| default  | Boolean | `true` for the first instance of this policy, which gets created by default.             |
 
 ### User Profile Policy Object Example
 
@@ -646,10 +646,10 @@ This object determines which profile attributes to require users to supply promp
 
 #### User Profile Rule Requirement Object
 
-| Property                   | Type   | Description                                                                                                                                                                                                                                     |
-|----------------------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| preRegistrationInlineHooks | String | Optional. The valid ID of an Inline Hook. Sets a Registration Inline Hook to invoke.                                                                                                                                                            |
-| profileAttributes          | Array  | Array specifying the `label` and `name` of each User Profile Attribute that should be collected from the user. `label` is human-readable text that can be displayed to the user in a web form. `name` is the name of a User Profile Attribute.| |   
+| Property                   | Type   | Description                                                                                                                                                                                                                                    |
+|----------------------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| preRegistrationInlineHooks | String | Optional. The valid ID of an Inline Hook. Sets a Registration Inline Hook to invoke.                                                                                                                                                           |
+| profileAttributes          | Array  | Array specifying the `label` and `name` of each User Profile Attribute that should be collected from the user. `label` is human-readable text that can be displayed to the user in a web form. `name` is the name of a User Profile Attribute. |
 
 ### User Profile Rule Object Example
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -101,7 +101,9 @@ This API uses the following objects:
 * [IdP Routing Policy Object](#idp-routing-policy-object)
 * [IdP Routing Rule Object](#idp-routing-rule-object)
 * [Identifier Match Policy Object](#identifier-match-policy-object)
-* [Identifier Match Rule Rule](#identifier-match-rule-object)
+* [Identifier Match Rule Object](#identifier-match-rule-object)
+* [Unknown User Policy Object](#uknown-user-policy-object)
+* [Unknown User Rule Object](#unknown-user-rule-object)
 
 <!-- Add one routing and one rule object for each of the OIE policy types-->
 
@@ -372,3 +374,47 @@ One Identifier Match Rule Object is created by default.
     }
 }
 ```
+
+## Unknown User Policy Object
+
+Evaluated if a match was not found with an existing User Profile, the Unknown User Policy determines whether is allowed to register and, if so, what User Type should be used for them.
+
+| Property | Type    | Description                                                                             |
+|----------|---------|-----------------------------------------------------------------------------------------|
+| id       | String  | Unique identifier for this Policy (read-only).                                           |
+| name     | String  | Human-readable name for the Policy, configurable during creation or updating.           |
+| type     | String  | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:UnknownUser`. |
+| status   | String  | 'ACTIVE' or                                                                             |
+| default  | Boolean | `True` for the first instance of this policy, which gets created by default.            |
+
+### Identifier Match Policy Object Example
+
+```json
+{
+    "id": "rst10y3icArzJtWvf0g4",
+    "name": "Default Policy",
+    "type": "Okta:UnknownUser",
+    "status": "ACTIVE",
+    "default": true,
+    "_links": {
+        "self": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst10y3icArzJtWvf0g4",
+            "hints": {
+                "allow": [
+                    "GET",
+                    "PUT"
+                ]
+            }
+        },
+        "rules": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst10y3icArzJtWvf0g4/rules",
+            "hints": {
+                "allow": [
+                    "GET"
+                ]
+            }
+        }
+    }
+}
+```
+

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -737,7 +737,9 @@ The User Profile object determines which user profile attributes to require user
 | Property                   | Type  | Description                                                                                                                                                                                                                                    |
 |----------------------------|-------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | preRegistrationInlineHooks | Array | Optional. An array that can currently contain only one element. The element must be the unique ID of a Registration Inline Hook to invoke.                                                                                                     |
-| profileAttributes          | Array | Array specifying the `label` and `name` of each User Profile Attribute that should be collected from the user. `label` is human-readable text that can be displayed to the user in a web form. `name` is the name of a User Profile Attribute. |
+| profileAttributes          | Array | Array specifying the `label` and `name` of each User Profile Attribute that should be collected from the user, as well as a `required` property set to `true` or `false` . `label` is human-readable text that can be displayed to the user in a web form. `name` is the name of a User Profile Attribute. |
+
+>**Note**: Even if a User Profile Attribute is not set to be required, it can be required at user enrollment time based on the User Type schema.
 
 ### User Profile Rule Object Example
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -12,6 +12,8 @@ During the Limited EA phase, Okta Identity Engine is enabled or disabled for an 
 
 API endpoints for creating, getting, and updating Policy and Rule objects function the same way in Okta Identity Engine as they do in the existing Okta `/policies` API; only the objects used are different, with Okta Identity Engine introducing a set of new Policy and Rule objects. See the [Okta Identity Engine Policy Objects](#okta-identity-enging-policy-objects) section of this document for descriptions of the objects.
 
+To enable the Okta Identity Engine Pipeline, you need to create at least one of each of the defined Okta Identity Engine Policy objects, and at least one Rule object for each Policy.
+
 ## Policies API Operations
 
 The API endpoints support the following operations:

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -182,81 +182,49 @@ The IdP Routing Policy Object determines which IdP users are routed to. One IdP 
 ### IdP Routing Rule Object Example
 
 ```json
-[
-    {
-        "name": "Catch-all Rule",
-        "id": "rul10y0LatXn0HP2p0g4",
-        "type": "Okta:IdpRouting",
-        "priority": 2,
-        "conditions": [],
-        "action": "ALLOW",
-        "requirement": {
-            "idpId": "OKTA",
-            "type": "okta_idp"
-        },
-        "status": "ACTIVE",
-        "default": false,
-        "_links": {
-            "self": {
-                "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4/rules/rul10y0LatXn0HP2p0g4",
-                "hints": {
-                    "allow": [
-                        "GET",
-                        "PUT",
-                        "DELETE"
-                    ]
-                }
-            },
-            "deactivate": {
-                "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4/rules/rul10y0LatXn0HP2p0g4/lifecycle/deactivate",
-                "hints": {
-                    "allow": [
-                        "POST"
-                    ]
-                }
-            },
-            "policy": {
-                "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4",
-                "hints": {
-                    "allow": [
-                        "GET",
-                        "PUT"
-                    ]
-                }
-            }
-        }
+{
+    "name": "Catch-all Rule",
+    "id": "rul10y0LatXn0HP2p0g4",
+    "type": "Okta:IdpRouting",
+    "priority": 2,
+    "conditions": [],
+    "action": "ALLOW",
+    "requirement": {
+        "idpId": "OKTA",
+        "type": "okta_idp"
     },
-    {
-        "name": "Default Rule",
-        "id": "default-rule",
-        "type": "Okta:IdpRouting",
-        "priority": -1,
-        "conditions": [],
-        "action": "DENY",
-        "requirement": {},
-        "status": "ACTIVE",
-        "default": true,
-        "_links": {
-            "self": {
-                "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4/rules/default-rule",
-                "hints": {
-                    "allow": [
-                        "GET"
-                    ]
-                }
-            },
-            "policy": {
-                "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4",
-                "hints": {
-                    "allow": [
-                        "GET",
-                        "PUT"
-                    ]
-                }
+    "status": "ACTIVE",
+    "default": false,
+    "_links": {
+        "self": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4/rules/rul10y0LatXn0HP2p0g4",
+            "hints": {
+                "allow": [
+                    "GET",
+                    "PUT",
+                    "DELETE"
+                ]
+            }
+        },
+        "deactivate": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4/rules/rul10y0LatXn0HP2p0g4/lifecycle/deactivate",
+            "hints": {
+                "allow": [
+                    "POST"
+                ]
+            }
+        },
+        "policy": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4",
+            "hints": {
+                "allow": [
+                    "GET",
+                    "PUT"
+                ]
             }
         }
     }
-]
+}
 ```
 
 ## Identifier Match Policy Object

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -691,13 +691,15 @@ This object determines which profile attributes to require users to supply promp
 Mappings specify which Policies apply to which Apps. You call the `/policies/${policyId}/mappings` endpoint to set a mapping. You cannot update mappings once you have created them.
 
 Mappings can be used with the following Policy types:
-* 
-* 
 
-Mappings cannot be used with the following Policy types because these Policies apply universally to all apps:
+* Sign On
+* User Profile
 
-* 
-* 
+Mappings cannot be used with the following Policy types, which apply universally:
+
+* IdP Routing
+* Identifier Match
+* Unknown User
 
 #### Request Body
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -285,10 +285,10 @@ The Identifier Match Policy Object determines which user profile attributes are 
 
 #### Identifier Match Rule Requirement Object
 
-| Property                   | Type   | Description                                                                                                                                 |
-|----------------------------|--------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| identifyingAttributes      | Array  | User profile attributes to match. For each user profile attribute, you need to specify the `userType` ID, as well as the  `attribute` name. |
-| `onConflictingUser.action` | String | Whether to proceed if more than one match is found. Currently only `DENY` is supported.||                                                  |
+| Property                 | Type   | Description                                                                                                                                |
+|--------------------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| identifyingAttributes    | Array  | User profile attributes to match. For each user profile attribute, you need to specify the `userType` ID, as well as the `attribute` name. |
+| onConflictingUser.action | String | Whether to proceed if more than one match is found. Currently only `DENY` is supported.                                                    |
  
 ### Identifier Match Rule Object Example
 
@@ -407,9 +407,9 @@ The Unknown User Policy determines whether a user who has not been found to matc
 |-------------|------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
 | name        | String                                                                       | Human-readable name for the Rule, configurable during creation or updating.                        |
 | id          | String                                                                       | Unique identifier for this Rule (read-only)                                                        |
-| type        | String                                                                       | Type of the Rule. For Identifier Match Rule Objects, this needs to be `Okta:UnknownUser`.          |
+| type        | String                                                                       | Type of the Rule. For Unknown User Rule Objects, this needs to be `Okta:UnknownUser`.              |
 | priority    | Integer                                                                      | Used to determine which Rules take precedence.                                                     |
-| conditions  | Array                                                                        | No conditions are supported for this Rule type, so this must be an empty array.                    |
+| conditions  | Array                                                                        | Identifier and App conditions are supported for this Rule type.                                    |
 | action      | String                                                                       | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.                         |
 | requirement | [Unknown User Rule Requirement Object](#unknow-user-rule-requirement-object) | Specifies whether to allow an unknown user to register and, if so, what User Type to use for them. |
 | status      | String                                                                       | `ACTIVE`  or  `INACTIVE`.                                                                          |
@@ -430,7 +430,20 @@ The Unknown User Policy determines whether a user who has not been found to matc
     "type": "Okta:UnknownUser",
     "priority": 0,
     "action": "ALLOW",
-    "conditions": [], 
+    "conditions": [
+        {
+            "key": "Okta:Identifier",
+            "op": "STRING_ENDS_WITH",
+            "value": "idx.com"
+        },
+        {
+            "key": "Okta:AppInstance",
+            "op": "IN_LIST",
+            "value": [
+            	"{{appInstanceId}}"
+        	]
+        }
+    ], 
     "requirement": {
         "noUserMatch": {
             "action": "REGISTER", 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -6,11 +6,11 @@ title: Okta Identity Engine Policy API
 
 <ApiLifecycle access="ea" />
 
-Okta Identity Engine adds new Policy objects to the Okta `/policies` API, to control and configure the behavior of the steps of the Okta Identity Engine Pipeline.
+Okta Identity Engine adds new Policy objects to the Okta `/policies` API, which control and configure the behavior of the steps of the Okta Identity Engine Pipeline.
 
-During the Limited EA phase, Okta Identity Engine is enabled or disabled for an org as a whole. If Okta Identity Engine is enabled for an org, these new Policies control the pipeline that end users progress through when accessing OpenID Connect apps defined in the org. You cannot mix old Policy and Rule objects with the new Okta Identity Engine objects; old objects will not affect the steps in the new pipeline.
+During the Limited EA phase, Okta Identity Engine is enabled or disabled for an org as a whole. If Okta Identity Engine is enabled for an org, these new Policies control the pipeline that end users progress through when accessing OpenID Connect apps. You cannot mix old Policy and Rule objects with new Okta Identity Engine objects; old objects do not affect the new pipeline.
 
-API endpoints for getting or updating Policy and Rules objects function the same way in Okta Identity Engine as they do in the existing Okta `/policies` API. Only the objects used are different, with Okta Identity Engine introducing a set of new Policy and Rule objects to configure the steps that make up the Okta Identity Engine Pipeline. See the [Okta Identity Engine Policy Objects](#okta-identity-enging-policy-objects) section of this document for descriptions of the objects.
+API endpoints for creating, getting, and updating Policy and Rule objects function the same way in Okta Identity Engine as they do in the existing Okta `/policies` API; only the objects used are different, with Okta Identity Engine introducing a set of new Policy and Rule objects. See the [Okta Identity Engine Policy Objects](#okta-identity-enging-policy-objects) section of this document for descriptions of the objects.
 
 ## Policies API Operations
 
@@ -91,7 +91,6 @@ curl -v -X GET \
 ```
 
 
-
 ## Okta Identity Engine Policy Objects
 
 This API uses the following objects:
@@ -103,11 +102,15 @@ This API uses the following objects:
 
 ### IdP Routing Policy Object
 
-Intro.
+This object is meant to determine which IdP is used for end users entering the pipeline. One instance of this Policy needs to exist. Additional instances cannot be created. Currently, only one Idp, Okta, can be used with the Okta Identity Engine Pipeline, so that, although this object together with its rule sub-object, needs to exist, this object cannot change the behavior of the pipeline.
 
-| Property | Type | Description |
-|----------|------|-------------|
-|          |      |             |
+| Property | Type   | Description                                                                    |
+|----------|--------|--------------------------------------------------------------------------------|
+| id       | String | Unique identifier for this Policy (read-only)                                  |
+| name     | String | Human-readable name for the Policy, configurable during creation or updating.  |
+| type     | String | Type of the policy. For IdP Routing Policy objects, this is `Okta:IdpRouting`. |
+| status   | String |                                                                                |
+
 
 ### IdP Routing Object Example
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -195,6 +195,8 @@ Okta Identity Engine introduces a set of new Policy and Rule objects that are di
 
 Default instances of each Policy type are created automatically when Okta Identity Engine is enabled for your org. Each of the default Policy objects also has a default Rule object that is created automatically.
 
+The `conditions` objects, which can be specified in Rule objects, are documented in the existing Policy API documentation at: <https://developer.okta.com/docs/reference/api/policy/#conditions>
+
 ### IdP Routing Policy Object
 
 The IdP Routing Policy object determines which IdP users are routed to. One IdP Routing Policy object is created by default. Additional IdP Routing Policy objects cannot be created. Currently, the only IdP you can configure for use with the Okta Identity Engine Pipeline is the Okta IdP, so that, although this object needs to exist, it cannot change the behavior of the pipeline.

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -118,8 +118,8 @@ This object determines which IdP end users are routed to. One IdP Routing Policy
 | id       | String  | Unique identifier for this Policy (read-only).                                           |
 | name     | String  | Human-readable name for the Policy, configurable during creation or updating.           |
 | type     | String  | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:IdpRouting`. |
-| status   | String  | 'ACTIVE' or                                                                             |
-| default  | Boolean | `True` for the first instance of this policy, which gets created by default.            |
+| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                                            |
+| default  | Boolean | `true` for the first instance of this policy, which gets created by default.            |
 
 ### IdP Routing Object Example
 
@@ -165,8 +165,8 @@ One IdP Routing Rule Object is created by default. Currently, the Okta Identity 
 | conditions  | Array                                                                       | No conditions are supported for this rule type, so this must be an empty array.         |
 | action      | String                                                                      | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.              |
 | requirement | [IdP Routing Rule Requirement Object](#idp-routing-rule-requirement-object) | Specifies the IdP to use.                                                               |
-| status      | String                                                                      | 'ACTIVE' or                                                                             |
-| default     | Boolean                                                                     | `True` for the first instance of this rule, which gets created by default.              |
+| status      | String                                                                      | `ACTIVE`  or  `INACTIVE`.                                                                            |
+| default     | Boolean                                                                     | `true` for the first instance of this rule, which gets created by default.              |
 
 #### IdP Routing Rule Requirement Object
 
@@ -264,8 +264,8 @@ This object determines which user profile attributes are used to check for match
 | id       | String  | Unique identifier for this Policy (read-only).                                           |
 | name     | String  | Human-readable name for the Policy, configurable during creation or updating.           |
 | type     | String  | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:IdpRouting`. |
-| status   | String  | 'ACTIVE' or                                                                             |
-| default  | Boolean | `True` for the first instance of this policy, which gets created by default.            |
+| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                                            |
+| default  | Boolean | `true` for the first instance of this policy, which gets created by default.            |
 
 ### Identifier Match Policy Object Example
 
@@ -310,8 +310,8 @@ One Identifier Match Rule Object is created by default.
 | conditions  | Array                                                                                 | No conditions are supported for this rule type, so this must be an empty array.                                                            |
 | action      | String                                                                                | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.                                                                 |
 | requirement | [Identifier Match Rule Requirement Object](#identifier-match-rule-requirement-object) | Specifies the user profile attributes to match against and the action to take in case of conflict between multiple possible user profiles. |
-| status      | String                                                                                | 'ACTIVE' or                                                                                                                                |
-| default     | Boolean                                                                               | `True` for the first instance of this rule, which gets created by default.                                                                 |
+| status      | String                                                                                | `ACTIVE`  or  `INACTIVE`.                                                                                                                               |
+| default     | Boolean                                                                               | `true` for the first instance of this rule, which gets created by default.                                                                 |
 
 #### Identifier Match Rule Requirement Object
 
@@ -384,8 +384,8 @@ Evaluated if a match was not found with an existing User Profile, the Unknown Us
 | id       | String  | Unique identifier for this Policy (read-only).                                           |
 | name     | String  | Human-readable name for the Policy, configurable during creation or updating.           |
 | type     | String  | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:UnknownUser`. |
-| status   | String  | 'ACTIVE' or                                                                             |
-| default  | Boolean | `True` for the first instance of this policy, which gets created by default.            |
+| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                                            |
+| default  | Boolean | `true` for the first instance of this policy, which gets created by default.            |
 
 ### Unknown User Policy Object Example
 
@@ -431,8 +431,8 @@ One Unknown User Rule Object is created by default.
 | conditions  | Array                                                                                 | No conditions are supported for this rule type, so this must be an empty array.                                                            |
 | action      | String                                                                                | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.                                                                 |
 | requirement | [Unknown User Rule Requirement Object](#unknow-user-rule-requirement-object) | Specifies whether to allow an unknown user to register and, if so, what User Type to use for them. |
-| status      | String                                                                                | 'ACTIVE' or                                                                                                                                |
-| default     | Boolean                                                                               | `True` for the first instance of this rule, which gets created by default.                                                                 |
+| status      | String                                                                                | `ACTIVE`  or  `INACTIVE`.                                                                                                                               |
+| default     | Boolean                                                                               | `true` for the first instance of this rule, which gets created by default.                                                                 |
 
 #### Unkown User Rule Requirement Object
 
@@ -459,3 +459,72 @@ One Unknown User Rule Object is created by default.
     }
 }
 ```
+
+## Sign-On Policy Object
+
+This object determines which user profile attributes are used to check for matches between the user and existing user profiles. One Identifier Match Policy object is created by default. You cannot create additional Identifier Match Policy objects.
+
+| Property | Type    | Description                                                                             |
+|----------|---------|-----------------------------------------------------------------------------------------|
+| id       | String  | Unique identifier for this Policy (read-only).                                           |
+| name     | String  | Human-readable name for the Policy, configurable during creation or updating.           |
+| type     | String  | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:SignOn`. |
+| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                                            |
+| default  | Boolean | `true` for the first instance of this policy, which gets created by default.            |
+
+### Sign-On Policy Object Example
+
+```json
+{
+    "id": "rst6v8jmmTIJdv6ms0g4",
+    "name": "Sign On Policy",
+    "type": "Okta:SignOn",
+    "status": "ACTIVE",
+    "default": false,
+    "_links": {
+        "mappings": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst6v8jmmTIJdv6ms0g4/mappings",
+            "hints": {
+                "allow": [
+                    "GET"
+                ]
+            }
+        },
+        "self": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst6v8jmmTIJdv6ms0g4",
+            "hints": {
+                "allow": [
+                    "GET",
+                    "PUT",
+                    "DELETE"
+                ]
+            }
+        },
+        "rules": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst6v8jmmTIJdv6ms0g4/rules",
+            "hints": {
+                "allow": [
+                    "GET"
+                ]
+            }
+        },
+        "deactivate": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst6v8jmmTIJdv6ms0g4/lifecycle/deactivate",
+            "hints": {
+                "allow": [
+                    "POST"
+                ]
+            }
+        },
+        "applications": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst6v8jmmTIJdv6ms0g4/app",
+            "hints": {
+                "allow": [
+                    "GET"
+                ]
+            }
+        }
+    }
+}
+```
+

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -14,7 +14,7 @@ API endpoints for creating, getting, and updating Policy and Rule objects functi
 
 Each Policy object, as well as a Rule for it, needs to exist, in order for Okta Identity Engine to function. One of each is created by default when Okta Identity Engine is enabled for an org.
 
-A `mappings` endpoint is used to set which Policies apply to which Apps. See [Mappings Between Apps and Policies](#mappings-between-apps-and-policies) below for information.
+A `/mappings` endpoint is used to set which Policies apply to which Apps. See the [Mappings Between Apps and Policies](#mappings-between-apps-and-policies) section of this document for a description of how to set mappings.
 
 ## Policies API Operations
 
@@ -61,7 +61,6 @@ curl -v -X GET \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
 "https://${yourOktaDomain}/api/v1/policies/${policyId}"
-}'
 ```
 
 ##### Response
@@ -728,7 +727,7 @@ curl -v -X GET \
 -d '{
 	"resourceType": "APP",
 	"resourceId": "{{appInstanceId}}"
- }' 
+}' \
 "https://${yourOktaDomain}/api/v1/policies/${policyId}/mappings"
 ```
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -8,9 +8,9 @@ title: Okta Identity Engine Policy API
 
 Okta Identity Engine adds new Policy objects to the Okta `/policies` API, to control and configure the behavior of the steps of the Okta Identity Engine Pipeline.
 
-During the Limited EA phase, Okta Identity Engine is enabled or disabled for an org as a whole. If Okta Identity Engine is enabled for an org, these new Policies control the pipeline that end users progress through when accessing OpenID Connect apps. You cannot mix old Policy and Rule objects with new Okta Identity Engine objects; old Policy and Rule objects do not affect the new pipeline.
+During the Limited EA phase, Okta Identity Engine is enabled or disabled for an org as a whole. If Okta Identity Engine is enabled for an org, these new Policies control the pipeline through which end users progress when accessing OpenID Connect apps. You cannot mix old Policy and Rule objects with new Okta Identity Engine objects; old Policy and Rule objects do not affect the new pipeline.
 
-API endpoints for creating, getting, and updating Policy and Rule objects function the same way in Okta Identity Engine as they do in the existing Okta `/policies` API; only the objects used are different, with Okta Identity Engine introducing a set of new Policy and Rule objects. See the [Okta Identity Engine Policy Objects](#okta-identity-enging-policy-objects) section of this document for descriptions of the objects.
+API endpoints for listing, getting, creating, updating and deleting Policy and Rule objects function the same way in Okta Identity Engine as they do in the existing Okta `/policies` API; only the objects used are different, with Okta Identity Engine introducing a set of new Policy and Rule objects. See the [Okta Identity Engine Policy Objects](#okta-identity-enging-policy-objects) section of this document for descriptions of the objects.
 
 Each Policy object, as well as a Rule for it, needs to exist, in order for Okta Identity Engine to function. One of each is created by default when Okta Identity Engine is enabled for an org.
 
@@ -33,15 +33,15 @@ API endpoints for creating, getting, and updating Policy and Rule objects functi
  
 ### Sample Operation: Get Policy
 
-<ApiOperation method="get" url="/policies/${PolicyID}" />
+<ApiOperation method="get" url="/policies/${policyId}" />
 
-Given a `PolicyID` identifier, returns a [Policy Object](#okta-identity-engine-policy-objects).
+Given a `policyId` identifier, returns a [Policy Object](#okta-identity-engine-policy-objects).
 
 #### Request Body
 
 | Property | Type   | Description                          |
 |----------|--------|--------------------------------------|
-| PolicyID | String | The unique identifier of the Policy. |
+| policyId | String | The unique identifier of the Policy. |
 
 #### Request Query Parameters
 
@@ -176,7 +176,7 @@ The IdP Routing Policy Object determines which IdP users are routed to. One IdP 
 
 | Property | Type   | Description                    |
 |----------|--------|--------------------------------|
-| idpId    | String | Currently, must be 'OKTA'.     |
+| idpId    | String | Currently, must be `OKTA`.     |
 | type     | String | Currently, must be `okta_idp`. |
  
 ### IdP Routing Rule Object Example
@@ -422,7 +422,7 @@ The Unknown User Policy determines whether a user who has not been found to matc
         "noUserMatch": {
             "action": "REGISTER", 
             "registration": {
-                "defaultUserType": "${userTypeId}}" 
+                "defaultUserType": "${userTypeId}" 
             }
         }
     }
@@ -630,7 +630,7 @@ The User Profile Object determines which user profile attributes to require user
     "requirement": {
         "preRegistrationInlineHooks": [
             {
-                "inlineHookId": "{{inlineHookId}}"
+                "inlineHookId": "${inlineHookId}"
             }
         ],
         "profileAttributes": [
@@ -692,7 +692,7 @@ curl -v -X GET \
 -H "Authorization: SSWS ${api_token}" \
 -d '{
 	"resourceType": "APP",
-	"resourceId": "{{appInstanceId}}"
+	"resourceId": "${appInstanceId}"
 }' \
 "https://${yourOktaDomain}/api/v1/policies/${policyId}/mappings"
 ```

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -440,7 +440,7 @@ The Unknown User Policy determines whether a user who has not been found to matc
             "key": "Okta:AppInstance",
             "op": "IN_LIST",
             "value": [
-            	"{{appInstanceId}}"
+            	"${appInstanceId}"
         	]
         }
     ], 
@@ -525,17 +525,17 @@ The Sign On Policy Object determines which authentication factors to prompt user
 
 ## Sign On Rule Object
 
-| Property    | Type                                                                | Description                                                                           |
-|-------------|---------------------------------------------------------------------|---------------------------------------------------------------------------------------|
-| name        | String                                                              | Human-readable name for the Rule, configurable during creation or updating.           |
-| id          | String                                                              | Unique identifier for this Rule (read-only).                                          |
-| type        | String                                                              | Type of the Rule. For Identifier Match Rule Objects, this needs to be `Okta:SignOn`.  |
-| priority    | Integer                                                             | Used to determine which Rules take precedence.                                        |
-| conditions  | Array                                                               | UserType, User, Group and various Device conditions are supported for this rule type. |
-| action      | String                                                              | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.            |
-| requirement | [Sign On Rule Requirement Object](#sign-on-rule-requirement-object) | Specifies credentials to prompt user for.                                             |
-| status      | String                                                              | `ACTIVE`  or  `INACTIVE`.                                                             |
-| default     | Boolean                                                             | `true` for the first instance of this Rule, which gets created by default.            |
+| Property    | Type                                                                | Description                                                                 |
+|-------------|---------------------------------------------------------------------|-----------------------------------------------------------------------------|
+| name        | String                                                              | Human-readable name for the Rule, configurable during creation or updating. |
+| id          | String                                                              | Unique identifier for this Rule (read-only).                                |
+| type        | String                                                              | Type of the Rule. For Sign On Rule Objects, this needs to be `Okta:SignOn`. |
+| priority    | Integer                                                             | Used to determine which Rules take precedence.                              |
+| conditions  | Array                                                               | User Type and Group conditions are supported for this Rule type.            |
+| action      | String                                                              | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.  |
+| requirement | [Sign On Rule Requirement Object](#sign-on-rule-requirement-object) | Specifies credentials to prompt user for.                                   |
+| status      | String                                                              | `ACTIVE`  or  `INACTIVE`.                                                   |
+| default     | Boolean                                                             | `true` for the first instance of this Rule, which gets created by default.  |
 
 #### Sign On Rule Requirement Object
 
@@ -551,7 +551,22 @@ The Sign On Policy Object determines which authentication factors to prompt user
 	"name": "Password THEN Email",
     "type": "Okta:SignOn",
     "priority": 0,
-    "conditions": [],
+    "conditions": [
+        {
+            "key": "Okta:UserType",
+            "op": "IN_LIST",
+            "value": [
+            	"${userTypeId}"
+        	]
+        },
+        {
+            "key": "Okta:Group",
+            "op": "INTERSECTS",
+            "value": [
+                "${groupId}"
+            ]
+        }	
+    ],
     "action": "ALLOW",
     "requirement": {
         "verificationMethod": {

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -229,7 +229,7 @@ The IdP Routing Policy Object determines which IdP users are routed to. One IdP 
 
 ## Identifier Match Policy Object
 
-The Identifier Match Object determines which user profile attributes are used to check for matches between the incoming user and existing Okta User Profiles. One Identifier Match Policy object is created by default. You cannot create additional Identifier Match Policy objects.
+The Identifier Match Policy Object determines which user profile attributes are used to check for matches between the user entering the Identity Engine Pipeline and existing Okta User Profiles. One Identifier Match Policy object is created by default. You cannot create additional Identifier Match Policy objects.
 
 | Property | Type    | Description                                                                                  |
 |----------|---------|----------------------------------------------------------------------------------------------|
@@ -273,8 +273,8 @@ The Identifier Match Object determines which user profile attributes are used to
 
 | Property    | Type                                                                                  | Description                                                                                                                                |
 |-------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| name        | String                                                                                | Human-readable name for the Policy, configurable during creation or updating.                                                              |
-| id          | String                                                                                | Unique identifier for this Policy (read-only)                                                                                              |
+| name        | String                                                                                | Human-readable name for the Rule, configurable during creation or updating.                                                                |
+| id          | String                                                                                | Unique identifier for this Rule (read-only).                                                                                               |
 | type        | String                                                                                | Type of the policy. For Identifier Match Rule Objects, this needs to be `Okta:IdentifierMatch`.                                            |
 | priority    | Integer                                                                               | Used to determine which rules take precedence.                                                                                             |
 | conditions  | Array                                                                                 | No conditions are supported for this rule type, so this must be an empty array.                                                            |
@@ -285,12 +285,12 @@ The Identifier Match Object determines which user profile attributes are used to
 
 #### Identifier Match Rule Requirement Object
 
-| Property              | Type   | Description                                                                                                                                                                                                  |
-|-----------------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| identifyingAttributes | Array  | User profile attributes to match. For each, you need to specify the valid ID of a `userType` that the attribute is a part of, as well as the name of an `attribute` in the Profile schema of that User Type. |
-| onConflictingUser     | String | Whether to proceed if more than one match is found. Can be `ALLOW` or `DENY`.|                                                                                                                               |                                                                        |
+| Property              | Type   | Description                                                                                                                                 |
+|-----------------------|--------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| identifyingAttributes | Array  | User profile attributes to match. For each user profile attribute, you need to specify the `userType` ID, as well as the  `attribute` name. |
+| onConflictingUser     | String | Whether to proceed if more than one match is found. Can be `ALLOW` or `DENY`.|                                                              |                                                                       |
  
-### Identifier Match Rule Object
+### Identifier Match Rule Object Example
 
 ```json
 {

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -701,14 +701,20 @@ Mappings cannot be used with the following Policy types, which apply universally
 * Identifier Match
 * Unknown User
 
-#### Request Body
+#### Mappings Request Body
 
 | Property     | Type   | Description              |
 |--------------|--------|--------------------------|
 | resourceType | String | Must be `APP`.           |
 | resourceID   | String | A valid App Instance ID. |
 
-#### Usage Example
+#### Mappings Path Parameter
+
+| Property | Type   | Description                                           |
+|----------|--------|-------------------------------------------------------|
+| policyId | String | The ID of the Policy object to apply this mapping to. |
+
+#### Mappings Usage Example
 
 ##### Request
 
@@ -720,9 +726,8 @@ curl -v -X GET \
 -d '{
 	"resourceType": "APP",
 	"resourceId": "{{appInstanceId}}"
-}' 
+ }' 
 "https://${yourOktaDomain}/api/v1/policies/${policyId}/mappings"
-}'
 ```
 
 ##### Response

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -621,10 +621,10 @@ The Sign On Policy object determines which authentication factors to prompt user
 
 #### Sign On Rule Requirement Object
 
-| Property                  | Type   | Description                                                                                                                                         |
-|---------------------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `verificationMethod.type` | String | `CHAIN` or `ANY_FACTOR` to determine whether users should be prompted for a sequence of credentials or allowed to choose one credential from a set. |
-| chains                    | Array  | Array specifying the chain of factor types to require. Not required if `verificationMethod.type` is `ANY_FACTOR`.|                                  |      
+| Property                  | Type   | Description                                                                                                                |
+|---------------------------|--------|----------------------------------------------------------------------------------------------------------------------------|
+| `verificationMethod.type` | String | Currently, the only allowed value is `CHAIN`, which specifies that users should be prompted for a sequence of credentials. |
+| chains                    | Array  | Array specifying the chain of factor types to require. Not required if `verificationMethod.type` is `ANY_FACTOR`.          |                                 |      
 
 ### Sign On Rule Object Example
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -195,8 +195,6 @@ Okta Identity Engine introduces a set of new Policy and Rule objects that are di
 
 Default instances of each Policy type are created automatically when Okta Identity Engine is enabled for your org. Each of the default Policy objects also has a default Rule object that is created automatically.
 
-The `conditions` objects, which can be specified in Rule objects, are documented in the existing Policy API documentation at: <https://developer.okta.com/docs/reference/api/policy/#conditions>
-
 ### IdP Routing Policy Object
 
 The IdP Routing Policy object determines which IdP users are routed to. One IdP Routing Policy object is created by default. Additional IdP Routing Policy objects cannot be created. Currently, the only IdP you can configure for use with the Okta Identity Engine Pipeline is the Okta IdP, so that, although this object needs to exist, it cannot change the behavior of the pipeline.

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -722,17 +722,17 @@ The User Profile object determines which user profile attributes to require user
 
 ## User Profile Rule Object
 
-| Property    | Type                                                                          | Description                                                                           |
-|-------------|-------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
-| name        | String                                                                        | Human-readable name for the Rule, configurable during creation or updating.           |
-| id          | String                                                                        | Unique identifier for this Rule (read-only).                                          |
-| type        | String                                                                        | Type of the Rule. For Identifier Match Rule objects, this needs to be `Okta:SignOn`.  |
-| priority    | Integer                                                                       | Used to determine which Rules take. precedence.                                       |
-| conditions  | Array                                                                         | UserType, User, Group and various Device conditions are supported for this rule type. |
-| action      | String                                                                        | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.            |
-| requirement | [User Profile Rule Requirement Object](#user-profile-rule-requirement-object) | Specifies profile attributes to prompt user for.                                      |
-| status      | String                                                                        | `ACTIVE` or `INACTIVE`.                                                               |
-| default     | Boolean                                                                       | `true` for the first instance of this Rule, which gets created by default.            |
+| Property    | Type                                                                          | Description                                                                          |
+|-------------|-------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| name        | String                                                                        | Human-readable name for the Rule, configurable during creation or updating.          |
+| id          | String                                                                        | Unique identifier for this Rule (read-only).                                         |
+| type        | String                                                                        | Type of the Rule. For Identifier Match Rule objects, this needs to be `Okta:SignOn`. |
+| priority    | Integer                                                                       | Used to determine which Rules take. precedence.                                      |
+| conditions  | Array                                                                         | UserType and Group conditions are supported for this rule type.                      |
+| action      | String                                                                        | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.           |
+| requirement | [User Profile Rule Requirement Object](#user-profile-rule-requirement-object) | Specifies profile attributes to prompt user for.                                     |
+| status      | String                                                                        | `ACTIVE` or `INACTIVE`.                                                              |
+| default     | Boolean                                                                       | `true` for the first instance of this Rule, which gets created by default.           |
 
 #### User Profile Rule Requirement Object
 
@@ -751,7 +751,22 @@ The User Profile object determines which user profile attributes to require user
     "type": "Okta:UserProfile",
     "priority": 0,
     "action": "ALLOW",
-    "conditions": [],
+    "conditions": [
+        {
+            "key": "Okta:UserType",
+            "op": "IN_LIST",
+            "value": [
+            	"${userTypeId}"
+        	]
+        },
+        {
+            "key": "Okta:Group",
+            "op": "INTERSECTS",
+            "value": [
+                "${groupId}"
+            ]
+        }	
+    ],
     "requirement": {
         "preRegistrationInlineHooks": [
             {

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -180,7 +180,7 @@ See <https://developer.okta.com/docs/reference/api/policy/#policy-api-operations
 
 ## Okta Identity Engine Policy and Rule Objects
 
-Okta Identity Engine introduces a set of new Policy and Rule objects that are different from the existing Policy and API objects:
+Okta Identity Engine introduces a set of new Policy and Rule objects that are different from the existing Policy and Rule objects:
 
 * [IdP Routing Policy Object](#idp-routing-policy-object)
 * [IdP Routing Rule Object](#idp-routing-rule-object)

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -74,7 +74,7 @@ curl -v -X GET \
     "default": true,
     "_links": {
         "self": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst10xzYOyK9ux6v70g4",
             "hints": {
                 "allow": [
                     "GET",
@@ -83,7 +83,7 @@ curl -v -X GET \
             }
         },
         "rules": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4/rules",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst10xzYOyK9ux6v70g4/rules",
             "hints": {
                 "allow": [
                     "GET"
@@ -138,7 +138,7 @@ The IdP Routing Policy Object determines which IdP users are routed to. One IdP 
     "default": true,
     "_links": {
         "self": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst10xzYOyK9ux6v70g4",
             "hints": {
                 "allow": [
                     "GET",
@@ -147,7 +147,7 @@ The IdP Routing Policy Object determines which IdP users are routed to. One IdP 
             }
         },
         "rules": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4/rules",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst10xzYOyK9ux6v70g4/rules",
             "hints": {
                 "allow": [
                     "GET"
@@ -186,7 +186,7 @@ The IdP Routing Policy Object determines which IdP users are routed to. One IdP 
     "name": "Catch-all Rule",
     "id": "rul10y0LatXn0HP2p0g4",
     "type": "Okta:IdpRouting",
-    "priority": 2,
+    "priority": 0,
     "conditions": [],
     "action": "ALLOW",
     "requirement": {
@@ -197,7 +197,7 @@ The IdP Routing Policy Object determines which IdP users are routed to. One IdP 
     "default": false,
     "_links": {
         "self": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4/rules/rul10y0LatXn0HP2p0g4",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst10xzYOyK9ux6v70g4/rules/rul10y0LatXn0HP2p0g4",
             "hints": {
                 "allow": [
                     "GET",
@@ -207,7 +207,7 @@ The IdP Routing Policy Object determines which IdP users are routed to. One IdP 
             }
         },
         "deactivate": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4/rules/rul10y0LatXn0HP2p0g4/lifecycle/deactivate",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst10xzYOyK9ux6v70g4/rules/rul10y0LatXn0HP2p0g4/lifecycle/deactivate",
             "hints": {
                 "allow": [
                     "POST"
@@ -215,7 +215,7 @@ The IdP Routing Policy Object determines which IdP users are routed to. One IdP 
             }
         },
         "policy": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst10xzYOyK9ux6v70g4",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst10xzYOyK9ux6v70g4",
             "hints": {
                 "allow": [
                     "GET",
@@ -250,7 +250,7 @@ The Identifier Match Policy Object determines which user profile attributes are 
     "default": true,
     "_links": {
         "self": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst10y1rmKOjickDM0g4",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst10y1rmKOjickDM0g4",
             "hints": {
                 "allow": [
                     "GET",
@@ -259,7 +259,7 @@ The Identifier Match Policy Object determines which user profile attributes are 
             }
         },
         "rules": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst10y1rmKOjickDM0g4/rules",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst10y1rmKOjickDM0g4/rules",
             "hints": {
                 "allow": [
                     "GET"
@@ -297,7 +297,7 @@ The Identifier Match Policy Object determines which user profile attributes are 
     "name": "Catch-all Rule",
     "id": "rul10y292nt87pGec0g4",
     "type": "Okta:IdentifierMatch",
-    "priority": 1,
+    "priority": 0,
     "conditions": [
         {
             "key": "Okta:Identifier",
@@ -328,7 +328,7 @@ The Identifier Match Policy Object determines which user profile attributes are 
     "default": false,
     "_links": {
         "self": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst10y1rmKOjickDM0g4/rules/rul10y292nt87pGec0g4",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst10y1rmKOjickDM0g4/rules/rul10y292nt87pGec0g4",
             "hints": {
                 "allow": [
                     "GET",
@@ -338,7 +338,7 @@ The Identifier Match Policy Object determines which user profile attributes are 
             }
         },
         "deactivate": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst10y1rmKOjickDM0g4/rules/rul10y292nt87pGec0g4/lifecycle/deactivate",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst10y1rmKOjickDM0g4/rules/rul10y292nt87pGec0g4/lifecycle/deactivate",
             "hints": {
                 "allow": [
                     "POST"
@@ -346,7 +346,7 @@ The Identifier Match Policy Object determines which user profile attributes are 
             }
         },
         "policy": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst10y1rmKOjickDM0g4",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst10y1rmKOjickDM0g4",
             "hints": {
                 "allow": [
                     "GET",
@@ -381,7 +381,7 @@ The Unknown User Policy determines whether a user who has not been found to matc
     "default": true,
     "_links": {
         "self": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst10y3icArzJtWvf0g4",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst10y3icArzJtWvf0g4",
             "hints": {
                 "allow": [
                     "GET",
@@ -390,7 +390,7 @@ The Unknown User Policy determines whether a user who has not been found to matc
             }
         },
         "rules": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst10y3icArzJtWvf0g4/rules",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst10y3icArzJtWvf0g4/rules",
             "hints": {
                 "allow": [
                     "GET"
@@ -478,7 +478,7 @@ The Sign On Policy Object determines which authentication factors to prompt user
     "default": false,
     "_links": {
         "mappings": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst6v8jmmTIJdv6ms0g4/mappings",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst6v8jmmTIJdv6ms0g4/mappings",
             "hints": {
                 "allow": [
                     "GET"
@@ -486,7 +486,7 @@ The Sign On Policy Object determines which authentication factors to prompt user
             }
         },
         "self": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst6v8jmmTIJdv6ms0g4",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst6v8jmmTIJdv6ms0g4",
             "hints": {
                 "allow": [
                     "GET",
@@ -496,7 +496,7 @@ The Sign On Policy Object determines which authentication factors to prompt user
             }
         },
         "rules": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst6v8jmmTIJdv6ms0g4/rules",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst6v8jmmTIJdv6ms0g4/rules",
             "hints": {
                 "allow": [
                     "GET"
@@ -504,7 +504,7 @@ The Sign On Policy Object determines which authentication factors to prompt user
             }
         },
         "deactivate": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst6v8jmmTIJdv6ms0g4/lifecycle/deactivate",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst6v8jmmTIJdv6ms0g4/lifecycle/deactivate",
             "hints": {
                 "allow": [
                     "POST"
@@ -512,7 +512,7 @@ The Sign On Policy Object determines which authentication factors to prompt user
             }
         },
         "applications": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst6v8jmmTIJdv6ms0g4/app",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst6v8jmmTIJdv6ms0g4/app",
             "hints": {
                 "allow": [
                     "GET"
@@ -603,7 +603,7 @@ The User Profile Object determines which user profile attributes to require user
 | id       | String  | Unique identifier for this Policy (read-only).                                            |
 | name     | String  | Human-readable name for the Policy, configurable during creation or updating.             |
 | type     | String  | Type of the policy. For User Profile Policy objects, this needs to be `Okta:UserProfile`. |
-| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                                 |
+| status   | String  | `ACTIVE` or `INACTIVE`.                                                                   |
 | default  | Boolean | `true` for the first instance of this policy, which gets created by default.              |
 
 ### User Profile Policy Object Example
@@ -617,7 +617,7 @@ The User Profile Object determines which user profile attributes to require user
     "default": true,
     "_links": {
         "self": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst10y7ftlPBUWJzu0g4",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst10y7ftlPBUWJzu0g4",
             "hints": {
                 "allow": [
                     "GET",
@@ -626,7 +626,7 @@ The User Profile Object determines which user profile attributes to require user
             }
         },
         "rules": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst10y7ftlPBUWJzu0g4/rules",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst10y7ftlPBUWJzu0g4/rules",
             "hints": {
                 "allow": [
                     "GET"
@@ -665,7 +665,7 @@ The User Profile Object determines which user profile attributes to require user
 {
 	"name": "New Rule",
     "type": "Okta:UserProfile",
-    "priority": 1,
+    "priority": 0,
     "action": "ALLOW",
     "conditions": [],
     "requirement": {
@@ -745,7 +745,7 @@ curl -v -X GET \
     "id": "rsm6v8k4qjUvQgPsa0g4",
     "_links": {
         "application": {
-            "href": "https://idx.okta1.com/api/v1/apps/0oat3dEB15WDr5SW30g3",
+            "href": "https://${yourOktaDomain}/api/v1/apps/0oat3dEB15WDr5SW30g3",
             "hints": {
                 "allow": [
                     "GET",
@@ -755,7 +755,7 @@ curl -v -X GET \
             }
         },
         "self": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst6v8abMiZPFyVfY0g4/mappings/rsm6v8k4qjUvQgPsa0g4",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst6v8abMiZPFyVfY0g4/mappings/rsm6v8k4qjUvQgPsa0g4",
             "hints": {
                 "allow": [
                     "GET",
@@ -764,7 +764,7 @@ curl -v -X GET \
             }
         },
         "policy": {
-            "href": "https://idx.okta1.com/api/v1/policies/rst6v8abMiZPFyVfY0g4",
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst6v8abMiZPFyVfY0g4",
             "hints": {
                 "allow": [
                     "GET",

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -113,7 +113,7 @@ Okta Identity Engine introduces a set of new Policy and Rule objects that are di
 * [User Profile Policy Object](#user-profile-policy-object)
 * [User Profile Rule Object](#user-profile-rule-object)
 
-Default instances of each Policy type are created automatically when Okta Identity Engine is enabled for your org. Each of the default Policy objects also has a default rule that is created automatically.
+Default instances of each Policy type are created automatically when Okta Identity Engine is enabled for your org. Each of the default Policy objects also has a default Rule that is created automatically.
 
 ### IdP Routing Policy Object
 
@@ -165,12 +165,12 @@ The IdP Routing Policy Object determines which IdP users are routed to. One IdP 
 | name        | String                                                                      | Human-readable name for this Rule, configurable during creation or updating.        |
 | id          | String                                                                      | Unique identifier for this Rule (read-only).                                        |
 | type        | String                                                                      | Type of the Rule. For IdP Routing Rule objects, this needs to be `Okta:IdpRouting`. |
-| priority    | Integer                                                                     | Used to determine which rules take precedence.                                      |
-| conditions  | Array                                                                       | No conditions are supported for this rule type, so this must be an empty array.     |
+| priority    | Integer                                                                     | Used to determine which Rules take precedence.                                      |
+| conditions  | Array                                                                       | No conditions are supported for this Rule type, so this must be an empty array.     |
 | action      | String                                                                      | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.          |
 | requirement | [IdP Routing Rule Requirement Object](#idp-routing-rule-requirement-object) | Specifies the IdP to use.                                                           |
 | status      | String                                                                      | `ACTIVE`  or  `INACTIVE`.                                                           |
-| default     | Boolean                                                                     | `true` for the first instance of this rule, which gets created by default.          |
+| default     | Boolean                                                                     | `true` for the first instance of this Rule, which gets created by default.          |
 
 #### IdP Routing Rule Requirement Object
 
@@ -276,12 +276,12 @@ The Identifier Match Policy Object determines which user profile attributes are 
 | name        | String                                                                                | Human-readable name for the Rule, configurable during creation or updating.                                        |
 | id          | String                                                                                | Unique identifier for this Rule (read-only).                                                                       |
 | type        | String                                                                                | Type of the policy. For Identifier Match Rule Objects, this needs to be `Okta:IdentifierMatch`.                    |
-| priority    | Integer                                                                               | Used to determine which rules take precedence.                                                                     |
-| conditions  | Array                                                                                 | No conditions are supported for this rule type, so this must be an empty array.                                    |
+| priority    | Integer                                                                               | Used to determine which Rules take precedence.                                                                     |
+| conditions  | Array                                                                                 | Identifier and App conditions are supported for this Rule type.                                                    |
 | action      | String                                                                                | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.                                         |
 | requirement | [Identifier Match Rule Requirement Object](#identifier-match-rule-requirement-object) | Specifies the user profile attributes to match against, as well as the action to take in case of multiple matches. |
 | status      | String                                                                                | `ACTIVE`  or  `INACTIVE`.                                                                                          |
-| default     | Boolean                                                                               | `true` for the first instance of this rule, which gets created by default.                                         |
+| default     | Boolean                                                                               | `true` for the first instance of this Rule, which gets created by default.                                         |
 
 #### Identifier Match Rule Requirement Object
 
@@ -347,7 +347,7 @@ The Identifier Match Policy Object determines which user profile attributes are 
 
 ## Unknown User Policy Object
 
-The Unknown User Policy determines whether a user who has not been found to match with any existing Okta User Profiles is allowed to register and, if so, what User Type they should be assigned.
+The Unknown User Policy determines whether a user who has not been found to match with any existing Okta User Profiles is allowed to register and, if so, what User Type they should be assigned. One Unknown User Policy object is created by default. You cannot create additional Unknown User Policy objects.
 
 | Property | Type    | Description                                                                              |
 |----------|---------|------------------------------------------------------------------------------------------|
@@ -395,12 +395,12 @@ The Unknown User Policy determines whether a user who has not been found to matc
 | name        | String                                                                       | Human-readable name for the Rule, configurable during creation or updating.                        |
 | id          | String                                                                       | Unique identifier for this Rule (read-only)                                                        |
 | type        | String                                                                       | Type of the Rule. For Identifier Match Rule Objects, this needs to be `Okta:UnknownUser`.          |
-| priority    | Integer                                                                      | Used to determine which rules take precedence.                                                     |
-| conditions  | Array                                                                        | No conditions are supported for this rule type, so this must be an empty array.                    |
+| priority    | Integer                                                                      | Used to determine which Rules take precedence.                                                     |
+| conditions  | Array                                                                        | No conditions are supported for this Rule type, so this must be an empty array.                    |
 | action      | String                                                                       | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.                         |
 | requirement | [Unknown User Rule Requirement Object](#unknow-user-rule-requirement-object) | Specifies whether to allow an unknown user to register and, if so, what User Type to use for them. |
 | status      | String                                                                       | `ACTIVE`  or  `INACTIVE`.                                                                          |
-| default     | Boolean                                                                      | `true` for the first instance of this rule, which gets created by default.                         |
+| default     | Boolean                                                                      | `true` for the first instance of this Rule, which gets created by default.                         |
 
 #### Unknown User Rule Requirement Object
 
@@ -499,17 +499,17 @@ The Sign On Policy Object determines which authentication factors to prompt user
 
 ## Sign On Rule Object
 
-| Property    | Type                                                                | Description                                                                          |
-|-------------|---------------------------------------------------------------------|--------------------------------------------------------------------------------------|
-| name        | String                                                              | Human-readable name for the Rule, configurable during creation or updating.          |
-| id          | String                                                              | Unique identifier for this Rule (read-only).                                         |
-| type        | String                                                              | Type of the Rule. For Identifier Match Rule Objects, this needs to be `Okta:SignOn`. |
-| priority    | Integer                                                             | Used to determine which rules take precedence.                                       |
-| conditions  | Array                                                               | No conditions are supported for this rule type, so this must be an empty array.      |
-| action      | String                                                              | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.           |
-| requirement | [Sign On Rule Requirement Object](#sign-on-rule-requirement-object) | Specifies credentials to prompt user for.                                            |
-| status      | String                                                              | `ACTIVE`  or  `INACTIVE`.                                                            |
-| default     | Boolean                                                             | `true` for the first instance of this Rule, which gets created by default.           |
+| Property    | Type                                                                | Description                                                                           |
+|-------------|---------------------------------------------------------------------|---------------------------------------------------------------------------------------|
+| name        | String                                                              | Human-readable name for the Rule, configurable during creation or updating.           |
+| id          | String                                                              | Unique identifier for this Rule (read-only).                                          |
+| type        | String                                                              | Type of the Rule. For Identifier Match Rule Objects, this needs to be `Okta:SignOn`.  |
+| priority    | Integer                                                             | Used to determine which Rules take precedence.                                        |
+| conditions  | Array                                                               | UserType, User, Group and various Device conditions are supported for this rule type. |
+| action      | String                                                              | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.            |
+| requirement | [Sign On Rule Requirement Object](#sign-on-rule-requirement-object) | Specifies credentials to prompt user for.                                             |
+| status      | String                                                              | `ACTIVE`  or  `INACTIVE`.                                                             |
+| default     | Boolean                                                             | `true` for the first instance of this Rule, which gets created by default.            |
 
 #### Sign On Rule Requirement Object
 
@@ -599,17 +599,17 @@ The User Profile Object determines which user profile attributes to require user
 
 ## User Profile Rule Object
 
-| Property    | Type                                                                | Description                                                                          |
-|-------------|---------------------------------------------------------------------|--------------------------------------------------------------------------------------|
-| name        | String                                                              | Human-readable name for the Rule, configurable during creation or updating.          |
-| id          | String                                                              | Unique identifier for this Rule (read-only).                                         |
-| type        | String                                                              | Type of the Rule. For Identifier Match Rule Objects, this needs to be `Okta:SignOn`. |
-| priority    | Integer                                                             | Used to determine which rules take. precedence.                                      |
-| conditions  | Array                                                               | No conditions are supported for this Rule. type, so this must be an empty array.     |
-| action      | String                                                              | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.           |
-| requirement | [Sign On Rule Requirement Object](#sign-on-rule-requirement-object) | Specifies profile attributes to prompt user for.                                     |
-| status      | String                                                              | `ACTIVE`  or  `INACTIVE`.                                                            |
-| default     | Boolean                                                             | `true` for the first instance of this rule, which gets created by default.           |
+| Property    | Type                                                                          | Description                                                                           |
+|-------------|-------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
+| name        | String                                                                        | Human-readable name for the Rule, configurable during creation or updating.           |
+| id          | String                                                                        | Unique identifier for this Rule (read-only).                                          |
+| type        | String                                                                        | Type of the Rule. For Identifier Match Rule Objects, this needs to be `Okta:SignOn`.  |
+| priority    | Integer                                                                       | Used to determine which Rules take. precedence.                                       |
+| conditions  | Array                                                                         | UserType, User, Group and various Device conditions are supported for this rule type. |
+| action      | String                                                                        | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.            |
+| requirement | [User Profile Rule Requirement Object](#user-profile-rule-requirement-object) | Specifies profile attributes to prompt user for.                                      |
+| status      | String                                                                        | `ACTIVE`  or  `INACTIVE`.                                                             |
+| default     | Boolean                                                                       | `true` for the first instance of this Rule, which gets created by default.            |
 
 #### User Profile Rule Requirement Object
 
@@ -655,7 +655,7 @@ The User Profile Object determines which user profile attributes to require user
 ```
 ## Mappings Between Apps and Policies
 
-Mappings specify which Policies apply to which Apps. You call the `/policies/${policyId}/mappings` endpoint to set a mapping. You cannot update mappings once you have created them.
+Mappings specify which Policies apply to which Apps. You call the `/policies/${policyId}/mappings` endpoint to set a mapping. You cannot update mappings once you have created them. Only deletion is allowed.
 
 Mappings can be used with the following Policy types:
 
@@ -673,7 +673,7 @@ The following Policy types apply universally, and mappings cannot be used with t
 | Property     | Type   | Description              |
 |--------------|--------|--------------------------|
 | resourceType | String | Must be `APP`.           |
-| resourceID   | String | A valid App Instance ID. |
+| resourceId   | String | A valid App Instance ID. |
 
 #### Mappings Path Parameter
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -117,7 +117,7 @@ Default instances of each Policy type are created automatically when Okta Identi
 
 ### IdP Routing Policy Object
 
-This object determines which IdP end users are routed to. One IdP Routing Policy object is created by default. Additional IdP Routing Policy objects cannot be created. Currently, the only IdP you can configure for use with the Okta Identity Engine Pipeline is the Okta IdP, so that, although this object needs to exist, it cannot change the behavior of the pipeline.
+The IdP Routing Policy Object determines which IdP users are routed to. One IdP Routing Policy object is created by default. Additional IdP Routing Policy objects cannot be created. Currently, the only IdP you can configure for use with the Okta Identity Engine Pipeline is the Okta IdP, so that, although this object needs to exist, it cannot change the behavior of the pipeline.
 
 | Property | Type    | Description                                                                             |
 |----------|---------|-----------------------------------------------------------------------------------------|

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -12,7 +12,7 @@ During the Limited EA phase, Okta Identity Engine is enabled or disabled for an 
 
 API endpoints for listing, getting, creating, updating and deleting Policy and Rule objects function the same way in Okta Identity Engine as they do in the existing Okta `/policies` API; only the objects used are different, with Okta Identity Engine introducing a set of new Policy and Rule objects. See the [Okta Identity Engine Policy and Rule Objects](#okta-identity-enging-policy-and-rule-objects) section of this document for descriptions of the objects.
 
-Each Policy object, as well as a Rule for it, needs to exist, in order for Okta Identity Engine to function. One of each is created by default when Okta Identity Engine is enabled for an org.
+Each Policy object, as well as a related Rule object, needs to exist, in order for Okta Identity Engine to function. One of each is created by default when Okta Identity Engine is enabled for an org.
 
 A `/mappings` endpoint is used to set which Policies apply to which Apps. See the [Mappings Between Apps and Policies](#mappings-between-apps-and-policies) section of this document for a description of how to set mappings.
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -159,7 +159,7 @@ This object determines which IdP end users are routed to. One IdP Routing Policy
 
 ### IdP Routing Rule Object
 
-One IdP Routing Rule Object is created by default. Currently, the Okta Identity Provider is the only supported IdP.
+Currently, the Okta Identity Provider is the only supported IdP.
 
 | Property    | Type                                                                        | Description                                                                             |
 |-------------|-----------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
@@ -303,8 +303,6 @@ This object determines which user profile attributes are used to check for match
 }
 ```
 ## Identifier Match Rule Object
-
-One Identifier Match Rule Object is created by default.
 
 | Property    | Type                                                                                  | Description                                                                                                                                |
 |-------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
@@ -534,8 +532,6 @@ This object determines which credentials to prompt users for. One Sign On Policy
 
 ## Sign On Rule Object
 
-One Sign On Rule Object is created by default.
-
 | Property    | Type                                                                | Description                                                                            |
 |-------------|---------------------------------------------------------------------|----------------------------------------------------------------------------------------|
 | name        | String                                                              | Human-readable name for the Policy, configurable during creation or updating.          |
@@ -635,8 +631,6 @@ This object determines which profile attributes to require users to supply promp
 ```
 
 ## User Profile Rule Object
-
-One Sign On Rule Object is created by default.
 
 | Property    | Type                                                                | Description                                                                            |
 |-------------|---------------------------------------------------------------------|----------------------------------------------------------------------------------------|

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -686,3 +686,78 @@ This object determines which profile attributes to require users to supply promp
     }
 }
 ```
+## Mappings Between Apps and Policies
+
+Mappings specify which Policies apply to which Apps. You call the `/policies/${policyId}/mappings` endpoint to set a mapping. You cannot update mappings once you have created them.
+
+Mappings can be used with the following Policy types:
+* 
+* 
+
+Mappings cannot be used with the following Policy types because these Policies apply universally to all apps:
+
+* 
+* 
+
+#### Request Body
+
+| Property     | Type   | Description              |
+|--------------|--------|--------------------------|
+| resourceType | String | Must be `APP`.           |
+| resourceID   | String | A valid App Instance ID. |
+
+#### Usage Example
+
+##### Request
+
+```bash
+curl -v -X GET \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+-d '{
+	"resourceType": "APP",
+	"resourceId": "{{appInstanceId}}"
+}' 
+"https://${yourOktaDomain}/api/v1/policies/${policyId}/mappings"
+}'
+```
+
+##### Response
+
+```json
+{
+    "id": "rsm6v8k4qjUvQgPsa0g4",
+    "_links": {
+        "application": {
+            "href": "https://idx.okta1.com/api/v1/apps/0oat3dEB15WDr5SW30g3",
+            "hints": {
+                "allow": [
+                    "GET",
+                    "PUT",
+                    "DELETE"
+                ]
+            }
+        },
+        "self": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst6v8abMiZPFyVfY0g4/mappings/rsm6v8k4qjUvQgPsa0g4",
+            "hints": {
+                "allow": [
+                    "GET",
+                    "DELETE"
+                ]
+            }
+        },
+        "policy": {
+            "href": "https://idx.okta1.com/api/v1/policies/rst6v8abMiZPFyVfY0g4",
+            "hints": {
+                "allow": [
+                    "GET",
+                    "PUT",
+                    "DELETE"
+                ]
+            }
+        }
+    }
+}
+```

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -590,13 +590,13 @@ This object determines which credentials to prompt users for. One Sign On Policy
 
 This object determines which profile attributes to require users to supply prompt users for. One User Profile Policy Object is created by default.
 
-| Property | Type    | Description                                                                              |
-|----------|---------|------------------------------------------------------------------------------------------|
-| id       | String  | Unique identifier for this Policy (read-only).                                           |
-| name     | String  | Human-readable name for the Policy, configurable during creation or updating.            |
-| type     | String  | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:UserProfile`. |
-| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                                |
-| default  | Boolean | `true` for the first instance of this policy, which gets created by default.             |
+| Property | Type    | Description                                                                               |
+|----------|---------|-------------------------------------------------------------------------------------------|
+| id       | String  | Unique identifier for this Policy (read-only).                                            |
+| name     | String  | Human-readable name for the Policy, configurable during creation or updating.             |
+| type     | String  | Type of the policy. For User Profile Policy objects, this needs to be `Okta:UserProfile`. |
+| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                                 |
+| default  | Boolean | `true` for the first instance of this policy, which gets created by default.              |
 
 ### User Profile Policy Object Example
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -271,17 +271,17 @@ The Identifier Match Policy Object determines which user profile attributes are 
 ```
 ## Identifier Match Rule Object
 
-| Property    | Type                                                                                  | Description                                                                                                                                |
-|-------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| name        | String                                                                                | Human-readable name for the Rule, configurable during creation or updating.                                                                |
-| id          | String                                                                                | Unique identifier for this Rule (read-only).                                                                                               |
-| type        | String                                                                                | Type of the policy. For Identifier Match Rule Objects, this needs to be `Okta:IdentifierMatch`.                                            |
-| priority    | Integer                                                                               | Used to determine which rules take precedence.                                                                                             |
-| conditions  | Array                                                                                 | No conditions are supported for this rule type, so this must be an empty array.                                                            |
-| action      | String                                                                                | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.                                                                 |
-| requirement | [Identifier Match Rule Requirement Object](#identifier-match-rule-requirement-object) | Specifies the user profile attributes to match against and the action to take in case of conflict between multiple possible user profiles. |
-| status      | String                                                                                | `ACTIVE`  or  `INACTIVE`.                                                                                                                  |
-| default     | Boolean                                                                               | `true` for the first instance of this rule, which gets created by default.                                                                 |
+| Property    | Type                                                                                  | Description                                                                                                        |
+|-------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| name        | String                                                                                | Human-readable name for the Rule, configurable during creation or updating.                                        |
+| id          | String                                                                                | Unique identifier for this Rule (read-only).                                                                       |
+| type        | String                                                                                | Type of the policy. For Identifier Match Rule Objects, this needs to be `Okta:IdentifierMatch`.                    |
+| priority    | Integer                                                                               | Used to determine which rules take precedence.                                                                     |
+| conditions  | Array                                                                                 | No conditions are supported for this rule type, so this must be an empty array.                                    |
+| action      | String                                                                                | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.                                         |
+| requirement | [Identifier Match Rule Requirement Object](#identifier-match-rule-requirement-object) | Specifies the user profile attributes to match against, as well as the action to take in case of multiple matches. |
+| status      | String                                                                                | `ACTIVE`  or  `INACTIVE`.                                                                                          |
+| default     | Boolean                                                                               | `true` for the first instance of this rule, which gets created by default.                                         |
 
 #### Identifier Match Rule Requirement Object
 
@@ -422,7 +422,7 @@ The Unknown User Policy determines whether a user who has not been found to matc
         "noUserMatch": {
             "action": "REGISTER", 
             "registration": {
-                "defaultUserType": "{{defaultUserTypeId}}" 
+                "defaultUserType": "${userTypeId}}" 
             }
         }
     }
@@ -431,7 +431,7 @@ The Unknown User Policy determines whether a user who has not been found to matc
 
 ## Sign On Policy Object
 
-The sign on object determines which credentials to prompt users for. One Sign On Policy Object is created by default.
+The Sign On Policy Object determines which authentication factors to prompt users for, in order to authenticate them. One Sign On Policy Object is created by default.
 
 | Property | Type    | Description                                                                         |
 |----------|---------|-------------------------------------------------------------------------------------|
@@ -499,17 +499,17 @@ The sign on object determines which credentials to prompt users for. One Sign On
 
 ## Sign On Rule Object
 
-| Property    | Type                                                                | Description                                                                            |
-|-------------|---------------------------------------------------------------------|----------------------------------------------------------------------------------------|
-| name        | String                                                              | Human-readable name for the Policy, configurable during creation or updating.          |
-| id          | String                                                              | Unique identifier for this Policy (read-only)                                          |
-| type        | String                                                              | Type of the policy. For Identifier Match Rule Objects, this needs to be `Okta:SignOn`. |
-| priority    | Integer                                                             | Used to determine which rules take precedence.                                         |
-| conditions  | Array                                                               | No conditions are supported for this rule type, so this must be an empty array.        |
-| action      | String                                                              | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.             |
-| requirement | [Sign On Rule Requirement Object](#sign-on-rule-requirement-object) | Specifies credentials to prompt user for.                                              |
-| status      | String                                                              | `ACTIVE`  or  `INACTIVE`.                                                              |
-| default     | Boolean                                                             | `true` for the first instance of this rule, which gets created by default.             |
+| Property    | Type                                                                | Description                                                                          |
+|-------------|---------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| name        | String                                                              | Human-readable name for the Rule, configurable during creation or updating.          |
+| id          | String                                                              | Unique identifier for this Rule (read-only).                                         |
+| type        | String                                                              | Type of the Rule. For Identifier Match Rule Objects, this needs to be `Okta:SignOn`. |
+| priority    | Integer                                                             | Used to determine which rules take precedence.                                       |
+| conditions  | Array                                                               | No conditions are supported for this rule type, so this must be an empty array.      |
+| action      | String                                                              | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.           |
+| requirement | [Sign On Rule Requirement Object](#sign-on-rule-requirement-object) | Specifies credentials to prompt user for.                                            |
+| status      | String                                                              | `ACTIVE`  or  `INACTIVE`.                                                            |
+| default     | Boolean                                                             | `true` for the first instance of this Rule, which gets created by default.           |
 
 #### Sign On Rule Requirement Object
 
@@ -555,7 +555,7 @@ The sign on object determines which credentials to prompt users for. One Sign On
 
 ## User Profile Policy Object
 
-The User Profile Object determines which profile attributes to require users to supply prompt users for. One User Profile Policy Object is created by default.
+The User Profile Object determines which user profile attributes to require users to supply. One User Profile Policy Object is created by default.
 
 | Property | Type    | Description                                                                               |
 |----------|---------|-------------------------------------------------------------------------------------------|
@@ -599,17 +599,17 @@ The User Profile Object determines which profile attributes to require users to 
 
 ## User Profile Rule Object
 
-| Property    | Type                                                                | Description                                                                            |
-|-------------|---------------------------------------------------------------------|----------------------------------------------------------------------------------------|
-| name        | String                                                              | Human-readable name for the Policy, configurable during creation or updating.          |
-| id          | String                                                              | Unique identifier for this Policy (read-only)                                          |
-| type        | String                                                              | Type of the policy. For Identifier Match Rule Objects, this needs to be `Okta:SignOn`. |
-| priority    | Integer                                                             | Used to determine which rules take precedence.                                         |
-| conditions  | Array                                                               | No conditions are supported for this rule type, so this must be an empty array.        |
-| action      | String                                                              | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.             |
-| requirement | [Sign On Rule Requirement Object](#sign-on-rule-requirement-object) | Specifies credentials to prompt user for.                                              |
-| status      | String                                                              | `ACTIVE`  or  `INACTIVE`.                                                              |
-| default     | Boolean                                                             | `true` for the first instance of this rule, which gets created by default.             |
+| Property    | Type                                                                | Description                                                                          |
+|-------------|---------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| name        | String                                                              | Human-readable name for the Rule, configurable during creation or updating.          |
+| id          | String                                                              | Unique identifier for this Rule (read-only).                                         |
+| type        | String                                                              | Type of the Rule. For Identifier Match Rule Objects, this needs to be `Okta:SignOn`. |
+| priority    | Integer                                                             | Used to determine which rules take. precedence.                                      |
+| conditions  | Array                                                               | No conditions are supported for this Rule. type, so this must be an empty array.     |
+| action      | String                                                              | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.           |
+| requirement | [Sign On Rule Requirement Object](#sign-on-rule-requirement-object) | Specifies profile attributes to prompt user for.                                     |
+| status      | String                                                              | `ACTIVE`  or  `INACTIVE`.                                                            |
+| default     | Boolean                                                             | `true` for the first instance of this rule, which gets created by default.           |
 
 #### User Profile Rule Requirement Object
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -264,13 +264,13 @@ Currently, the Okta Identity Provider is the only supported IdP.
 
 This object determines which user profile attributes are used to check for matches between the incoming user and existing user profiles. One Identifier Match Policy object is created by default. You cannot create additional Identifier Match Policy objects.
 
-| Property | Type    | Description                                                                             |
-|----------|---------|-----------------------------------------------------------------------------------------|
-| id       | String  | Unique identifier for this Policy (read-only).                                           |
-| name     | String  | Human-readable name for the Policy, configurable during creation or updating.           |
-| type     | String  | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:IdpRouting`. |
-| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                                            |
-| default  | Boolean | `true` for the first instance of this policy, which gets created by default.            |
+| Property | Type    | Description                                                                                  |
+|----------|---------|----------------------------------------------------------------------------------------------|
+| id       | String  | Unique identifier for this Policy (read-only).                                               |
+| name     | String  | Human-readable name for the Policy, configurable during creation or updating.                |
+| type     | String  | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:IdentifierMatch`. |
+| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                                    |
+| default  | Boolean | `true` for the first instance of this policy, which gets created by default.                 |
 
 ### Identifier Match Policy Object Example
 
@@ -462,7 +462,7 @@ the Unknown User Policy is evaluated if a match was not found with an existing U
 }
 ```
 
-## Sign-On Policy Object
+## Sign On Policy Object
 
 This object determines which credentials to prompt users for. One Sign On Policy Object is created by default.
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -734,10 +734,10 @@ The User Profile object determines which user profile attributes to require user
 
 #### User Profile Rule Requirement Object
 
-| Property                   | Type   | Description                                                                                                                                                                                                                                    |
-|----------------------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| preRegistrationInlineHooks | String | Optional. The valid ID of an Inline Hook. Sets a Registration Inline Hook to invoke.                                                                                                                                                           |
-| profileAttributes          | Array  | Array specifying the `label` and `name` of each User Profile Attribute that should be collected from the user. `label` is human-readable text that can be displayed to the user in a web form. `name` is the name of a User Profile Attribute. |
+| Property                   | Type  | Description                                                                                                                                                                                                                                    |
+|----------------------------|-------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| preRegistrationInlineHooks | Array | Optional. An array that can currently contain only one element. The element must be the unique ID of a Registration Inline Hook to invoke.                                                                                                     |
+| profileAttributes          | Array | Array specifying the `label` and `name` of each User Profile Attribute that should be collected from the user. `label` is human-readable text that can be displayed to the user in a web form. `name` is the name of a User Profile Attribute. |
 
 ### User Profile Rule Object Example
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -8,11 +8,11 @@ title: Okta Identity Engine Policy API
 
 Okta Identity Engine adds new Policy objects to the Okta `/policies` API, to control and configure the behavior of the steps of the Okta Identity Engine Pipeline.
 
-During the Limited EA phase, Okta Identity Engine is enabled or disabled for an org as a whole. If Okta Identity Engine is enabled for an org, these new Policies control the pipeline end users progress through when accessing OpenID Connect apps. You cannot mix old Policy and Rule objects with new Okta Identity Engine objects; old Policy and Rule objects do not affect the new pipeline.
+During the Limited EA phase, Okta Identity Engine is enabled or disabled for an org as a whole. If Okta Identity Engine is enabled for an org, these new Policies control the pipeline that end users progress through when accessing OpenID Connect apps. You cannot mix old Policy and Rule objects with new Okta Identity Engine objects; old Policy and Rule objects do not affect the new pipeline.
 
 API endpoints for creating, getting, and updating Policy and Rule objects function the same way in Okta Identity Engine as they do in the existing Okta `/policies` API; only the objects used are different, with Okta Identity Engine introducing a set of new Policy and Rule objects. See the [Okta Identity Engine Policy Objects](#okta-identity-enging-policy-objects) section of this document for descriptions of the objects.
 
-To enable the Okta Identity Engine Pipeline, you need to create at least one of each of the defined Okta Identity Engine Policy objects, and at least one Rule object for each Policy.
+To enable the Okta Identity Engine Pipeline, you need to create at least one of each of the defined Okta Identity Engine Policy objects, and at least one Rule object for each Policy object.
 
 ## Policies API Operations
 
@@ -106,8 +106,8 @@ This API uses the following objects:
 * [Unknown User Rule Object](#unknown-user-rule-object)
 * [Sign On Policy Object](#sign-on-policy-object)
 * [Sign On Rule Object](#sign-on-rule-object)
-
-<!-- Add one routing and one rule object for each of the OIE policy types-->
+* [User Profile Policy Object](#user-profile-policy-object)
+* [User Profile Rule Object](#user-profile-rule-object)
 
 Default instances of each Policy type are created automatically when Okta Identity Engine is enabled for your org. Each of those default Policy objects also has a default rule that is created automatically.
 
@@ -467,13 +467,13 @@ One Unknown User Rule Object is created by default.
 
 This object determines which credentials to prompt users for. One Sign On Policy Object is created by default.
 
-| Property | Type    | Description                                                                             |
-|----------|---------|-----------------------------------------------------------------------------------------|
-| id       | String  | Unique identifier for this Policy (read-only).                                           |
-| name     | String  | Human-readable name for the Policy, configurable during creation or updating.           |
+| Property | Type    | Description                                                                         |
+|----------|---------|-------------------------------------------------------------------------------------|
+| id       | String  | Unique identifier for this Policy (read-only).                                      |
+| name     | String  | Human-readable name for the Policy, configurable during creation or updating.       |
 | type     | String  | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:SignOn`. |
-| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                                            |
-| default  | Boolean | `true` for the first instance of this policy, which gets created by default.            |
+| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                           |
+| default  | Boolean | `true` for the first instance of this policy, which gets created by default.        |
 
 ### Sign-On Policy Object Example
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -14,6 +14,8 @@ API endpoints for creating, getting, and updating Policy and Rule objects functi
 
 Each Policy object, as well as a Rule for it, needs to exist, in order for Okta Identity Engine to function. One of each is created by default when Okta Identity Engine is enabled for an org.
 
+A `mappings` endpoint is used to set which Policies apply to which Apps. See [Mappings Between Apps and Policies](#mappings-between-apps-and-policies) below for information.
+
 ## Policies API Operations
 
 API endpoints for creating, getting, and updating Policy and Rule objects function the same way in Okta Identity Engine as they do in the existing Okta `/policies` API. The API endpoints support the following operations:

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -307,7 +307,7 @@ The IdP Routing Policy object determines which IdP users are routed to. One IdP 
 }
 ```
 
-## Identifier Match Policy Object
+### Identifier Match Policy Object
 
 The Identifier Match Policy object determines which user profile attributes are used to check for matches between the user entering the Identity Engine Pipeline and existing Okta User Profiles. One Identifier Match Policy object is created by default. You cannot create additional Identifier Match Policy objects.
 
@@ -349,7 +349,7 @@ The Identifier Match Policy object determines which user profile attributes are 
     }
 }
 ```
-## Identifier Match Rule Object
+### Identifier Match Rule Object
 
 | Property    | Type                                                                                  | Description                                                                                                        |
 |-------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
@@ -440,7 +440,7 @@ The Identifier Match Policy object determines which user profile attributes are 
 }
 ```
 
-## Unknown User Policy Object
+### Unknown User Policy Object
 
 The Unknown User Policy determines whether a user who has not been found to match with any existing Okta User Profiles is allowed to register and, if so, what User Type they should be assigned. One Unknown User Policy object is created by default. You cannot create additional Unknown User Policy objects.
 
@@ -483,7 +483,7 @@ The Unknown User Policy determines whether a user who has not been found to matc
 }
 ```
 
-## Unknown User Rule Object
+### Unknown User Rule Object
 
 | Property    | Type                                                                         | Description                                                                                        |
 |-------------|------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
@@ -537,7 +537,7 @@ The Unknown User Policy determines whether a user who has not been found to matc
 }
 ```
 
-## Sign On Policy Object
+### Sign On Policy Object
 
 The Sign On Policy object determines which authentication factors to prompt users for, in order to authenticate them. One Sign On Policy object is created by default.
 
@@ -605,7 +605,7 @@ The Sign On Policy object determines which authentication factors to prompt user
 }
 ```
 
-## Sign On Rule Object
+### Sign On Rule Object
 
 | Property    | Type                                                                | Description                                                                 |
 |-------------|---------------------------------------------------------------------|-----------------------------------------------------------------------------|
@@ -676,7 +676,7 @@ The Sign On Policy object determines which authentication factors to prompt user
 }
 ```
 
-## User Profile Policy Object
+### User Profile Policy Object
 
 The User Profile object determines which user profile attributes to require users to supply. One User Profile Policy object is created by default.
 
@@ -720,7 +720,7 @@ The User Profile object determines which user profile attributes to require user
 
 ```
 
-## User Profile Rule Object
+### User Profile Rule Object
 
 | Property    | Type                                                                          | Description                                                                          |
 |-------------|-------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -347,7 +347,7 @@ The Identifier Match Policy Object determines which user profile attributes are 
 
 ## Unknown User Policy Object
 
-The Unknown User Policy is evaluated if a match was not found with an existing User Profile and determines whether the user is allowed to register and, if so, what User Type they should be assigned.
+The Unknown User Policy determines whether a user who has not been found to match with any existing Okta User Profiles is allowed to register and, if so, what User Type they should be assigned.
 
 | Property | Type    | Description                                                                              |
 |----------|---------|------------------------------------------------------------------------------------------|

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -35,7 +35,7 @@ API endpoints function the same way in Okta Identity Engine as they do in the ex
 
 <ApiOperation method="get" url="/policies/${policyId}" />
 
-Given a `policyId` identifier, returns a [Policy Object](#okta-identity-engine-policy-objects).
+Given a `policyId` identifier, returns a [Policy Object](#okta-identity-engine-policy-and-rule-objects).
 
 #### Request Body
 
@@ -49,7 +49,7 @@ None
 
 #### Response Body
 
-A [Policy Object](#okta-identity-engine-policy-objects).
+A [Policy Object](#okta-identity-engine-policy-and-rule-objects).
 
 #### Usage Example
 
@@ -87,6 +87,86 @@ curl -v -X GET \
             "hints": {
                 "allow": [
                     "GET"
+                ]
+            }
+        }
+    }
+}
+```
+### Sample Operation: Get Rule
+
+<ApiOperation method="get" url="/policies/${policyId}/rules/${ruleId}" />
+
+Given a `policyId` identifier and a `ruleId`, returns a [Rule Object](#okta-identity-engine-policy-and-rule-objects).
+
+#### Request Body
+
+| Property | Type   | Description                          |
+|----------|--------|--------------------------------------|
+| policyId | String | The unique identifier of the Policy. |
+| ruleId   | String | The unique identifier of a Rule.     |
+
+#### Request Query Parameters
+
+None
+
+#### Response Body
+
+A [Rule Object](#okta-identity-engine-policy-and-rule-objects).
+
+#### Usage Example
+
+##### Request
+
+```bash
+curl -v -X GET \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+"https://${yourOktaDomain}/api/v1/policies/${policyId}/rules/${ruleId}"
+```
+
+##### Response
+
+```json
+{
+    "name": "Catch-all Rule",
+    "id": "rul10y0LatXn0HP2p0g4",
+    "type": "Okta:IdpRouting",
+    "priority": 0,
+    "conditions": [],
+    "action": "ALLOW",
+    "requirement": {
+        "idpId": "OKTA",
+        "type": "okta_idp"
+    },
+    "status": "ACTIVE",
+    "default": false,
+    "_links": {
+        "self": {
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst10xzYOyK9ux6v70g4/rules/rul10y0LatXn0HP2p0g4",
+            "hints": {
+                "allow": [
+                    "GET",
+                    "PUT",
+                    "DELETE"
+                ]
+            }
+        },
+        "deactivate": {
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst10xzYOyK9ux6v70g4/rules/rul10y0LatXn0HP2p0g4/lifecycle/deactivate",
+            "hints": {
+                "allow": [
+                    "POST"
+                ]
+            }
+        },
+        "policy": {
+            "href": "https://${yourOktaDomain}/api/v1/policies/rst10xzYOyK9ux6v70g4",
+            "hints": {
+                "allow": [
+                    "GET",
+                    "PUT"
                 ]
             }
         }

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -160,17 +160,17 @@ The IdP Routing Policy Object determines which IdP users are routed to. One IdP 
 
 ### IdP Routing Rule Object
 
-| Property    | Type                                                                        | Description                                                                             |
-|-------------|-----------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
-| name        | String                                                                      | Human-readable name for the Policy, configurable during creation or updating.           |
-| id          | String                                                                      | Unique identifier for this Policy (read-only)                                           |
-| type        | String                                                                      | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:IdpRouting`. |
-| priority    | Integer                                                                     | Used to determine which rules take precedence.                                          |
-| conditions  | Array                                                                       | No conditions are supported for this rule type, so this must be an empty array.         |
-| action      | String                                                                      | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.              |
-| requirement | [IdP Routing Rule Requirement Object](#idp-routing-rule-requirement-object) | Specifies the IdP to use.                                                               |
-| status      | String                                                                      | `ACTIVE`  or  `INACTIVE`.                                                                            |
-| default     | Boolean                                                                     | `true` for the first instance of this rule, which gets created by default.              |
+| Property    | Type                                                                        | Description                                                                         |
+|-------------|-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| name        | String                                                                      | Human-readable name for this Rule, configurable during creation or updating.        |
+| id          | String                                                                      | Unique identifier for this Rule (read-only).                                        |
+| type        | String                                                                      | Type of the Rule. For IdP Routing Rule objects, this needs to be `Okta:IdpRouting`. |
+| priority    | Integer                                                                     | Used to determine which rules take precedence.                                      |
+| conditions  | Array                                                                       | No conditions are supported for this rule type, so this must be an empty array.     |
+| action      | String                                                                      | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.          |
+| requirement | [IdP Routing Rule Requirement Object](#idp-routing-rule-requirement-object) | Specifies the IdP to use.                                                           |
+| status      | String                                                                      | `ACTIVE`  or  `INACTIVE`.                                                           |
+| default     | Boolean                                                                     | `true` for the first instance of this rule, which gets created by default.          |
 
 #### IdP Routing Rule Requirement Object
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -257,7 +257,7 @@ One IdP Routing Rule Object is created by default. Currently, the Okta Identity 
 
 ## Identifier Match Policy Object
 
-This object determines which user profile attributes are used to check for matches between the user and existing user progiles. One Identifier Match Policy object is created by default.
+This object determines which user profile attributes are used to check for matches between the user and existing user profiles. One Identifier Match Policy object is created by default. You cannot create additional Identifier Match Policy objects.
 
 | Property | Type    | Description                                                                             |
 |----------|---------|-----------------------------------------------------------------------------------------|
@@ -387,7 +387,7 @@ Evaluated if a match was not found with an existing User Profile, the Unknown Us
 | status   | String  | 'ACTIVE' or                                                                             |
 | default  | Boolean | `True` for the first instance of this policy, which gets created by default.            |
 
-### Identifier Match Policy Object Example
+### Unknown User Policy Object Example
 
 ```json
 {
@@ -418,3 +418,44 @@ Evaluated if a match was not found with an existing User Profile, the Unknown Us
 }
 ```
 
+## Unknown User Rule Object
+
+One Unknown User Rule Object is created by default.
+
+| Property    | Type                                                                                  | Description                                                                                                                                |
+|-------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| name        | String                                                                                | Human-readable name for the Policy, configurable during creation or updating.                                                              |
+| id          | String                                                                                | Unique identifier for this Policy (read-only)                                                                                              |
+| type        | String                                                                                | Type of the policy. For Identifier Match Rule Objects, this needs to be `Okta:UnknownUser`.                                            |
+| priority    | Integer                                                                               | Used to determine which rules take precedence.                                                                                             |
+| conditions  | Array                                                                                 | No conditions are supported for this rule type, so this must be an empty array.                                                            |
+| action      | String                                                                                | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.                                                                 |
+| requirement | [Unknown User Rule Requirement Object](#unknow-user-rule-requirement-object) | Specifies whether to allow an unknown user to register and, if so, what User Type to use for them. |
+| status      | String                                                                                | 'ACTIVE' or                                                                                                                                |
+| default     | Boolean                                                                               | `True` for the first instance of this rule, which gets created by default.                                                                 |
+
+#### Unkown User Rule Requirement Object
+
+| Property                                   | Type   | Description                                                                                                                                                            |
+|--------------------------------------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `noUserMatch.action`                       | String | `REGISTER` or `DENY` to determine whether unknown users should be allowed to register.                                                                                 |
+| `noUserMatch.registration.defaultUserType` | String | Valid ID of a User Type. Sets the User Type to enroll unknown users as, if you have allowed unknown users to register. Not required if `noUserMatch.action` is `DENY`. |      
+### Unknown User Rule Object Example
+
+```json
+{
+    "name": "New Rule",
+    "type": "Okta:UnknownUser",
+    "priority": 0,
+    "action": "ALLOW",
+    "conditions": [], 
+    "requirement": {
+        "noUserMatch": {
+            "action": "REGISTER", 
+            "registration": {
+                "defaultUserType": "{{defaultUserTypeId}}" 
+            }
+        }
+    }
+}
+```

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -288,7 +288,7 @@ The Identifier Match Policy Object determines which user profile attributes are 
 | Property                   | Type   | Description                                                                                                                                 |
 |----------------------------|--------|---------------------------------------------------------------------------------------------------------------------------------------------|
 | identifyingAttributes      | Array  | User profile attributes to match. For each user profile attribute, you need to specify the `userType` ID, as well as the  `attribute` name. |
-| `onConflictingUser.action` | String | Whether to proceed if more than one match is found. Currently, only `DENY` is supported.||                                                  |
+| `onConflictingUser.action` | String | Whether to proceed if more than one match is found. Currently only `DENY` is supported.||                                                  |
  
 ### Identifier Match Rule Object Example
 
@@ -298,7 +298,20 @@ The Identifier Match Policy Object determines which user profile attributes are 
     "id": "rul10y292nt87pGec0g4",
     "type": "Okta:IdentifierMatch",
     "priority": 1,
-    "conditions": [],
+    "conditions": [
+        {
+            "key": "Okta:Identifier",
+            "op": "STRING_ENDS_WITH",
+            "value": "idx.com"
+        },
+        {
+            "key": "Okta:AppInstance",
+            "op": "IN_LIST",
+            "value": [
+            	"${appInstanceId}"
+        	]
+        }
+    ],
     "action": "ALLOW",
     "requirement": {
         "identifyingAttributes": [

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -147,33 +147,24 @@ This object determines which IdP end users are routed to. You need to create one
 
 ### IdP Routing Rule Object
 
-You need to create at least one IdP Routing Rule Object. Currently, the Okta Identity Provider is the only supported IdP, and the only supported value for the `requirement` property of this rule is:
+You need to create at least one IdP Routing Rule Object. Currently, the Okta Identity Provider is the only supported IdP, and the only supported value for the `requirement.type` property of this rule is `okta_idp`.
 
-```json
-{
-    "idpId": "OKTA",
-    "type": "okta_idp"
-}
-```
-
-
-| Property | Type   | Description |
-|----------|--------|-------------|
-| name     | String |             |
-| id       |        |             |
-| type     |        |             |
-| priority |        |             |
-| conditions | Array ||
-| action | String | Either `ALLOW` or `DENY`. |
-| requirement | An [IdP Routing Rule Requirement Object](#idp-routing-rule-requirement-object). |
-
+| Property    | Type                                                                            | Description               |
+|-------------|---------------------------------------------------------------------------------|---------------------------|
+| name        | String                                                                          |                           |
+| id          |                                                                                 |                           |
+| type        |                                                                                 |                           |
+| priority    |                                                                                 |                           |
+| conditions  | Array                                                                           |                           |
+| action      | String                                                                          | Either `ALLOW` or `DENY`. |
+| requirement | An [IdP Routing Rule Requirement Object](#idp-routing-rule-requirement-object). |                           |
 
 #### IdP Routing Rule Requirement Object
 
 | Property | Type   | Description |
 |----------|--------|-------------|
 | idpId    | String |             |
-| type     |        |             |
+| type     | String |             |
  
 ### IdP Routing Rule Object
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -359,7 +359,7 @@ The Identifier Match Policy object determines which user profile attributes are 
 | id          | String                                                                                | Unique identifier for this Rule (read-only).                                                                       |
 | type        | String                                                                                | Type of the policy. For Identifier Match Rule objects, this needs to be `Okta:IdentifierMatch`.                    |
 | priority    | Integer                                                                               | Used to determine which Rules take precedence.                                                                     |
-| conditions  | Array                                                                                 | Identifier and App conditions are supported for this Rule type.                                                    |
+| conditions  | Array                                                                                 | User Type and Group conditions are supported for this Rule type.                                                    |
 | action      | String                                                                                | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.                                         |
 | requirement | [Identifier Match Rule Requirement Object](#identifier-match-rule-requirement-object) | Specifies the user profile attributes to match against, as well as the action to take in case of multiple matches. |
 | status      | String                                                                                | `ACTIVE`  or  `INACTIVE`.                                                                                          |
@@ -382,17 +382,19 @@ The Identifier Match Policy object determines which user profile attributes are 
     "priority": 0,
     "conditions": [
         {
-            "key": "Okta:Identifier",
-            "op": "STRING_ENDS_WITH",
-            "value": "idx.com"
-        },
-        {
-            "key": "Okta:AppInstance",
+            "key": "Okta:UserType",
             "op": "IN_LIST",
             "value": [
-            	"${appInstanceId}"
+            	"${userTypeId}"
         	]
-        }
+        },
+        {
+            "key": "Okta:Group",
+            "op": "INTERSECTS",
+            "value": [
+                "${groupId}"
+            ]
+        }	
     ],
     "action": "ALLOW",
     "requirement": {

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -120,10 +120,10 @@ This object determines which IdP end users are routed to. One IdP Routing Policy
 
 | Property | Type    | Description                                                                             |
 |----------|---------|-----------------------------------------------------------------------------------------|
-| id       | String  | Unique identifier for this Policy (read-only).                                           |
+| id       | String  | Unique identifier for this Policy (read-only).                                          |
 | name     | String  | Human-readable name for the Policy, configurable during creation or updating.           |
 | type     | String  | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:IdpRouting`. |
-| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                                            |
+| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                               |
 | default  | Boolean | `true` for the first instance of this policy, which gets created by default.            |
 
 ### IdP Routing Object Example
@@ -159,7 +159,7 @@ This object determines which IdP end users are routed to. One IdP Routing Policy
 
 ### IdP Routing Rule Object
 
-One IdP Routing Rule Object is created by default. Currently, the Okta Identity Provider is the only supported IdP, and the only supported value for the `requirement.type` property of this rule is `okta_idp`.
+One IdP Routing Rule Object is created by default. Currently, the Okta Identity Provider is the only supported IdP.
 
 | Property    | Type                                                                        | Description                                                                             |
 |-------------|-----------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
@@ -175,10 +175,10 @@ One IdP Routing Rule Object is created by default. Currently, the Okta Identity 
 
 #### IdP Routing Rule Requirement Object
 
-| Property | Type   | Description         |
-|----------|--------|---------------------|
-| idpId    | String | Must be 'OKTA'.     |
-| type     | String | Must be `okta_idp`. |
+| Property | Type   | Description                    |
+|----------|--------|--------------------------------|
+| idpId    | String | Currently, must be 'OKTA'.     |
+| type     | String | Currently, must be `okta_idp`. |
  
 ### IdP Routing Rule Object
 
@@ -262,7 +262,7 @@ One IdP Routing Rule Object is created by default. Currently, the Okta Identity 
 
 ## Identifier Match Policy Object
 
-This object determines which user profile attributes are used to check for matches between the user and existing user profiles. One Identifier Match Policy object is created by default. You cannot create additional Identifier Match Policy objects.
+This object determines which user profile attributes are used to check for matches between the incoming user and existing user profiles. One Identifier Match Policy object is created by default. You cannot create additional Identifier Match Policy objects.
 
 | Property | Type    | Description                                                                             |
 |----------|---------|-----------------------------------------------------------------------------------------|
@@ -320,10 +320,10 @@ One Identifier Match Rule Object is created by default.
 
 #### Identifier Match Rule Requirement Object
 
-| Property              | Type   | Description                                                                                                                                                                                                                             |
-|-----------------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| identifyingAttributes | Array  | User profile attributes to match. For each, you need to specify the valid ID of a `userType` that the attribute is a part of, as well as the name of the `attribute` that is included in the User Profile Attributes of that User Type. |
-| onConflictingUser     | String | Whether to proceed if more than one match is found. Can be `ALLOW` or `DENY`.                                                                                                                                                           |                                                                            |
+| Property              | Type   | Description                                                                                                                                                                                                  |
+|-----------------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| identifyingAttributes | Array  | User profile attributes to match. For each, you need to specify the valid ID of a `userType` that the attribute is a part of, as well as the name of an `attribute` in the Profile schema of that User Type. |
+| onConflictingUser     | String | Whether to proceed if more than one match is found. Can be `ALLOW` or `DENY`.|                                                                                                                               |                                                                        |
  
 ### Identifier Match Rule Object
 
@@ -382,7 +382,7 @@ One Identifier Match Rule Object is created by default.
 
 ## Unknown User Policy Object
 
-Evaluated if a match was not found with an existing User Profile, the Unknown User Policy determines whether is allowed to register and, if so, what User Type should be used for them.
+the Unknown User Policy is evaluated if a match was not found with an existing User Profile and determines whether the user is allowed to register and, if so, what User Type they should be assigned.
 
 | Property | Type    | Description                                                                             |
 |----------|---------|-----------------------------------------------------------------------------------------|
@@ -424,8 +424,6 @@ Evaluated if a match was not found with an existing User Profile, the Unknown Us
 ```
 
 ## Unknown User Rule Object
-
-One Unknown User Rule Object is created by default.
 
 | Property    | Type                                                                                  | Description                                                                                                                                |
 |-------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
@@ -552,10 +550,10 @@ One Sign On Rule Object is created by default.
 
 #### Sign On Rule Requirement Object
 
-| Property                  | Type   | Description                                                                                                                            |
-|---------------------------|--------|----------------------------------------------------------------------------------------------------------------------------------------|
-| `verificationMethod.type` | String | `CHAIN` or `ANY_FACTOR` to determine whether users should be prompted for a sequence of credentials or allowed to choose one of a set. |
-| chains                    | Array  | Array specifying the chain of factor types to require. Not required if `verificationMethod.type` is `ANY_FACTOR`.                      |      
+| Property                  | Type   | Description                                                                                                                                         |
+|---------------------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `verificationMethod.type` | String | `CHAIN` or `ANY_FACTOR` to determine whether users should be prompted for a sequence of credentials or allowed to choose one credential from a set. |
+| chains                    | Array  | Array specifying the chain of factor types to require. Not required if `verificationMethod.type` is `ANY_FACTOR`.                                   |                 |      
 
 ### Sign On Rule Object Example
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -206,7 +206,7 @@ The IdP Routing Policy object determines which IdP users are routed to. One IdP 
 | id       | String  | Unique identifier for this Policy (read-only).                                          |
 | name     | String  | Human-readable name for the Policy, configurable during creation or updating.           |
 | type     | String  | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:IdpRouting`. |
-| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                               |
+| status   | String  | `ACTIVE` or `INACTIVE`.                                                                 |
 | default  | Boolean | `true` for the first instance of this policy, which gets created by default.            |
 
 ### IdP Routing Object Example
@@ -251,7 +251,7 @@ The IdP Routing Policy object determines which IdP users are routed to. One IdP 
 | conditions  | Array                                                                       | No conditions are supported for this Rule type, so this must be an empty array.     |
 | action      | String                                                                      | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.          |
 | requirement | [IdP Routing Rule Requirement Object](#idp-routing-rule-requirement-object) | Specifies the IdP to use.                                                           |
-| status      | String                                                                      | `ACTIVE`  or  `INACTIVE`.                                                           |
+| status      | String                                                                      | `ACTIVE` or `INACTIVE`.                                                             |
 | default     | Boolean                                                                     | `true` for the first instance of this Rule, which gets created by default.          |
 
 #### IdP Routing Rule Requirement Object
@@ -318,7 +318,7 @@ The Identifier Match Policy object determines which user profile attributes are 
 | id       | String  | Unique identifier for this Policy (read-only).                                               |
 | name     | String  | Human-readable name for the Policy, configurable during creation or updating.                |
 | type     | String  | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:IdentifierMatch`. |
-| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                                    |
+| status   | String  | `ACTIVE` or `INACTIVE`.                                                                      |
 | default  | Boolean | `true` for the first instance of this policy, which gets created by default.                 |
 
 ### Identifier Match Policy Object Example
@@ -359,10 +359,10 @@ The Identifier Match Policy object determines which user profile attributes are 
 | id          | String                                                                                | Unique identifier for this Rule (read-only).                                                                       |
 | type        | String                                                                                | Type of the policy. For Identifier Match Rule objects, this needs to be `Okta:IdentifierMatch`.                    |
 | priority    | Integer                                                                               | Used to determine which Rules take precedence.                                                                     |
-| conditions  | Array                                                                                 | User Type and Group conditions are supported for this Rule type.                                                    |
+| conditions  | Array                                                                                 | User Type and Group conditions are supported for this Rule type.                                                   |
 | action      | String                                                                                | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.                                         |
 | requirement | [Identifier Match Rule Requirement Object](#identifier-match-rule-requirement-object) | Specifies the user profile attributes to match against, as well as the action to take in case of multiple matches. |
-| status      | String                                                                                | `ACTIVE`  or  `INACTIVE`.                                                                                          |
+| status      | String                                                                                | `ACTIVE` or `INACTIVE`.                                                                                            |
 | default     | Boolean                                                                               | `true` for the first instance of this Rule, which gets created by default.                                         |
 
 #### Identifier Match Rule Requirement Object
@@ -451,7 +451,7 @@ The Unknown User Policy determines whether a user who has not been found to matc
 | id       | String  | Unique identifier for this Policy (read-only).                                           |
 | name     | String  | Human-readable name for the Policy, configurable during creation or updating.            |
 | type     | String  | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:UnknownUser`. |
-| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                                |
+| status   | String  | `ACTIVE` or `INACTIVE`.                                                                  |
 | default  | Boolean | `true` for the first instance of this policy, which gets created by default.             |
 
 ### Unknown User Policy Object Example
@@ -496,7 +496,7 @@ The Unknown User Policy determines whether a user who has not been found to matc
 | conditions  | Array                                                                        | Identifier and App conditions are supported for this Rule type.                                    |
 | action      | String                                                                       | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.                         |
 | requirement | [Unknown User Rule Requirement Object](#unknow-user-rule-requirement-object) | Specifies whether to allow an unknown user to register and, if so, what User Type to use for them. |
-| status      | String                                                                       | `ACTIVE`  or  `INACTIVE`.                                                                          |
+| status      | String                                                                       | `ACTIVE` or `INACTIVE`.                                                                            |
 | default     | Boolean                                                                      | `true` for the first instance of this Rule, which gets created by default.                         |
 
 #### Unknown User Rule Requirement Object
@@ -548,7 +548,7 @@ The Sign On Policy object determines which authentication factors to prompt user
 | id       | String  | Unique identifier for this Policy (read-only).                                      |
 | name     | String  | Human-readable name for the Policy, configurable during creation or updating.       |
 | type     | String  | Type of the policy. For IdP Routing Policy objects, this needs to be `Okta:SignOn`. |
-| status   | String  | `ACTIVE`  or  `INACTIVE`.                                                           |
+| status   | String  | `ACTIVE` or `INACTIVE`.                                                             |
 | default  | Boolean | `true` for the first instance of this policy, which gets created by default.        |
 
 ### Sign On Policy Object Example
@@ -618,7 +618,7 @@ The Sign On Policy object determines which authentication factors to prompt user
 | conditions  | Array                                                               | User Type and Group conditions are supported for this Rule type.            |
 | action      | String                                                              | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.  |
 | requirement | [Sign On Rule Requirement Object](#sign-on-rule-requirement-object) | Specifies credentials to prompt user for.                                   |
-| status      | String                                                              | `ACTIVE`  or  `INACTIVE`.                                                   |
+| status      | String                                                              | `ACTIVE` or `INACTIVE`.                                                     |
 | default     | Boolean                                                             | `true` for the first instance of this Rule, which gets created by default.  |
 
 #### Sign On Rule Requirement Object
@@ -733,7 +733,7 @@ The User Profile object determines which user profile attributes to require user
 | conditions  | Array                                                                         | UserType, User, Group and various Device conditions are supported for this rule type. |
 | action      | String                                                                        | Either `ALLOW` or `DENY`. Controls whether the user is allowed to proceed.            |
 | requirement | [User Profile Rule Requirement Object](#user-profile-rule-requirement-object) | Specifies profile attributes to prompt user for.                                      |
-| status      | String                                                                        | `ACTIVE`  or  `INACTIVE`.                                                             |
+| status      | String                                                                        | `ACTIVE` or `INACTIVE`.                                                               |
 | default     | Boolean                                                                       | `true` for the first instance of this Rule, which gets created by default.            |
 
 #### User Profile Rule Requirement Object

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -313,12 +313,12 @@ One Identifier Match Rule Object is created by default.
 
 #### Identifier Match Rule Requirement Object
 
-| Property              | Type   | Description                                                                                                                                                       |
-|-----------------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| identifyingAttributes | Array  | User profile attributes to match. For each, you need to specify the ID of the `userType` that the attribute is a part of, as well as the name of the `attribute`. |
-| onConflictingUser     | String | Whether to proceed if more than one match is found. Can be `ALLOW` or `DENY`.                                                                                     |
+| Property              | Type   | Description                                                                                                                                                                                                                             |
+|-----------------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| identifyingAttributes | Array  | User profile attributes to match. For each, you need to specify the valid ID of a `userType` that the attribute is a part of, as well as the name of the `attribute` that is included in the User Profile Attributes of that User Type. |
+| onConflictingUser     | String | Whether to proceed if more than one match is found. Can be `ALLOW` or `DENY`.                                                                                                                                                           |                                                                            |
  
-### IdP Routing Rule Object
+### Identifier Match Rule Object
 
 ```json
 {

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -179,7 +179,7 @@ The IdP Routing Policy Object determines which IdP users are routed to. One IdP 
 | idpId    | String | Currently, must be 'OKTA'.     |
 | type     | String | Currently, must be `okta_idp`. |
  
-### IdP Routing Rule Object
+### IdP Routing Rule Object Example
 
 ```json
 [

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policies/index.md
@@ -12,7 +12,7 @@ During the Limited EA phase, Okta Identity Engine is enabled or disabled for an 
 
 API endpoints for creating, getting, and updating Policy and Rule objects function the same way in Okta Identity Engine as they do in the existing Okta `/policies` API; only the objects used are different, with Okta Identity Engine introducing a set of new Policy and Rule objects. See the [Okta Identity Engine Policy Objects](#okta-identity-enging-policy-objects) section of this document for descriptions of the objects.
 
-To enable the Okta Identity Engine Pipeline, you need to create at least one of each of the defined Okta Identity Engine Policy objects, and at least one Rule object for each Policy object.
+Each Policy object, as well as a Rule for it, needs to exist, in order for Okta Identity Engine to function. One of each is created by default when Okta Identity Engine is enabled for an org.
 
 ## Policies API Operations
 


### PR DESCRIPTION
# Description:
- **What's changed?** Creating documentation for the Policies objects used with the Okta Identity Engine.
- **Is this PR related to a Monolith release?** This documentation is for the LEA.

### Resolves:

* [OKTA-220228](https://oktainc.atlassian.net/browse/OKTA-220228)

### Reviewers:
@okta/idx 