### PR TITLE
Fixes bug in sidebar and breadcrumb spacing

### DIFF
--- a/packages/@okta/vuepress-theme-default/components/Code.vue
+++ b/packages/@okta/vuepress-theme-default/components/Code.vue
@@ -5,9 +5,9 @@
     <!-- End Sidebar -->
 
     <!-- Begin Content -->
-    <div class="PageContent-main language-content">
+    <div class="PageContent-main language-content NoPaddingTop">
       <EditLink />
-      <Breadcrumb></Breadcrumb>
+      <Breadcrumb wrapStyle="width: 80%"></Breadcrumb>
       <Content />
     </div>
     <!-- End Content -->
@@ -69,5 +69,10 @@ export default {
 </script>
 
 <style scoped>
+
+.breadcrumb-nav {
+  margin-top: 0px;
+  border-bottom: 0px;
+}
 
 </style>

--- a/packages/@okta/vuepress-theme-default/components/Sidebar.vue
+++ b/packages/@okta/vuepress-theme-default/components/Sidebar.vue
@@ -1,6 +1,6 @@
 <template>
-  <div>
-    <aside class="Sidebar" :class="{'Sidebar-active': sidebarActive}" v-if="oldNavigation">
+  <div :class="{'Sidebar': oldNavigation}" >
+    <aside :class="{'Sidebar-active': sidebarActive}" v-if="oldNavigation">
 
       <h2 class="Sidebar-location Sidebar-toggle h6">Navigation</h2>
       <div class="Sidebar-close Sidebar-toggle" v-on:click="sidebarActive = !sidebarActive"></div>

--- a/packages/@okta/vuepress-theme-default/global-components/Breadcrumb.vue
+++ b/packages/@okta/vuepress-theme-default/global-components/Breadcrumb.vue
@@ -1,6 +1,6 @@
 <template>
   <nav class="breadcrumb-nav" aria-label="breadcrumb">
-    <ol class="breadcrumb Wrap">
+    <ol class="breadcrumb Wrap" :style="wrapStyle">
       <li class="breadcrumb-item" v-for="crumb in breadcrumb" :key="crumb.path"><router-link :to="crumb.path">{{crumb.title}}</router-link></li>
     </ol>
   </nav>
@@ -9,6 +9,12 @@
 <script>
   export default {
     name: "Breadcrumb",
+    props: {
+      wrapStyle: {
+        default: "",
+        type: String
+      }
+    },
     computed: {
       breadcrumb() {
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- Breadcrumbs when displayed on old layout were showing an odd padding, this has been fixed with scoped css and props for breadcrumb (this fix is temporary until Prose layout is built
- Sidebar was not full due to an added div, this has been fixed

### Resolves:

