### PR TITLE
Fix link to integrate sign up; fix nav tree

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/test-scim-server/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/test-scim-server/index.md
@@ -80,7 +80,7 @@ Here is how to share a test result from Runscope with someone else:
 ## Testing your SCIM server with Okta
 
 Once you have a SCIM server that passes all of the Runscope tests,
-test your SCIM integration directly with Okta. To do so, you will first need to sign up for [an Okta developer account](https://developer.okta.com/signup/).
+test your SCIM integration directly with Okta. To do so, you will first need to sign up for [an Okta developer account](https://www.okta.com/integrate/signup/).
 
 Note: If you are using OAuth Authorization Code Grant flow as your authentication method
 or need to support the Profile Master action, Okta will need to custom-configure a template app for you.

--- a/packages/@okta/vuepress-site/docs/guides/build-sso-integration/integrate/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-sso-integration/integrate/index.md
@@ -7,7 +7,7 @@ title: Integrate Your App
 > If you are using the developer dashboard you will first need to switch to the Classic UI.
 > If you see a **Developer** prompt in the top left, click it and select **Classic UI** to switch to the Classic UI.
 
-* Sign up for an Okta [developer account](https://developer.okta.com/signup/).
+* Sign up for an Okta [developer account](https://www.okta.com/integrate/signup/).
 * In your Okta account (make sure you are signed in as an admin), use the [App Wizard](https://help.okta.com/en/prod/Content/Topics/Apps/Apps_App_Integration_Wizard.htm) to build a Single Sign-on integration with Okta.
 * When you are ready, navigate to the Feedback tab of the App Wizard:
     ![Feedback tab of SAML App Wizard](/img/oin/saml-step3.png "Feedback page for App wizard")

--- a/packages/@okta/vuepress-site/docs/guides/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/index.md
@@ -4,9 +4,7 @@ layout: Guides
 guides:
  - add-an-external-idp
  - build-custom-ui-mobile
- - build-provisioning-integration
  - build-self-signed-jwt
- - build-sso-integration
  - create-an-api-token
  - create-token-with-groups-claim
  - custom-error-pages
@@ -22,6 +20,8 @@ guides:
  - implement-implicit
  - implement-password
  - mfa
+ - build-provisioning-integration
+ - build-sso-integration
  - protect-your-api
  - refresh-tokens
  - request-user-consent


### PR DESCRIPTION
## Description:
1) Developer signup for OIN accounts still has to go through the old o.c/integrate signup until we have the OK7 correctly initialized to accept OIN accounts.

2) Nav tree entries look wrong (because they're prefixed with "OIN", and the nav tree is just using alphabetic organization, they look like they're in the wrong place. This fix puts them in the correct place alphabetically.

### Resolves:

* [OKTA-259707](https://oktainc.atlassian.net/browse/OKTA-259707)
