### PR TITLE
Prose style layout to concepts/references/release-notes

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/nav/concepts.js
+++ b/packages/@okta/vuepress-site/.vuepress/nav/concepts.js
@@ -3,7 +3,8 @@
 module.exports = [
     {
         title: "Overview",
-        link: "/docs/concepts/"
+        link: "/docs/concepts/",
+        overview: true
     },
     { 
         title: 'API Access Management', 

--- a/packages/@okta/vuepress-site/docs/concepts/api-access-management/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/api-access-management/index.md
@@ -3,6 +3,7 @@ title: API Access Management
 meta:
   - name: description
     content: With API Access Management, you can secure all of your APIs. Read about its benefits and how to get started.
+layout: Landing
 ---
 
 # API Access Management with Okta

--- a/packages/@okta/vuepress-site/docs/concepts/auth-overview/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/auth-overview/index.md
@@ -3,6 +3,7 @@ title: OAuth 2.0 Overview
 meta:
   - name: description
     content: An overview of OAuth 2.0 and OpenID Connect and their Okta implementations. This guide helps you determine what flow is best for the app you are building.
+layout: Landing
 ---
 
 # OAuth 2.0 Overview

--- a/packages/@okta/vuepress-site/docs/concepts/auth-servers/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/auth-servers/index.md
@@ -3,6 +3,7 @@ title: Authorization Servers
 meta:
   - name: description
     content: An overview of what an authorization server is and the types of authorization servers available at Okta.
+layout: Landing
 ---
 ## What is an authorization server
 

--- a/packages/@okta/vuepress-site/docs/concepts/authentication/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/authentication/index.md
@@ -3,6 +3,7 @@ title: Authentication
 meta:
   - name: description
     content: Use Okta to create a custom login experience for your apps. Learn more about OAuth 2.0 and OIDC implementations, the Authentication API, and the Sign-In Widget.
+layout: Landing
 ---
 
 # Authentication with Okta

--- a/packages/@okta/vuepress-site/docs/concepts/event-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/event-hooks/index.md
@@ -3,6 +3,7 @@ title: Event Hooks
 meta:
   - name: description
     content: Event Hooks are outbound calls from Okta, sent when specified events occur in your org. Get information on eligible events and setting up Event Hooks in this guide.
+layout: Landing
 ---
 
 # Event Hooks

--- a/packages/@okta/vuepress-site/docs/concepts/events-api-migration/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/events-api-migration/index.md
@@ -3,6 +3,7 @@ title: Events API Migration
 meta:
   - name: description
     content: Okta is deprecating the Events API in favor of the System Log API. Find out more about their key differences and how to migrate to the System Log API.
+layout: Landing
 ---
 # Events API Migration
 

--- a/packages/@okta/vuepress-site/docs/concepts/feature-lifecycle-management/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/feature-lifecycle-management/index.md
@@ -1,5 +1,6 @@
 ---
 title: Feature Lifecycle Management
+layout: Landing
 ---
 
 # Feature Lifecycle Management

--- a/packages/@okta/vuepress-site/docs/concepts/identity-providers/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/identity-providers/index.md
@@ -1,5 +1,6 @@
 ---
 title: External Identity Providers
+layout: Landing
 ---
 # External Identity Providers
 As a developer building a custom application, you want to give your users the freedom to choose which Identity Provider that they use to sign in to your application. But first you should understand how various Identity Providers connect to Okta. 

--- a/packages/@okta/vuepress-site/docs/concepts/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/index.md
@@ -1,6 +1,7 @@
 ---
 layout: Landing
 title: Concepts
+showToc: false
 ---
 
 # Concepts

--- a/packages/@okta/vuepress-site/docs/concepts/inline-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/inline-hooks/index.md
@@ -3,6 +3,7 @@ title: Inline Hooks
 meta:
   - name: description
     content: Inline hooks are outbound calls from Okta to your own custom code. Find out more about the types of Okta Inline Hooks, the process flow, and how to set them up.
+layout: Landing
 ---
 
 # Inline Hooks

--- a/packages/@okta/vuepress-site/docs/concepts/key-rotation/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/key-rotation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Key Rotation
+layout: Landing
 ---
 ## Key Rotation
 

--- a/packages/@okta/vuepress-site/docs/concepts/okta-hosted-flows/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/okta-hosted-flows/index.md
@@ -1,5 +1,6 @@
 ---
 title: Okta-hosted Flows
+layout: Landing
 ---
 
 # Okta-hosted flows

--- a/packages/@okta/vuepress-site/docs/concepts/okta-organizations/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/okta-organizations/index.md
@@ -1,5 +1,6 @@
 ---
 title: Okta Organizations
+layout: Landing
 ---
 
 # Okta Organizations

--- a/packages/@okta/vuepress-site/docs/concepts/saml/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/saml/index.md
@@ -1,10 +1,10 @@
 ---
 title: Understanding SAML
-layout: docs_page
 icon: /assets/img/icons/saml.svg
 meta:
   - name: description
     content: Secure Authentication Markup Language is a standards-based protocol for exchanging digital authentication signatures. Learn how SAML operates and how to set up SAML applications in Okta.
+layout: Landing
 ---
 
 # SAML

--- a/packages/@okta/vuepress-site/docs/concepts/scim/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/scim/index.md
@@ -1,10 +1,10 @@
 ---
 title: Understanding SCIM
-layout: docs_page
 icon: /assets/img/icons/scim.svg
 meta:
   - name: description
     content: System for Cross-domain Identity Management. Understand the the value of provisioning accounts with SCIM and how to set them up in Okta.
+layout: Landing
 ---
 
 ## SCIM: Provisioning with Okta's Lifecycle Management

--- a/packages/@okta/vuepress-site/docs/concepts/social-login/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/social-login/index.md
@@ -3,6 +3,7 @@ title: Social Login Overview
 meta:
   - name: description
     content: You can use external social sign-in providers for your Okta apps. Learn more about the accepted features and the social sign-in process. 
+layout: Landing
 ---
 
 # Social Login

--- a/packages/@okta/vuepress-site/docs/reference/api-overview/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api-overview/index.md
@@ -3,6 +3,7 @@ title: Okta API Design Principles
 meta:
   - name: description
     content: Learn how the Okta API works and learn about the compatibility rules and design principles.
+layout: Landing
 ---
 
 ### Versioning

--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -1,6 +1,7 @@
 ---
 title: Apps
 category: management
+layout: Landing
 ---
 
 # Apps API

--- a/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
@@ -2,6 +2,7 @@
 title: Authentication
 category: authentication
 excerpt: Control user access to Okta.
+layout: Landing
 ---
 
 # Authentication API

--- a/packages/@okta/vuepress-site/docs/reference/api/authorization-servers/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/authorization-servers/index.md
@@ -1,6 +1,7 @@
 ---
 title: Authorization Servers
 category: management
+layout: Landing
 ---
 
 # Authorization Servers

--- a/packages/@okta/vuepress-site/docs/reference/api/event-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/event-hooks/index.md
@@ -4,6 +4,7 @@ category: management
 excerpt:
   The Event Hooks Management API provides a CRUD interface for registering
   event hook endpoints.
+layout: Landing
 ---
 
 # Event Hooks Management API

--- a/packages/@okta/vuepress-site/docs/reference/api/event-types/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/event-types/index.md
@@ -5,6 +5,7 @@ weight: 2
 title: Event Types
 showToc: false
 excerpt: Catalogs the Okta event type system for System Log API.
+layout: Landing
 ---
 
 # Event Types

--- a/packages/@okta/vuepress-site/docs/reference/api/events/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/events/index.md
@@ -2,6 +2,7 @@
 title: Events
 category: management
 deprecated: true
+layout: Landing
 ---
 
 # Events API

--- a/packages/@okta/vuepress-site/docs/reference/api/factor-admin/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/factor-admin/index.md
@@ -2,6 +2,7 @@
 title: Factors Administration
 beta: true
 category: management
+layout: Landing
 ---
 
 # Factors Administration API

--- a/packages/@okta/vuepress-site/docs/reference/api/factors/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/factors/index.md
@@ -1,6 +1,7 @@
 ---
 title: Factors
 category: management
+layout: Landing
 ---
 
 # Factors API

--- a/packages/@okta/vuepress-site/docs/reference/api/features/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/features/index.md
@@ -1,6 +1,7 @@
 ---
 title: Features
 category: management
+layout: Landing
 ---
 
 # Features API

--- a/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
@@ -1,6 +1,7 @@
 ---
 title: Groups
 category: management
+layout: Landing
 ---
 
 # Groups API

--- a/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
@@ -1,6 +1,7 @@
 ---
 title: Identity Providers
 category: management
+layout: Landing
 ---
 
 # Identity Providers API

--- a/packages/@okta/vuepress-site/docs/reference/api/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/index.md
@@ -1,0 +1,15 @@
+---
+layout: Landing
+title: Manage Okta Resources 
+showToc: false
+---
+
+# Manage Okta Resources
+REST endpoints to configure resources such as users, apps, sessions, and factors whenever you need.
+
+## Featured Concepts
+
+<Cards>
+  <Card href="/docs/reference/api/apps/" :showHeaderIcon=false cardTitle="Apps" :showFooter=false>The Okta Application API provides operations to manage applications and/or assignments to users or groups for your organization.</Card>
+  <Card href="/docs/reference/api/users/" :showHeaderIcon=false cardTitle="Users" :showFooter=false>The Okta User API provides operations to manage users in your organization.</Card>
+</Cards>

--- a/packages/@okta/vuepress-site/docs/reference/api/inline-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/inline-hooks/index.md
@@ -4,6 +4,7 @@ category: management
 excerpt:
   The Inline Hooks Management API provides a CRUD interface for registering
   Inline Hook endpoints.
+layout: Landing
 ---
 
 # Inline Hooks Management API

--- a/packages/@okta/vuepress-site/docs/reference/api/linked-objects/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/linked-objects/index.md
@@ -4,6 +4,7 @@ category: management
 meta:
   - name: description
     content: Users have relationships to each other, such as managers and reporting employees. With the Linked Objects API, you can create up to 200 linked object definitions.
+layout: Landing
 ---
 
 # Linked Objects API

--- a/packages/@okta/vuepress-site/docs/reference/api/mappings/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/mappings/index.md
@@ -1,6 +1,7 @@
 ---
 title: Mappings
 category: management
+layout: Landing
 ---
 
 # Mappings API

--- a/packages/@okta/vuepress-site/docs/reference/api/oauth-clients/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oauth-clients/index.md
@@ -4,6 +4,7 @@ category: management
 excerpt: >-
   Operations to register and manage client applications for use with Okta's
   OAuth 2.0 and OpenID Connect endpoints
+layout: Landing
 ---
 
 # Dynamic Client Registration API

--- a/packages/@okta/vuepress-site/docs/reference/api/oidc/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oidc/index.md
@@ -5,6 +5,7 @@ excerpt: Control user access to your applications.
 meta:
   - name: description
     content: Find information about the OAuth 2.0 and OpenID Connect endpoints that Okta exposes on its authorization servers.
+layout: Landing
 ---
 
 # OpenID Connect & OAuth 2.0 API

--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -1,6 +1,7 @@
 ---
 title: Policy
 category: management
+layout: Landing
 ---
 
 # Policy API

--- a/packages/@okta/vuepress-site/docs/reference/api/roles/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/roles/index.md
@@ -4,6 +4,7 @@ category: management
 meta:
   - name: description
     content: The Okta Administrator Roles API provides operations to manage administrative role assignments for a user. Read this page to get started with Admin Roles.
+layout: Landing
 ---
 
 # Administrator Roles API

--- a/packages/@okta/vuepress-site/docs/reference/api/schemas/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/schemas/index.md
@@ -2,6 +2,7 @@
 title: Schemas
 category: management
 excerpt: The Schemas API defines custom user profiles for Okta users and applications.
+layout: Landing
 ---
 
 # Schemas API

--- a/packages/@okta/vuepress-site/docs/reference/api/sessions/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/sessions/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sessions
 category: management
+layout: Landing
 ---
 
 # Sessions API

--- a/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
@@ -1,6 +1,7 @@
 ---
 title: System Log
 category: management
+layout: Landing
 ---
 
 # System Log API

--- a/packages/@okta/vuepress-site/docs/reference/api/templates/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/templates/index.md
@@ -1,6 +1,7 @@
 ---
 title: Templates
 category: management
+layout: Landing
 ---
 
 # Custom Templates API

--- a/packages/@okta/vuepress-site/docs/reference/api/trusted-origins/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/trusted-origins/index.md
@@ -1,6 +1,7 @@
 ---
 title: Trusted Origins
 category: management
+layout: Landing
 ---
 
 # Trusted Origins API

--- a/packages/@okta/vuepress-site/docs/reference/api/user-types/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/user-types/index.md
@@ -1,6 +1,7 @@
 ---
 title: User Types
 category: management
+layout: Landing
 ---
 
 # User Types API

--- a/packages/@okta/vuepress-site/docs/reference/api/users/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/users/index.md
@@ -1,6 +1,7 @@
 ---
 title: Users
 category: management
+layout: Landing
 ---
 
 # Users API

--- a/packages/@okta/vuepress-site/docs/reference/api/zones/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/zones/index.md
@@ -1,6 +1,7 @@
 ---
 title: Zones
 category: management
+layout: Landing
 ---
 # Zones API
 

--- a/packages/@okta/vuepress-site/docs/reference/error-codes/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/error-codes/index.md
@@ -3,6 +3,7 @@ title: Okta API Error Codes
 meta:
   - name: description
     content: Here you can find further information about the errors that the Okta API returns, sorted by error code and HTTP return code.
+layout: Landing
 ---
 
 # Okta Example Error Codes and Descriptions

--- a/packages/@okta/vuepress-site/docs/reference/import-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/import-hook/index.md
@@ -1,6 +1,7 @@
 ---
 title: Import Inline Hook Reference
 excerpt: Add custom logic to the user import process.
+layout: Landing
 ---
 
 # Import Inline Hook Reference

--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
@@ -3,6 +3,7 @@ title: Expression Language Overview
 meta:
   - name: description
     content: Learn more about the features and syntax of the Okta Expression Language, which can be used throughout the administrator UI and API.
+layout: Landing
 ---
 
 # Overview

--- a/packages/@okta/vuepress-site/docs/reference/postman-collections/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/postman-collections/index.md
@@ -3,6 +3,7 @@ title: Postman Collections
 meta:
   - name: description
     content: Find all of the Okta API collections which you can use with Postman.
+layout: Landing
 ---
 
 # Import a Postman Collection

--- a/packages/@okta/vuepress-site/docs/reference/rate-limits/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/rate-limits/index.md
@@ -3,6 +3,7 @@ title: Rate Limits
 excerpt: >-
   Understand rate limits at Okta and learn how to design for efficient use of
   resources
+layout: Landing
 ---
 
 # Rate Limits

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -1,6 +1,7 @@
 ---
 title: Registration Inline Hook Reference
 excerpt: Customize handling of user registration requests in Self-Service Registration
+layout: Landing
 ---
 
 # Registration Inline Hook Reference

--- a/packages/@okta/vuepress-site/docs/reference/releases-at-okta/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/releases-at-okta/index.md
@@ -1,5 +1,6 @@
 ---
-title: Release Life Cycle
+title: Release Lifecycle
+layout: Landing
 ---
 
 # Release Life Cycle

--- a/packages/@okta/vuepress-site/docs/reference/saml-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/saml-hook/index.md
@@ -1,6 +1,7 @@
 ---
 title: SAML Assertion Inline Hook Reference
 excerpt: Customize SAML assertions returned by Okta.
+layout: Landing
 ---
 
 # SAML Assertion Inline Hook Reference

--- a/packages/@okta/vuepress-site/docs/reference/scim/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/scim/index.md
@@ -4,6 +4,7 @@ icon: /assets/img/icons/scim.svg
 meta:
   - name: description
     content: Your SCIM API must support specific SCIM API endpoints to work with Okta. Those endpoints and their explanations are detailed here.
+layout: Landing
 ---
 
 # SCIM Protocol

--- a/packages/@okta/vuepress-site/docs/reference/social-settings/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/social-settings/index.md
@@ -1,5 +1,6 @@
 ---
 title: Social IdP Settings
+layout: Landing
 ---
 
 # Social Identity Provider Settings

--- a/packages/@okta/vuepress-site/docs/reference/token-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/token-hook/index.md
@@ -1,6 +1,7 @@
 ---
 title: Token Inline Hook Reference
 excerpt: Customize tokens returned by the Okta API Access Management process flow.
+layout: Landing
 ---
 
 # Token Inline Hook Reference

--- a/packages/@okta/vuepress-site/docs/reference/webfinger/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/webfinger/index.md
@@ -3,6 +3,7 @@ title: WebFinger
 meta:
   - name: description
     content: The Webfinger protocol helps to determine the Identity Provider where a given username should be routed. This guide explains the process of finding the Identity Provider for a user.
+layout: Landing
 ---
 
 # WebFinger

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-02/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-02/index.md
@@ -6,10 +6,10 @@ title: Okta API Products Release Notes
 
 ### Feature Enhancements
 
-| Feature Enhancement                          | Expected in Preview Orgs | Expected in Production Orgs |
-|:---------------------------------------------------|:------------------------------------|:---------------------------------------|
-| [App User Schema API is Generally Available](#generally-available-app-user-schema-api)   | January 10, 2018          | February 13, 2017  |
-| [SHA-256 Certificates for New SAML 2.0 Apps is Generally Available](#generally-available-sha-256-certificates-for-saml-20-apps) | Available  Now        | January 10, 2018                |
+| Feature Enhancement                                                                                                             | Expected in Preview Orgs | Expected in Production Orgs |
+| ------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | --------------------------- |
+| [App User Schema API is Generally Available](#generally-available-app-user-schema-api)                                          | January 10, 2018         | February 13, 2017           |
+| [SHA-256 Certificates for New SAML 2.0 Apps is Generally Available](#generally-available-sha-256-certificates-for-saml-20-apps)   | Available  Now           | January 10, 2018            |
 
 #### Generally Available: App User Schema API
 Use the [App User Schema API](/docs/reference/api/schemas/#app-user-schema-operations) to work with App User profiles, typically for apps that have features for provisioning users. <!--OKTA-154105-->

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-03/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-03/index.md
@@ -6,9 +6,9 @@ title: Okta API Products Release Notes
 
 ### Feature Enhancements
 
-| Feature Enhancement                          | Expected in Preview Orgs | Expected in Production Orgs |
-|:---------------------------------------------------|:------------------------------------|:---------------------------------------|
-| [App User Schema API is Generally Available](#generally-available-app-user-schema-api)   | Available Now          | February 13, 2017  |
+| Feature Enhancement                                                                    | Expected in Preview Orgs | Expected in Production Orgs |
+| -------------------------------------------------------------------------------------- | ------------------------ | --------------------------- |
+| [App User Schema API is Generally Available](#generally-available-app-user-schema-api) | Available Now            | February 13, 2017           |
 
 #### Generally Available: App User Schema API
 Use the [App User Schema API](/docs/reference/api/schemas/#app-user-schema-operations) to work with App User profiles, typically for apps that have features for provisioning users. <!--OKTA-154105-->

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-05/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-05/index.md
@@ -6,15 +6,15 @@ title: Okta API Products Release Notes
 
 ### Feature Enhancements
 
-| Feature Enhancement                          | Expected in Preview Orgs | Expected in Production Orgs |
-|:---------------------------------------------------|:------------------------------------|:---------------------------------------|
-| [App User Schema API is Generally Available](#generally-available-app-user-schema-api)   | Available Now          | Available Now  |
-| [Special HTML Characters in `state` for `okta_post_message`](#special-html-characters-in-state-for-okta_post_message) | January 31, 2018        | February 7, 2018                |
-| [Custom Scopes in Metadata Endpoints](#custom-scopes-in-metadata-endpoints) | January 31, 2018        | February 7, 2018                |
-| [Improved Enforcement of Authorization Server Policies](#improved-enforcement-of-authorization-server-policies) | January 31, 2018        | February 7, 2018                |
-| [Functions for Including Groups in Tokens](#functions-for-including-groups-in-tokens) | January 31, 2018        | February 7, 2018        |
-| [New System Log Messages](#new-system-log-messages) | January 31, 2018        | February 7, 2018                |
-| [New Version of the Sign-In Widget](#new-version-of-the-sign-in-widget) | Available Now | Available Now |
+| Feature Enhancement                                                                                                   | Expected in Preview Orgs | Expected in Production Orgs |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | --------------------------- |
+| [App User Schema API is Generally Available](#generally-available-app-user-schema-api)                                | Available Now            | Available Now               |
+| [Special HTML Characters in `state` for `okta_post_message`](#special-html-characters-in-state-for-okta_post_message) | January 31, 2018         | February 7, 2018            |
+| [Custom Scopes in Metadata Endpoints](#custom-scopes-in-metadata-endpoints)                                           | January 31, 2018         | February 7, 2018            |
+| [Improved Enforcement of Authorization Server Policies](#improved-enforcement-of-authorization-server-policies)       | January 31, 2018         | February 7, 2018            |
+| [Functions for Including Groups in Tokens](#functions-for-including-groups-in-tokens)                                 | January 31, 2018         | February 7, 2018            |
+| [New System Log Messages](#new-system-log-messages)                                                                   | January 31, 2018         | February 7, 2018            |
+| [New Version of the Sign-In Widget](#new-version-of-the-sign-in-widget)                                               | Available Now            | Available Now               |
 
 #### Generally Available: App User Schema API
 Use the [App User Schema API](/docs/reference/api/schemas/#app-user-schema-operations) to work with App User profiles, typically for apps that have features for provisioning users. <!--OKTA-154105-->

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-06/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-06/index.md
@@ -6,11 +6,11 @@ title: Okta API Products Release Notes
 
 ### Feature Enhancements
 
-| Feature Enhancement        | Expected in Preview Orgs | Expected in Production Orgs |
-|:------------------------------------|:------------------------------------|:---------------------------------------|
-| [API Access Management is Generally Available in Preview](#api-access-management-is-generally-available-in-preview) | February 7, 2018               | starting March 12, 2018                  |
-| [New Administrator Role for API Access Management](#new-administrator-role-for-api-access-management) | February 7, 2018 | starting February 12, 2018 |
-| [New and Changed Messages for the System Log](#new-and-changed-messages-for-the-system-log) | February 7, 2018 | starting February 12, 2018 |
+| Feature Enhancement                                                                                                 | Expected in Preview Orgs | Expected in Production Orgs |
+| ------------------------------------------------------------------------------------------------------------------- | ------------------------ | --------------------------- |
+| [API Access Management is Generally Available in Preview](#api-access-management-is-generally-available-in-preview) | February 7, 2018         | starting March 12, 2018     |
+| [New Administrator Role for API Access Management](#new-administrator-role-for-api-access-management)               | February 7, 2018         | starting February 12, 2018  |
+| [New and Changed Messages for the System Log](#new-and-changed-messages-for-the-system-log)                         | February 7, 2018         | starting February 12, 2018  |
 
 #### API Access Management is Generally Available in Preview
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-09/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-09/index.md
@@ -7,14 +7,14 @@ title: Okta API Products Release Notes
 | Change                                                                                                                                                                      | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
 | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
 | [API Access Management is Generally Available in Preview](#api-access-management-is-generally-available-in-preview)                                                         | February 7, 2018         | March 12, 2018                               |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows in Early Availability (EA)](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)              | February 28, 2018        | March 5, 2018                                |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows in Early Availability (EA)](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)               | February 28, 2018        | March 5, 2018                                |
 | [Sessions API Supports HTTP Header Prefer](#sessions-api-supports-http-header-prefer)                                                                                       | February 28, 2018        | March 5, 2018                                |
-| [User Schema API Allows Nullable `firstName`, `lastName`](#user-schema-api-allows-nullable-firstname-lastname)                                                              | February 28, 2018        | March 5, 2018                                |
+| [User Schema API Allows Nullable `firstName`, `lastName`](#user-schema-api-allows-nullable-firstname-lastname)                                                                | February 28, 2018        | March 5, 2018                                |
 | [Improved Response Mode for OAuth 2.0 and OpenID Connect Requests](#improved-response-mode-for-oauth-20-and-openid-connect-requests)                                        | February 28, 2018        | March 5, 2018                                |
 | [Change to `/authorize` Response for `prompt` for OAuth 2.0 and OpenID Connect Requests](#change-to-authorize-response-for-prompt-for-oauth-20-and-openid-connect-requests) | February 28, 2018        | March 5, 2018                                |
 | [Improved System Log Behavior for Date Queries](#improved-system-log-behavior-for-date-queries)                                                                             | February 28, 2018        | March 5, 2018                                |
 | [System Log Message Changes Related to Authorization Servers](#system-log-message-changes-related-to-authorization-servers)                                                 | February 28, 2018        | March 5, 2018                                |
-| [Bugs Fixed for 2018.09](#bugs-fixed-for-2018-09)                                                                                                                           | February 28, 2018        | March 5, 2018                                |
+| [Bugs Fixed for 2018.09](#bugs-fixed-for-2018-09)                                                                                                                            | February 28, 2018        | March 5, 2018                                |
 
 ### User Consent for OAuth 2.0 and OpenID Connect Flows in Early Availability (EA)
 
@@ -203,4 +203,3 @@ The following bugs have been fixed and are expected in preview orgs February 28,
 * If a user had a status of `ACTIVE` and had never signed in, and an API call reset the user's password, the user's status was incorrectly changed from `ACTIVE` to `PROVISIONED`, instead of the expected `RECOVERY`. (OKTA-154024)
 * If `-admin` was incorrectly included in the domain name during initialization of [an OktaAuth object](https://github.com/okta/okta-auth-js), no error was returned. (OKTA-156927)
 * If a user was created with a password, that password wasn't considered as part of their password history. (OKTA-158966)
-

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-09/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-09/index.md
@@ -76,12 +76,18 @@ This applies to `/authorize` with either the Okta Org Authorization Server or a 
 ```xml
 {
     "errorCode": "E0000001",
-    "errorSummary": "Api validation failed: com.saasure.core.services.user.InvalidUserProfileException: Could not create user due to invalid profile: com.saasure.framework.validation.util.SimpleErrors: 1 errors\nError in object 'newUser': codes [password.passwordRequirementsNotMet.newUser,password.passwordRequirementsNotMet]; arguments [Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, no parts of your username.]; default message [Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, no parts of your username.]",
+    "errorSummary": "Api validation failed: com.saasure.core.services.user.InvalidUserProfileException:
+        Could not create user due to invalid profile: com.saasure.framework.validation.util.SimpleErrors: 1 errors\nError in object
+        'newUser': codes [password.passwordRequirementsNotMet.newUser,password.passwordRequirementsNotMet]; arguments [Password
+        requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, no parts of your username.];
+        default message [Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter,
+        an uppercase letter, a number, no parts of your username.]",
     "errorLink": "E0000001",
     "errorId": "oaecNfS38enQ8KtWDvNfusWRw",
     "errorCauses": [
         {
-            "errorSummary": "Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, no parts of your username."
+            "errorSummary": "Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter,
+            an uppercase letter, a number, no parts of your username."
         }
     ]
 }
@@ -92,7 +98,15 @@ This applies to `/authorize` with either the Okta Org Authorization Server or a 
 ```xml
 {
     "errorCode": "E0000001",
-    "errorSummary": "Api validation failed: com.saasure.core.services.user.InvalidUserProfileException: Could not create user due to invalid profile: com.saasure.framework.validation.util.SimpleErrors: 3 errors\nField error in object 'newUser' on field 'password': rejected value [aaaa]; codes [password.minlength.newUser.password,password.minlength.password,password.minlength.java.lang.String,password.minlength]; arguments [8]; default message [Password requirements: at least 8 characters.]\nField error in object 'newUser' on field 'password': rejected value [aaaa]; codes [password.uppercase.newUser.password,password.uppercase.password,password.uppercase.java.lang.String,password.uppercase]; arguments [Password requirements: at least 0 characters, an uppercase letter.]; default message [Password requirements: at least 0 characters, an uppercase letter.]\nField error in object 'newUser' on field 'password': rejected value [aaaa]; codes [password.number.newUser.password,password.number.password,password.number.java.lang.String,password.number]; arguments [Password requirements: at least 0 characters, a number.]; default message [Password requirements: at least 0 characters, a number.]",
+    "errorSummary": "Api validation failed: com.saasure.core.services.user.InvalidUserProfileException: Could not create user due
+        to invalid profile: com.saasure.framework.validation.util.SimpleErrors: 3 errors\nField error in object 'newUser' on field
+        "password": rejected value [aaaa]; codes [password.minlength.newUser.password,password.minlength.password,password.minlength.java.lang.String,password.minlength];
+        arguments [8]; default message [Password requirements: at least 8 characters.]\nField error in object 'newUser' on field 'password': rejected value [aaaa];
+        codes [password.uppercase.newUser.password,password.uppercase.password,password.uppercase.java.lang.String,password.uppercase];
+        arguments [Password requirements: at least 0 characters, an uppercase letter.]; default message [Password requirements: at least
+        0 characters, an uppercase letter.]\nField error in object 'newUser' on field 'password': rejected value [aaaa]; codes
+        [password.number.newUser.password,password.number.password,password.number.java.lang.String,password.number]; arguments
+        [Password requirements: at least 0 characters, a number.]; default message [Password requirements: at least 0 characters, a number.]",
     "errorLink": "E0000001",
     "errorId": "oaeGZUg95w6SK2GbA44cXgtvA",
     "errorCauses": [

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-09/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-09/index.md
@@ -4,17 +4,17 @@ title: Okta API Products Release Notes
 
 ## 2018.09
 
-| Change | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| :---------- | :--------------------------------- | :----------------------------------------------------------- |
-| [API Access Management is Generally Available in Preview](#api-access-management-is-generally-available-in-preview) | February 7, 2018               | March 12, 2018  |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows in Early Availability (EA)](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) | February 28, 2018               | March 5, 2018 |
-| [Sessions API Supports HTTP Header Prefer](#sessions-api-supports-http-header-prefer)  | February 28, 2018               | March 5, 2018 |
-| [User Schema API Allows Nullable `firstName`, `lastName`](#user-schema-api-allows-nullable-firstname-lastname) | February 28, 2018 | March 5, 2018 |
-| [Improved Response Mode for OAuth 2.0 and OpenID Connect Requests](#improved-response-mode-for-oauth-20-and-openid-connect-requests)  | February 28, 2018               | March 5, 2018 |
-| [Change to `/authorize` Response for `prompt` for OAuth 2.0 and OpenID Connect Requests](#change-to-authorize-response-for-prompt-for-oauth-20-and-openid-connect-requests)  | February 28, 2018               | March 5, 2018 |
-| [Improved System Log Behavior for Date Queries](#improved-system-log-behavior-for-date-queries)  | February 28, 2018               | March 5, 2018 |
-| [System Log Message Changes Related to Authorization Servers](#system-log-message-changes-related-to-authorization-servers)  | February 28, 2018               | March 5, 2018 |
-| [Bugs Fixed for 2018.09](#bugs-fixed-for-2018-09)  | February 28, 2018               | March 5, 2018 |
+| Change                                                                                                                                                                      | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [API Access Management is Generally Available in Preview](#api-access-management-is-generally-available-in-preview)                                                         | February 7, 2018         | March 12, 2018                               |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows in Early Availability (EA)](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)              | February 28, 2018        | March 5, 2018                                |
+| [Sessions API Supports HTTP Header Prefer](#sessions-api-supports-http-header-prefer)                                                                                       | February 28, 2018        | March 5, 2018                                |
+| [User Schema API Allows Nullable `firstName`, `lastName`](#user-schema-api-allows-nullable-firstname-lastname)                                                              | February 28, 2018        | March 5, 2018                                |
+| [Improved Response Mode for OAuth 2.0 and OpenID Connect Requests](#improved-response-mode-for-oauth-20-and-openid-connect-requests)                                        | February 28, 2018        | March 5, 2018                                |
+| [Change to `/authorize` Response for `prompt` for OAuth 2.0 and OpenID Connect Requests](#change-to-authorize-response-for-prompt-for-oauth-20-and-openid-connect-requests) | February 28, 2018        | March 5, 2018                                |
+| [Improved System Log Behavior for Date Queries](#improved-system-log-behavior-for-date-queries)                                                                             | February 28, 2018        | March 5, 2018                                |
+| [System Log Message Changes Related to Authorization Servers](#system-log-message-changes-related-to-authorization-servers)                                                 | February 28, 2018        | March 5, 2018                                |
+| [Bugs Fixed for 2018.09](#bugs-fixed-for-2018-09)                                                                                                                           | February 28, 2018        | March 5, 2018                                |
 
 ### User Consent for OAuth 2.0 and OpenID Connect Flows in Early Availability (EA)
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-10/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-10/index.md
@@ -4,14 +4,14 @@ title: Okta API Products Release Notes
 
 ## 2018.10
 
-| Change | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| :---------- | :--------------------------------- | :----------------------------------------------------------- |
-| [API Access Management is Generally Available (GA) in Production](#api-access-management-is-generally-available-ga-in-production) | Available now   | March 12, 2018  |
-| [System Log API Is in Early Access (EA)](#system-log-api-is-in-early-access-ea) | March 7, 2018 | March 12, 2018 |
-| [Password Imports with Salted SHA-256 Algorithm is in Early Access (EA)](#password-imports-with-salted-sha-256-algorithm-is-in-early-access-ea) | March 7, 2018 | March 12, 2018 |
-| [New Parameter for Authentication with Okta Verify with Auto-Push](#new-parameter-for-authentication-with-okta-verify-with-auto-push)   | March 7, 2018 | March 12, 2018 |
-| [System Log Changes for 2018.10](#system-log-changes-for-2018-10) | March 7, 2018 | March 12, 2018 |
-| [Bugs Fixed for 2018.10](#bugs-fixed-for-2018-10) | March 7, 2018 | March 12, 2018 |
+| Change                                                                                                                                          | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [API Access Management is Generally Available (GA) in Production](#api-access-management-is-generally-available-ga-in-production)               | Available now            | March 12, 2018                               |
+| [System Log API Is in Early Access (EA)](#system-log-api-is-in-early-access-ea)                                                                 | March 7, 2018            | March 12, 2018                               |
+| [Password Imports with Salted SHA-256 Algorithm is in Early Access (EA)](#password-imports-with-salted-sha-256-algorithm-is-in-early-access-ea) | March 7, 2018            | March 12, 2018                               |
+| [New Parameter for Authentication with Okta Verify with Auto-Push](#new-parameter-for-authentication-with-okta-verify-with-auto-push)           | March 7, 2018            | March 12, 2018                               |
+| [System Log Changes for 2018.10](#system-log-changes-for-2018-10)                                                                               | March 7, 2018            | March 12, 2018                               |
+| [Bugs Fixed for 2018.10](#bugs-fixed-for-2018-10)                                                                                                | March 7, 2018            | March 12, 2018                               |
 
 ### API Access Management is Generally Available (GA) in Production
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-11/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-11/index.md
@@ -4,15 +4,15 @@ title: Okta API Products Release Notes
 
 ## 2018.11
 
-| Change | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| :---------- | :--------------------------------- | :----------------------------------------------------------- |
-| [API Support for IdP-initiated Authentication](#api-support-for-idp-initiated-authentication) | March 14 | March 19 |
-| [New Powershell Module for TLS 1.2 Compatibility](#new-powershell-module-for-tls-12-compatibility) | Available Now | Available Now |
-| [Rate Limit for System Log Increased](#rate-limit-for-system-log-increased) | Available Now | Available Now |
-| [New Version of Okta Sign-in Widget](#new-version-of-okta-sign-in-widget) | Available Now | Available Now |
-| [System Log API Is in Early Access (EA)](#system-log-api-is-in-early-access-ea) | Available Now | Available Now |
-| [Password Imports with Salted SHA-256 Algorithm is in Early Access (EA)](#password-imports-with-salted-sha-256-algorithm-is-in-early-access-ea) | Available Now | Available Now |
-| [Bugs Fixed for 2018.11](#bugs-fixed-for-2018-11) | March 14, 2018 | March 19, 2018 |
+| Change                                                                                                                                          | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [API Support for IdP-initiated Authentication](#api-support-for-idp-initiated-authentication)                                                   | March 14                 | March 19                                     |
+| [New Powershell Module for TLS 1.2 Compatibility](#new-powershell-module-for-tls-12-compatibility)                                              | Available Now            | Available Now                                |
+| [Rate Limit for System Log Increased](#rate-limit-for-system-log-increased)                                                                     | Available Now            | Available Now                                |
+| [New Version of Okta Sign-in Widget](#new-version-of-okta-sign-in-widget)                                                                       | Available Now            | Available Now                                |
+| [System Log API Is in Early Access (EA)](#system-log-api-is-in-early-access-ea)                                                                 | Available Now            | Available Now                                |
+| [Password Imports with Salted SHA-256 Algorithm is in Early Access (EA)](#password-imports-with-salted-sha-256-algorithm-is-in-early-access-ea) | Available Now            | Available Now                                |
+| [Bugs Fixed for 2018.11](#bugs-fixed-for-2018-11)                                                                                                | March 14, 2018           | March 19, 2018                               |
 
 ### API Support for IdP-initiated Authentication
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-12/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-12/index.md
@@ -4,13 +4,13 @@ title: Okta API Products Release Notes
 
 ## 2018.12
 
-| Change | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| :---------- | :--------------------------------- | :----------------------------------------------------------- |
-| [Change to App Variable Name Incrementing](#change-to-app-variable-name-incrementing) | March 21, 2018 | March 26, 2018 |
-| [Token Management API Is in Early Access (EA)](#token-management-api-is-in-early-access-ea) | March 21, 2018 | March 26, 2018 |
-| [System Log API Is in Early Access (EA)](#system-log-api-is-in-early-access-ea) | Available Now | Available Now |
-| [Password Imports with Salted SHA-256 Algorithm is in Early Access (EA)](#password-imports-with-salted-sha-256-algorithm-is-in-early-access-ea) | Available Now | Available Now |
-| [Bug Fixed for 2018.12](#bug-fixed-for-2018-12) | March 21, 2018 | March 26, 2018 |
+| Change                                                                                                                                          | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [Change to App Variable Name Incrementing](#change-to-app-variable-name-incrementing)                                                           | March 21, 2018           | March 26, 2018                               |
+| [Token Management API Is in Early Access (EA)](#token-management-api-is-in-early-access-ea)                                                     | March 21, 2018           | March 26, 2018                               |
+| [System Log API Is in Early Access (EA)](#system-log-api-is-in-early-access-ea)                                                                 | Available Now            | Available Now                                |
+| [Password Imports with Salted SHA-256 Algorithm is in Early Access (EA)](#password-imports-with-salted-sha-256-algorithm-is-in-early-access-ea) | Available Now            | Available Now                                |
+| [Bug Fixed for 2018.12](#bug-fixed-for-2018-12)                                                                                                  | March 21, 2018           | March 26, 2018                               |
 
 ### Change to App Variable Name Incrementing
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-14/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-14/index.md
@@ -4,12 +4,12 @@ title: Okta API Products Release Notes
 
 ## 2018.14
 
-| Change | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| :---------- | :--------------------------------- | :----------------------------------------------------------- |
-| [Linked Objects API in Early Access (EA)](#linked-objects-api-in-early-access-ea) | April 4, 2018 | April 9, 2018 |
-| [Client SDKs Version 1.0](#client-sdks-version-10) | Available Now | Available Now |
-| [Bug Fixed for 2018.14](#bug-fixed-for-2018-14) | April 4, 2018 | April 9, 2018 |
-| [Previously Released Early Access Features](#previously-released-early-access-features) | Available now | Available now |
+| Change                                                                                  | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [Linked Objects API in Early Access (EA)](#linked-objects-api-in-early-access-ea)       | April 4, 2018            | April 9, 2018                                |
+| [Client SDKs Version 1.0](#client-sdks-version-10)                                      | Available Now            | Available Now                                |
+| [Bug Fixed for 2018.14](#bug-fixed-for-2018-14)                                          | April 4, 2018            | April 9, 2018                                |
+| [Previously Released Early Access Features](#previously-released-early-access-features) | Available now            | Available now                                |
 
 ### Linked Objects API in Early Access (EA)
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-15/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-15/index.md
@@ -4,11 +4,11 @@ title: Okta API Products Release Notes
 
 ## 2018.15
 
-| Change | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| :---------- | :--------------------------------- | :----------------------------------------------------------- |
-| [Enhanced Feature: API Support for Assigning App Instance to App Admins](#enhanced-feature-api-support-for-assigning-app-instance-to-app-admins) | April 11, 2018 | April 15, 2018 |
-| [Bug Fixed in 2018.15](#bug-fixed-in-2018-15) | April 11, 2018 | April 16, 2018 |
-| [Previously Released Early Access Features 2018.15 Update](#previously-released-early-access-features-2018-15-update) | Available now | Available now |
+| Change                                                                                                                                           | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------ | -------------------------------------------- |
+| [Enhanced Feature: API Support for Assigning App Instance to App Admins](#enhanced-feature-api-support-for-assigning-app-instance-to-app-admins) | April 11, 2018           | April 15, 2018                               |
+| [Bug Fixed in 2018.15](#bug-fixed-in-2018-15)                                                                                                     | April 11, 2018           | April 16, 2018                               |
+| [Previously Released Early Access Features 2018.15 Update](#previously-released-early-access-features-2018-15-update)                            | Available now            | Available now                                |
 
 ### Enhanced Feature: API Support for Assigning App Instance to App Admins
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-17/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-17/index.md
@@ -4,10 +4,10 @@ title: Okta API Products Release Notes
 
 ## 2018.17
 
-| Change | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| :---------- | :--------------------------------- | :----------------------------------------------------------- |
-| [Bugs Fixed in 2018.17](#bugs-fixed-in-2018-17) | April 24, 2018 | May 1, 2018 |
-| [Previously Released Early Access Features 2018.17 Update](#previously-released-early-access-features-2018-17-update) | Available now | Available now |
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [Bugs Fixed in 2018.17](#bugs-fixed-in-2018-17)                                                                        | April 24, 2018           | May 1, 2018                                  |
+| [Previously Released Early Access Features 2018.17 Update](#previously-released-early-access-features-2018-17-update) | Available now            | Available now                                |
 
 ### Bugs Fixed in 2018.17
 
@@ -19,9 +19,9 @@ title: Okta API Products Release Notes
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Linked Objects API Is in Early Access (EA)](#linked-objects-api-in-early-access-ea) |
-| [Token Management API Is in Early Access (EA)](#token-management-api-is-in-early-access-ea) |
-| [System Log API Is in Early Access (EA)](#system-log-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows is in Early Access (EA)](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                                         |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Linked Objects API Is in Early Access (EA)](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API Is in Early Access (EA)](#token-management-api-is-in-early-access-ea)                                                                 |
+| [System Log API Is in Early Access (EA)](#system-log-api-is-in-early-access-ea)                                                                             |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows is in Early Access (EA)](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-18/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-18/index.md
@@ -4,12 +4,12 @@ title: Okta API Products Release Notes
 
 ## 2018.18
 
-| Change | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| :---------- | :--------------------------------- | :----------------------------------------------------------- |
-| [Authentication Object for Step-up Authentication Is in Early Access](#authentication-object-for-step-up-authentication-is-in-early-access) | May 2, 2018 | May 7, 2018 |
-| [New Version of the Okta Sign-In Widget](#new-version-of-the-okta-sign-in-widget) | Available Now | Available Now |
-| [Bug Fixed in 2018.18](#bug-fixed-in-2018-18) | May 2, 2018 | May 7, 2018 |
-| [Previously Released Early Access Features 2018.18 Update](#previously-released-early-access-features-2018-18-update) | Available now | Available now |
+| Change                                                                                                                                      | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [Authentication Object for Step-up Authentication Is in Early Access](#authentication-object-for-step-up-authentication-is-in-early-access) | May 2, 2018              | May 7, 2018                                  |
+| [New Version of the Okta Sign-In Widget](#new-version-of-the-okta-sign-in-widget)                                                           | Available Now            | Available Now                                |
+| [Bug Fixed in 2018.18](#bug-fixed-in-2018-18)                                                                                                | May 2, 2018              | May 7, 2018                                  |
+| [Previously Released Early Access Features 2018.18 Update](#previously-released-early-access-features-2018-18-update)                       | Available now            | Available now                                |
 
 ### Authentication Object for Step-up Authentication Is in Early Access
 
@@ -30,9 +30,9 @@ If the configured default IdP was set to inactive, Okta still used the inactive 
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Linked Objects API Is in Early Access (EA)](#linked-objects-api-in-early-access-ea) |
-| [Token Management API Is in Early Access (EA)](#token-management-api-is-in-early-access-ea) |
-| [System Log API Is in Early Access (EA)](#system-log-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows Is in Early Access (EA)](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                                         |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Linked Objects API Is in Early Access (EA)](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API Is in Early Access (EA)](#token-management-api-is-in-early-access-ea)                                                                 |
+| [System Log API Is in Early Access (EA)](#system-log-api-is-in-early-access-ea)                                                                             |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows Is in Early Access (EA)](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-19/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-19/index.md
@@ -4,14 +4,14 @@ title: Okta API Products Release Notes
 
 ## 2018.19
 
-| Change | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| :---------- | :--------------------------------- | :----------------------------------------------------------- |
-| [ID Tokens Can Be Refreshed](#id-tokens-can-be-refreshed)| May 9, 2018 | May 14, 2018 |
-| [Custom URL Domains are in Early Access](#custom-url-domains-are-in-early-access)| May 9, 2018 | May 14, 2018 |
-| [Custom Okta-hosted Sign-In Page is in Early Access](#custom-okta-hosted-sign-in-page-is-in-early-access)| May 9, 2018 | May 14, 2018 |
-| [Custom Error Page is in Early Access](#custom-error-page-is-in-early-access)| May 9, 2018 | May 14, 2018 |
-| [Bugs Fixed in 2018.19](#bugs-fixed-in-2018-19) | May 9, 2018 | May 14, 2018 |
-| [Previously Released Early Access Features 2018.19 Update](#previously-released-early-access-features-2018-19-update) | Available now | Available now |
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [ID Tokens Can Be Refreshed](#id-tokens-can-be-refreshed)                                                             | May 9, 2018              | May 14, 2018                                 |
+| [Custom URL Domains are in Early Access](#custom-url-domains-are-in-early-access)                                     | May 9, 2018              | May 14, 2018                                 |
+| [Custom Okta-hosted Sign-In Page is in Early Access](#custom-okta-hosted-sign-in-page-is-in-early-access)             | May 9, 2018              | May 14, 2018                                 |
+| [Custom Error Page is in Early Access](#custom-error-page-is-in-early-access)                                         | May 9, 2018              | May 14, 2018                                 |
+| [Bugs Fixed in 2018.19](#bugs-fixed-in-2018-19)                                                                        | May 9, 2018              | May 14, 2018                                 |
+| [Previously Released Early Access Features 2018.19 Update](#previously-released-early-access-features-2018-19-update) | Available now            | Available now                                |
 
 ### ID Tokens Can Be Refreshed
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-20/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-20/index.md
@@ -4,10 +4,10 @@ title: Okta API Products Release Notes
 
 ## 2018.20
 
-| Change | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| :---------- | :--------------------------------- | :----------------------------------------------------------- |
-| [System Log Entry Delay Change](#system-log-entry-delay-change)| May 15, 2018 | May 29, 2018 |
-| [Previously Released Early Access Features 2018.20 Update](#previously-released-early-access-features-2018-20-update) | Available now | Available now |
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [System Log Entry Delay Change](#system-log-entry-delay-change)                                                       | May 15, 2018             | May 29, 2018                                 |
+| [Previously Released Early Access Features 2018.20 Update](#previously-released-early-access-features-2018-20-update) | Available now            | Available now                                |
 
 ### System Log Entry Delay Change
 
@@ -21,12 +21,12 @@ Events returned from the `/logs` endpoint when using the `until` parameter were 
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Linked Objects API](#linked-objects-api-in-early-access-ea) |
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [System Log API](#system-log-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Linked Objects API](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [System Log API](#system-log-api-is-in-early-access-ea)                                                                             |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-22/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-22/index.md
@@ -4,11 +4,11 @@ title: Okta API Products Release Notes
 
 ## 2018.22
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [New Session Token Behavior is in Early Access](#new-session-token-behavior-is-in-early-access)                      | May 30, 2018             | June 4, 2018                                 |
-| [System Log Events for New Device Notification Emails](#system-log-events-for-new-device-notification-emails)        | May 30, 2018             | June 4, 2018                                 |
-| [Bugs Fixed in 2018.22](#bugs-fixed-in-2018-22)                                                                       | May 30, 2018             | June 4, 2018                                 |
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [New Session Token Behavior is in Early Access](#new-session-token-behavior-is-in-early-access)                       | May 30, 2018             | June 4, 2018                                 |
+| [System Log Events for New Device Notification Emails](#system-log-events-for-new-device-notification-emails)           | May 30, 2018             | June 4, 2018                                 |
+| [Bugs Fixed in 2018.22](#bugs-fixed-in-2018-22)                                                                        | May 30, 2018             | June 4, 2018                                 |
 | [Previously Released Early Access Features 2018.22 Update](#previously-released-early-access-features-2018-22-update) | Available now            | Available now                                |
 
 ### New Session Token Behavior is in Early Access
@@ -29,12 +29,12 @@ New device notification email events will now appear in the System Log. <!-- OKT
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Linked Objects API](#linked-objects-api-in-early-access-ea) |
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [System Log API](#system-log-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Linked Objects API](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [System Log API](#system-log-api-is-in-early-access-ea)                                                                             |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-23/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-23/index.md
@@ -4,11 +4,11 @@ title: Okta API Products Release Notes
 
 ## 2018.23
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [Factors API Now Supports U2F](#factors-api-now-supports-u2f)                      | June 6, 2018             | June 11, 2018                                 |
-| [Network Selection Modes Deprecated](#network-selection-modes-deprecated)        | June 6, 2018             | June 11, 2018                                 |
-| [Better Signing Key Errors](#better-signing-key-errors)        | June 6, 2018             | June 11, 2018                                 |
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [Factors API Now Supports U2F](#factors-api-now-supports-u2f)                                                         | June 6, 2018             | June 11, 2018                                |
+| [Network Selection Modes Deprecated](#network-selection-modes-deprecated)                                             | June 6, 2018             | June 11, 2018                                |
+| [Better Signing Key Errors](#better-signing-key-errors)                                                               | June 6, 2018             | June 11, 2018                                |
 | [Previously Released Early Access Features 2018.23 Update](#previously-released-early-access-features-2018-23-update) | Available now            | Available now                                |
 
 ### Factors API Now Supports U2F
@@ -27,12 +27,12 @@ If signing keys cannot be generated for a new Authorization Server, a more descr
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Linked Objects API](#linked-objects-api-in-early-access-ea) |
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [System Log API](#system-log-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Linked Objects API](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [System Log API](#system-log-api-is-in-early-access-ea)                                                                             |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-24/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-24/index.md
@@ -4,10 +4,10 @@ title: Okta API Products Release Notes
 
 ## 2018.24
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [User Login Pattern Validation](#user-login-pattern-validation)                                                      | June 13, 2018            | June 18, 2018                                |
-| [Bugs Fixed in 2018.24](#bugs-fixed-in-2018-24)                                                                       | June 13, 2018            | June 18, 2018                                |
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [User Login Pattern Validation](#user-login-pattern-validation)                                                       | June 13, 2018            | June 18, 2018                                |
+| [Bugs Fixed in 2018.24](#bugs-fixed-in-2018-24)                                                                        | June 13, 2018            | June 18, 2018                                |
 | [Previously Released Early Access Features 2018.24 Update](#previously-released-early-access-features-2018-24-update) | Available now            | Available now                                |
 
 ### User Login Pattern Validation
@@ -24,12 +24,12 @@ A user's `login` no longer needs to be in the form of an email address.  Instead
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Linked Objects API](#linked-objects-api-in-early-access-ea) |
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [System Log API](#system-log-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Linked Objects API](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [System Log API](#system-log-api-is-in-early-access-ea)                                                                             |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-25/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-25/index.md
@@ -4,10 +4,10 @@ title: Okta API Products Release Notes
 
 ## 2018.25
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [Better /userinfo Errors](#better-userinfo-errors)                                                                  | June 20, 2018            | June 25, 2018                                |
-| [Bugs Fixed in 2018.25](#bugs-fixed-in-2018-25)                                                                       | June 20, 2018            | June 25, 2018                                |
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [Better /userinfo Errors](#better-userinfo-errors)                                                                    | June 20, 2018            | June 25, 2018                                |
+| [Bugs Fixed in 2018.25](#bugs-fixed-in-2018-25)                                                                        | June 20, 2018            | June 25, 2018                                |
 | [Previously Released Early Access Features 2018.25 Update](#previously-released-early-access-features-2018-25-update) | Available now            | Available now                                |
 
 ### Better /userinfo Errors
@@ -30,12 +30,12 @@ The following information has been added to the `userinfo` endpoint's error resp
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Linked Objects API](#linked-objects-api-in-early-access-ea) |
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [System Log API](#system-log-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Linked Objects API](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [System Log API](#system-log-api-is-in-early-access-ea)                                                                             |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-27/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-27/index.md
@@ -4,10 +4,10 @@ title: Okta API Products Release Notes
 
 ## 2018.27
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [System Log API is Generally Available (GA)](#system-log-api-is-generally-available-ga)                              | July 5, 2018            | July 9, 2018                                |
-| [Bugs Fixed in 2018.27](#bugs-fixed-in-2018-27)                                                                       | July 5, 2018            | July 9, 2018                                |
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [System Log API is Generally Available (GA)](#system-log-api-is-generally-available-ga)                               | July 5, 2018             | July 9, 2018                                 |
+| [Bugs Fixed in 2018.27](#bugs-fixed-in-2018-27)                                                                        | July 5, 2018             | July 9, 2018                                 |
 | [Previously Released Early Access Features 2018.27 Update](#previously-released-early-access-features-2018-27-update) | Available now            | Available now                                |
 
 ### System Log API is Generally Available (GA)
@@ -23,11 +23,11 @@ The [System Log API](/docs/reference/api/system-log/) is now Generally Available
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Linked Objects API](#linked-objects-api-in-early-access-ea) |
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Linked Objects API](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-28/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-28/index.md
@@ -4,11 +4,11 @@ title: Okta API Products Release Notes
 
 ## 2018.28
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [MFA Call Factor is Generally Available (GA)](#mfa-call-factor-is-generally-available-ga)   | July 11, 2018            | July 16, 2018                                |
-| [Bugs Fixed in 2018.28](#bugs-fixed-in-2018-28)                                                                       | July 11, 2018            | July 16, 2018                                |
-| [Previously Released Early Access Features 2018.28 Update](#previously-released-early-access-features-2018-28-update) | Available now            | Available now                                
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [MFA Call Factor is Generally Available (GA)](#mfa-call-factor-is-generally-available-ga)                             | July 11, 2018            | July 16, 2018                                |
+| [Bugs Fixed in 2018.28](#bugs-fixed-in-2018-28)                                                                        | July 11, 2018            | July 16, 2018                                |
+| [Previously Released Early Access Features 2018.28 Update](#previously-released-early-access-features-2018-28-update) | Available now            | Available now                                |
 
 ### MFA Call Factor is Generally Available (GA)
 
@@ -18,17 +18,17 @@ The MFA [call factor](/docs/reference/api/factors/#factor-type) is now Generally
 
 * Users received an incorrect error message when using the [System Log API](/docs/reference/api/system-log/) and specifying a sort order with an unbounded `until` statement. (OKTA-175411)
 
- * Under certain circumstances, the [System Log API](/docs/reference/api/system-log/) did not return events on the first query, but did on subsequent queries. (OKTA-174660)
+* Under certain circumstances, the [System Log API](/docs/reference/api/system-log/) did not return events on the first query, but did on subsequent queries. (OKTA-174660)
 
 ### Previously Released Early Access Features 2018.28 Update
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Linked Objects API](#linked-objects-api-in-early-access-ea) |
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Linked Objects API](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-29/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-29/index.md
@@ -4,10 +4,10 @@ title: Okta API Products Release Notes
 
 ## 2018.29
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [Bugs Fixed in 2018.29](#bugs-fixed-in-2018-29)                                                                       | July 18, 2018            | July 23, 2018                                |
-| [Previously Released Early Access Features 2018.29 Update](#previously-released-early-access-features-2018-29-update) | Available now            | Available now                                
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [Bugs Fixed in 2018.29](#bugs-fixed-in-2018-29)                                                                        | July 18, 2018            | July 23, 2018                                |
+| [Previously Released Early Access Features 2018.29 Update](#previously-released-early-access-features-2018-29-update) | Available now            | Available now                                |
 
 
 ### Bugs Fixed in 2018.29
@@ -21,11 +21,11 @@ title: Okta API Products Release Notes
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Linked Objects API](#linked-objects-api-in-early-access-ea) |
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Linked Objects API](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-31/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-31/index.md
@@ -4,9 +4,9 @@ title: Okta API Products Release Notes
 
 ## 2018.31
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [Bugs Fixed in 2018.31](#bugs-fixed-in-2018-31)                                                                       | August 1, 2018           | August 6, 2018                               |
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [Bugs Fixed in 2018.31](#bugs-fixed-in-2018-31)                                                                        | August 1, 2018           | August 6, 2018                               |
 | [Previously Released Early Access Features 2018.31 Update](#previously-released-early-access-features-2018-31-update) | Available now            | Available now                                |
 
 
@@ -27,11 +27,11 @@ title: Okta API Products Release Notes
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Linked Objects API](#linked-objects-api-in-early-access-ea) |
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Linked Objects API](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-32/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-32/index.md
@@ -4,11 +4,11 @@ title: Okta API Products Release Notes
 
 ## 2018.32
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [Interstitial Page Settings are Generally Available (GA)](#interstitial-page-settings-are-generally-available)       | August 8, 2018           | September 2018                               |
-| [New System Log Event Type for Denied Events](#new-system-log-event-type-for-denied-events)                          | August 8, 2018           | August 13, 2018                              |
-| [Bugs Fixed in 2018.32](#bugs-fixed-in-2018-32)                                                                       | August 8, 2018           | August 13, 2018                              |
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [Interstitial Page Settings are Generally Available (GA)](#interstitial-page-settings-are-generally-available)        | August 8, 2018           | September 2018                               |
+| [New System Log Event Type for Denied Events](#new-system-log-event-type-for-denied-events)                           | August 8, 2018           | August 13, 2018                              |
+| [Bugs Fixed in 2018.32](#bugs-fixed-in-2018-32)                                                                        | August 8, 2018           | August 13, 2018                              |
 | [Previously Released Early Access Features 2018.32 Update](#previously-released-early-access-features-2018-32-update) | Available now            | Available now                                |
 
 
@@ -29,11 +29,11 @@ The [System Log](/docs/reference/api/system-log/) now reports when requests are 
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Linked Objects API](#linked-objects-api-in-early-access-ea) |
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Linked Objects API](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-33/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-33/index.md
@@ -4,9 +4,9 @@ title: Okta API Products Release Notes
 
 ## 2018.33
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [Bugs Fixed in 2018.33](#bugs-fixed-in-2018-33)                                                                       | August 15, 2018           | August 20, 2018                              |
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [Bugs Fixed in 2018.33](#bugs-fixed-in-2018-33)                                                                        | August 15, 2018          | August 20, 2018                              |
 | [Previously Released Early Access Features 2018.33 Update](#previously-released-early-access-features-2018-33-update) | Available now            | Available now                                |
 
 ### Bugs Fixed in 2018.33
@@ -18,11 +18,11 @@ title: Okta API Products Release Notes
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Linked Objects API](#linked-objects-api-in-early-access-ea) |
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Linked Objects API](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-35/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-35/index.md
@@ -4,9 +4,9 @@ title: Okta API Products Release Notes
 
 ## 2018.35
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [Bugs Fixed in 2018.35](#bugs-fixed-in-2018-35)                                                                       | August 29, 2018          | September 4, 2018                            |
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [Bugs Fixed in 2018.35](#bugs-fixed-in-2018-35)                                                                        | August 29, 2018          | September 4, 2018                            |
 | [Previously Released Early Access Features 2018.35 Update](#previously-released-early-access-features-2018-35-update) | Available now            | Available now                                |
 
 ### Bugs Fixed in 2018.35
@@ -17,11 +17,11 @@ title: Okta API Products Release Notes
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Linked Objects API](#linked-objects-api-in-early-access-ea) |
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Linked Objects API](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-36/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-36/index.md
@@ -4,15 +4,15 @@ title: Okta API Products Release Notes
 
 ## 2018.36
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [New Device Notification Emails are Generally Available](#new-device-notification-emails-are-generally-available-ga)       | September 5, 2018           | September 10, 2018                               |
-| [Email Rate Limiting](#email-rate-limiting)                          | September 5, 2018           | September 10, 2018                              |
-| [New sendEmail Parameter for User Deletion and Deactivation](#new-sendemail-parameter-for-user-deletion-and-deactivation)                          | September 5, 2018           | October 15, 2018                              |
-| [Support for JWTs Signed with Private Keys](#support-for-jwts-signed-with-private-keys)                          | September 5, 2018           | September 10, 2018                              |
-| [System Log Event for Rate Limit Override Expiration](#system-log-event-for-rate-limit-override-expiration)                          | September 5, 2018           | September 10, 2018                              |
-| [Required Properties in App User Schema](#required-properties-in-app-user-schema)                          | September 5, 2018           | September 10, 2018                              |
-| [Previously Released Early Access Features 2018.36 Update](#previously-released-early-access-features-2018-36-update) | Available now            | Available now                                |
+| Change                                                                                                                    | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| ------------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [New Device Notification Emails are Generally Available](#new-device-notification-emails-are-generally-available-ga)        | September 5, 2018        | September 10, 2018                           |
+| [Email Rate Limiting](#email-rate-limiting)                                                                               | September 5, 2018        | September 10, 2018                           |
+| [New sendEmail Parameter for User Deletion and Deactivation](#new-sendemail-parameter-for-user-deletion-and-deactivation) | September 5, 2018        | October 15, 2018                             |
+| [Support for JWTs Signed with Private Keys](#support-for-jwts-signed-with-private-keys)                                   | September 5, 2018        | September 10, 2018                           |
+| [System Log Event for Rate Limit Override Expiration](#system-log-event-for-rate-limit-override-expiration)               | September 5, 2018        | September 10, 2018                           |
+| [Required Properties in App User Schema](#required-properties-in-app-user-schema)                                         | September 5, 2018        | September 10, 2018                           |
+| [Previously Released Early Access Features 2018.36 Update](#previously-released-early-access-features-2018-36-update)     | Available now            | Available now                                |
 
 ### New Device Notification Emails are Generally Available (GA)
 
@@ -48,11 +48,11 @@ API calls to [modify an app user schema](/docs/reference/api/schemas/#update-app
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Linked Objects API](#linked-objects-api-in-early-access-ea) |
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Linked Objects API](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-38/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-38/index.md
@@ -4,10 +4,10 @@ title: Okta API Products Release Notes
 
 ## 2018.38
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [User Sessions Deleted after Password Reset](#user-sessions-deleted-after-password-reset)                            | September 19, 2018       | October 15, 2018                             |
-| [Bugs Fixed in 2018.38](#bugs-fixed-in-2018-38)                                                                       | September 19, 2018       | September 24, 2018                           |
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [User Sessions Deleted after Password Reset](#user-sessions-deleted-after-password-reset)                             | September 19, 2018       | October 15, 2018                             |
+| [Bugs Fixed in 2018.38](#bugs-fixed-in-2018-38)                                                                        | September 19, 2018       | September 24, 2018                           |
 | [Previously Released Early Access Features 2018.38 Update](#previously-released-early-access-features-2018-38-update) | Available Now            | Available Now                                |
 
 ### User Sessions Deleted after Password Reset
@@ -22,11 +22,11 @@ We now delete all sessions for a user after a successful password reset as part 
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Linked Objects API](#linked-objects-api-in-early-access-ea) |
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Linked Objects API](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-39/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-39/index.md
@@ -4,9 +4,9 @@ title: Okta API Products Release Notes
 
 ## 2018.39
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [Bugs Fixed in 2018.39](#bugs-fixed-in-2018-39)                                                                       | September 26, 2018       | October 1, 2018                           |
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [Bugs Fixed in 2018.39](#bugs-fixed-in-2018-39)                                                                        | September 26, 2018       | October 1, 2018                              |
 | [Previously Released Early Access Features 2018.39 Update](#previously-released-early-access-features-2018-39-update) | Available Now            | Available Now                                |
 
 ### Bugs Fixed in 2018.39
@@ -19,11 +19,11 @@ title: Okta API Products Release Notes
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Linked Objects API](#linked-objects-api-in-early-access-ea) |
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Linked Objects API](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-40/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-40/index.md
@@ -4,9 +4,9 @@ title: Okta API Products Release Notes
 
 ## 2018.40
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [Bugs Fixed in 2018.40](#bugs-fixed-in-2018-40)                                                                       | October 3, 2018       | October 8, 2018                           |
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [Bugs Fixed in 2018.40](#bugs-fixed-in-2018-40)                                                                        | October 3, 2018          | October 8, 2018                              |
 | [Previously Released Early Access Features 2018.40 Update](#previously-released-early-access-features-2018-40-update) | Available Now            | Available Now                                |
 
 ### Bugs Fixed in 2018.40
@@ -18,11 +18,11 @@ title: Okta API Products Release Notes
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Linked Objects API](#linked-objects-api-in-early-access-ea) |
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Linked Objects API](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-41/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-41/index.md
@@ -4,12 +4,12 @@ title: Okta API Products Release Notes
 
 ## 2018.41
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [Rate Limit Notifications for One App and Enterprise](#rate-limit-notifications-for-one-app-and-enterprise)                            | October 10, 2018       | October 15, 2018                             |
-| [OIDC Clients Can Initiate Logout with Expired Token](#oidc-clients-can-initiate-logout-with-expired-token)                            | October 10, 2018       | October 15, 2018                             |
-| [Change to User Link Editing Permissions](#change-to-user-link-editing-permissions)                            | October 10, 2018       | October 15, 2018                             |
-| [Bugs Fixed in 2018.41](#bugs-fixed-in-2018-41)                                                                       | October 10, 2018         | October 15, 2018                             |
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [Rate Limit Notifications for One App and Enterprise](#rate-limit-notifications-for-one-app-and-enterprise)             | October 10, 2018         | October 15, 2018                             |
+| [OIDC Clients Can Initiate Logout with Expired Token](#oidc-clients-can-initiate-logout-with-expired-token)           | October 10, 2018         | October 15, 2018                             |
+| [Change to User Link Editing Permissions](#change-to-user-link-editing-permissions)                                   | October 10, 2018         | October 15, 2018                             |
+| [Bugs Fixed in 2018.41](#bugs-fixed-in-2018-41)                                                                        | October 10, 2018         | October 15, 2018                             |
 | [Previously Released Early Access Features 2018.41 Update](#previously-released-early-access-features-2018-41-update) | Available Now            | Available Now                                |
 
 ### Rate Limit Notifications for One App and Enterprise
@@ -33,11 +33,11 @@ Editing the [link](/docs/reference/api/users/#links-object) between users now re
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Linked Objects API](#linked-objects-api-in-early-access-ea) |
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Linked Objects API](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-42/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-42/index.md
@@ -4,9 +4,9 @@ title: Okta API Products Release Notes
 
 ## 2018.42
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [Bugs Fixed in 2018.42](#bugs-fixed-in-2018-42)                                                                       | October 17, 2018         | October 22, 2018                             |
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [Bugs Fixed in 2018.42](#bugs-fixed-in-2018-42)                                                                        | October 17, 2018         | October 22, 2018                             |
 | [Previously Released Early Access Features 2018.42 Update](#previously-released-early-access-features-2018-42-update) | Available Now            | Available Now                                |
 
 ### Bugs Fixed in 2018.42
@@ -18,11 +18,11 @@ title: Okta API Products Release Notes
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Linked Objects API](#linked-objects-api-in-early-access-ea) |
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Linked Objects API](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-44/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-44/index.md
@@ -4,9 +4,9 @@ title: Okta API Products Release Notes
 
 ## 2018.44
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [Bugs Fixed in 2018.44](#bugs-fixed-in-2018-44)                                                                       | October 31, 2018         | November 5, 2018                             |
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [Bugs Fixed in 2018.44](#bugs-fixed-in-2018-44)                                                                        | October 31, 2018         | November 5, 2018                             |
 | [Previously Released Early Access Features 2018.44 Update](#previously-released-early-access-features-2018-44-update) | Available Now            | Available Now                                |
 
 ### Bugs Fixed in 2018.44
@@ -18,11 +18,11 @@ title: Okta API Products Release Notes
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Linked Objects API](#linked-objects-api-in-early-access-ea) |
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Linked Objects API](#linked-objects-api-in-early-access-ea)                                                                        |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-45/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-45/index.md
@@ -4,10 +4,10 @@ title: Okta API Products Release Notes
 
 ## 2018.45
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [Linked Objects API is Generally Available (GA)](#linked-objects-api-is-generally-available-ga)                            | November 6, 2018       | December 10, 2018                             |
-| [Bugs Fixed in 2018.45](#bugs-fixed-in-2018-45)                                                                       | November 6, 2018         | November 12, 2018                             |
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [Linked Objects API is Generally Available (GA)](#linked-objects-api-is-generally-available-ga)                       | November 6, 2018         | December 10, 2018                            |
+| [Bugs Fixed in 2018.45](#bugs-fixed-in-2018-45)                                                                        | November 6, 2018         | November 12, 2018                            |
 | [Previously Released Early Access Features 2018.45 Update](#previously-released-early-access-features-2018-45-update) | Available Now            | Available Now                                |
 
 ### Linked Objects API is Generally Available (GA)
@@ -23,10 +23,10 @@ The [Linked Objects API](/docs/reference/api/linked-objects/) is now available t
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-48/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-48/index.md
@@ -4,10 +4,10 @@ title: Okta API Products Release Notes
 
 ## 2018.48
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [System Log API Returns Threat Insight Attribute](#system-log-api-returns-threat-insight-attribute)                            | November 28, 2018       | December 3, 2018                             |
-| [Bugs Fixed in 2018.48](#bugs-fixed-in-2018-48)                                                                       | November 28, 2018         | December 3, 2018                             |
+| Change                                                                                                                | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [System Log API Returns Threat Insight Attribute](#system-log-api-returns-threat-insight-attribute)                   | November 28, 2018        | December 3, 2018                             |
+| [Bugs Fixed in 2018.48](#bugs-fixed-in-2018-48)                                                                        | November 28, 2018        | December 3, 2018                             |
 | [Previously Released Early Access Features 2018.48 Update](#previously-released-early-access-features-2018-48-update) | Available Now            | Available Now                                |
 
 ### System Log API Returns Threat Insight Attribute
@@ -24,10 +24,10 @@ The `debugContext` object returned by the [System Log API](/docs/reference/api/s
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [Token Management API](#token-management-api-is-in-early-access-ea) |
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [Token Management API](#token-management-api-is-in-early-access-ea)                                                                 |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-49/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-49/index.md
@@ -6,9 +6,9 @@ title: Okta API Products Release Notes
 
 > **Note:** Okta has changed our release model and version numbering. Under the old system, this would have been release 2019.49. For more information, see here: <https://support.okta.com/help/s/article/New-Okta-Release-Model>
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [Bug Fixed in 2018.12.0](#bug-fixed-in-2018-12-0)                                                                       | December 5, 2018         | December 10, 2018                             |
+| Change                                                                                                                    | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| ------------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [Bug Fixed in 2018.12.0](#bug-fixed-in-2018-12-0)                                                                          | December 5, 2018         | December 10, 2018                            |
 | [Previously Released Early Access Features 2018.12.0 Update](#previously-released-early-access-features-2018-12-0-update) | Available Now            | Available Now                                |
 
 ### Bug Fixed in 2018.12.0
@@ -19,9 +19,9 @@ title: Okta API Products Release Notes
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-50/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-50/index.md
@@ -6,9 +6,9 @@ title: Okta API Products Release Notes
 
 > **Note:** Okta has changed our release model and version numbering. Under the old system, this would have been release 2019.50. For more information, see here: <https://support.okta.com/help/s/article/New-Okta-Release-Model>
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [Bug Fixed in 2018.12.1](#bug-fixed-in-2018-12-1)                                                                       | December 12, 2018         | December 17, 2018                             |
+| Change                                                                                                                    | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| ------------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [Bug Fixed in 2018.12.1](#bug-fixed-in-2018-12-1)                                                                          | December 12, 2018        | December 17, 2018                            |
 | [Previously Released Early Access Features 2018.12.1 Update](#previously-released-early-access-features-2018-12-1-update) | Available Now            | Available Now                                |
 
 ### Bug Fixed in 2018.12.1
@@ -19,9 +19,9 @@ title: Okta API Products Release Notes
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/2018-52/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2018-52/index.md
@@ -6,9 +6,9 @@ title: Okta API Products Release Notes
 
 > **Note:** Okta has changed our release model and version numbering. Under the old system, this would have been release 2018.52. For more information, see here: <https://support.okta.com/help/s/article/New-Okta-Release-Model>
 
-| Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
-| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [Bugs Fixed in 2018.12.2](#bugs-fixed-in-2018-12-2)                                                                       | December 27, 2018         | January 7, 2019                             |
+| Change                                                                                                                    | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
+| ------------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
+| [Bugs Fixed in 2018.12.2](#bugs-fixed-in-2018-12-2)                                                                        | December 27, 2018        | January 7, 2019                              |
 | [Previously Released Early Access Features 2018.12.2 Update](#previously-released-early-access-features-2018-12-2-update) | Available Now            | Available Now                                |
 
 ### Bugs Fixed in 2018.12.2
@@ -25,9 +25,9 @@ title: Okta API Products Release Notes
 
 The following features have already been released as Early Access. To enable them, contact [Support](https://support.okta.com/help/open_case).
 
-| Early Access Features Available Now
-| :------------------------------------------------- |
-| [Custom URL Domains](#custom-url-domains-are-in-early-access)|
-| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)|
-| [Custom Error Page](#custom-error-page-is-in-early-access)|
-| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea) |
+| Early Access Features Available Now                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Custom URL Domains](#custom-url-domains-are-in-early-access)                                                                       |
+| [Custom Okta-hosted Sign-In Page](#custom-okta-hosted-sign-in-page-is-in-early-access)                                              |
+| [Custom Error Page](#custom-error-page-is-in-early-access)                                                                          |
+| [User Consent for OAuth 2.0 and OpenID Connect Flows](#user-consent-for-oauth-20-and-openid-connect-flows-in-early-availability-ea)  |

--- a/packages/@okta/vuepress-site/docs/release-notes/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/index.md
@@ -3,7 +3,8 @@ title: Okta API Products Release Notes | Okta Developer
 meta:
   - name: description
     content: List of changes to the Okta API and related API...
-component: ReleaseNotes
+showToc: false
+layout: Landing
 ---
 
 # Okta API Products Release Notes

--- a/packages/@okta/vuepress-theme-default/assets/css/okta/components/Breadcrumbs.scss
+++ b/packages/@okta/vuepress-theme-default/assets/css/okta/components/Breadcrumbs.scss
@@ -4,6 +4,18 @@
 .breadcrumb-nav {
 	border-bottom: 2px solid #e5e9eb;
 
+	ol.breadcrumb li.show-contents {
+		visibility: hidden;
+		@extend %all-caps;
+		font-size: get-font-size('button');
+		color: $dark-cerulean;
+		cursor: pointer;
+	}
+
+	ol.breadcrumb li.show-contents:hover {
+		text-decoration: underline
+	}
+
 	@include media('>=1024px') {
 		margin-top: 95px;
 	}
@@ -12,6 +24,9 @@
 	}
 	@include media('<860px') {
 		margin-top: 5px;
+		ol.breadcrumb li.show-contents {
+			visibility: visible;
+		}
 	}
 	@include media('<=600px') {
 		margin-top: 75px;
@@ -42,6 +57,10 @@ ol.breadcrumb {
 			color: get-color('iron');
 			content: $chevron-small;
 			align-items: center;
+		}
+
+		&.show-contents::after {
+			content: '';
 		}
 
 		a {

--- a/packages/@okta/vuepress-theme-default/assets/css/okta/pages/landing.scss
+++ b/packages/@okta/vuepress-theme-default/assets/css/okta/pages/landing.scss
@@ -5,6 +5,13 @@
 .landing-page-content {
   display: flex;
   padding-top: 20px;
+
+  @include media('<860px') {
+    .landing-navigation {
+      display: none;
+    }
+  }
+  
 }
 
 .landing-content { 
@@ -20,7 +27,12 @@
   padding-right: 2rem;
   width: 250px;
   flex: 0 0 auto;
-
+  
+	@include media('<860px') {
+	  &.main {
+      display: none;
+    }
+	}
   a {
     cursor: pointer
   }

--- a/packages/@okta/vuepress-theme-default/assets/css/okta/pages/landing.scss
+++ b/packages/@okta/vuepress-theme-default/assets/css/okta/pages/landing.scss
@@ -24,6 +24,10 @@ $big-spacing: 3rem;
   max-width: 750px;
 }
 
+.landing-content.full-width {
+  max-width: 100%;
+}
+
 .landing-navigation {
   padding-right: 2rem;
   width: 250px;
@@ -63,7 +67,7 @@ $big-spacing: 3rem;
       padding-left: $indent;
     }
 
-    &.active {
+    a.active {
       font-weight: bold;
     }
 

--- a/packages/@okta/vuepress-theme-default/assets/css/okta/pages/landing.scss
+++ b/packages/@okta/vuepress-theme-default/assets/css/okta/pages/landing.scss
@@ -48,13 +48,21 @@ $big-spacing: 3rem;
       width: $icon-size;
     }
 
-    &.active {
+    &:first-child:before {
+      content: ''
+    }
+
+    &.overview {
       font-weight: bold;
       $indent: 20px;
       border-bottom: 2px solid black;
       background-color: #e5edfb;
       margin-left: -($indent);
       padding-left: $indent;
+    }
+
+    &.active {
+      font-weight: bold;
     }
 
     &.subnav:before {

--- a/packages/@okta/vuepress-theme-default/assets/css/okta/pages/landing.scss
+++ b/packages/@okta/vuepress-theme-default/assets/css/okta/pages/landing.scss
@@ -1,16 +1,3 @@
-$border-color: #b7bcc0;
-$text-color: #5c6971;
-$title-color: #3d3d3d;
-$action-base: #1662dd;
-$action-dark: #124a94;
-$gray-000: #fafafa;
-$gray-100: #e4e5e7;
-$gray-900: #2f3f4a;
-$tiny-spacing: 0.375rem;
-$small-spacing: 0.75rem;
-$base-spacing: 1.5rem;
-$big-spacing: 3rem;
-
 .okta-landing .TableOfContents {
   top: 160px;
   z-index: 10;
@@ -22,6 +9,7 @@ $big-spacing: 3rem;
 
 .landing-content { 
   max-width: 750px;
+  overflow: scroll;
 }
 
 .landing-content.full-width {
@@ -47,44 +35,54 @@ $big-spacing: 3rem;
     $icon-size: 1.3rem;
 
     &:before {
-      content: '\2022';
+      content: '';
       display: inline-block;
       text-align: center;
       margin-left: -($icon-size);
       width: $icon-size;
+      color: #1662DD;
     }
 
     &:first-child:before {
       content: ''
     }
 
-    &.overview {
-      font-weight: bold;
-      $indent: 20px;
-      border-bottom: 2px solid black;
-      background-color: #e5edfb;
-      margin-left: -($indent);
-      padding-left: $indent;
+    a:hover,
+    a:hover:before {
+      color: #124A94;
+      text-decoration: none;
     }
+    
 
     a.active {
       font-weight: bold;
+      border-left: 2px solid #2F3F4A;
+      margin-left: -12px;
+      padding-left: 10px;
+      color: #2F3F4A;
+    }
+
+    &.subnav > a.active {
+      border-left: none;
+      padding-left: 12px;
     }
 
     &.subnav:before {
-        content: '\f138'; /* chevron-circle-right per https://fontawesome.com/cheatsheet?from=io*/
+        content: '\f0da'; 
         font-family: FontAwesome;
         display: inline-block;
         margin-left: -($icon-size);
         width: $icon-size;
+        color: #1662DD;
     }
     &.subnav.open:before {
-      content: '\f13a'; /* chevron-circle-down per https://fontawesome.com/cheatsheet?from=io*/
+      content: '\f0d7'; 
     }
+
   }
 
   a {
-    color: $text-color;
+    color: #1662DD;
     font-size: 0.85rem;
   }
 
@@ -92,7 +90,7 @@ $big-spacing: 3rem;
     margin-left: 1.5rem;
 
     a {
-      color: $text-color;
+      color: #1662DD;
       font-size: 0.85rem;
     }
 

--- a/packages/@okta/vuepress-theme-default/assets/css/okta/pages/landing.scss
+++ b/packages/@okta/vuepress-theme-default/assets/css/okta/pages/landing.scss
@@ -11,15 +11,17 @@ $small-spacing: 0.75rem;
 $base-spacing: 1.5rem;
 $big-spacing: 3rem;
 
-
+.okta-landing .TableOfContents {
+  top: 160px;
+  z-index: 10;
+}
 .landing-page-content {
   display: flex;
   padding-top: 20px;
 }
 
 .landing-content { 
-  width: 100%;
-  max-width: 890px;
+  max-width: 750px;
 }
 
 .landing-navigation {
@@ -85,7 +87,7 @@ $big-spacing: 3rem;
   .sections {
     margin-left: 1.5rem;
 
-    .section {
+    a {
       color: $text-color;
       font-size: 0.85rem;
     }

--- a/packages/@okta/vuepress-theme-default/components/Sidebar.vue
+++ b/packages/@okta/vuepress-theme-default/components/Sidebar.vue
@@ -24,7 +24,9 @@
 
     <aside class="landing-navigation" v-else>
       <ul class="landing">
-        <li :class="{overview: true}">Overview</li>
+        <li :class="{overview: true}">
+          <router-link :to="overview.path" :class="{active: isActive(overview)}">{{overview.title}}</router-link>
+        </li>
         <li v-for="link in navigation" :key="link.title" :class="{subnav: showSublinks(link), open: $page.path.includes(link.path)}">
           <a :href="link.path" :class="{active: isActive(link)}">{{link.title}}</a>
           <ol v-if="subLinks(link) && $page.path.includes(link.path)"  class="sections">
@@ -51,7 +53,11 @@
     },
     data () {
       return {
-        sidebarActive: false
+        sidebarActive: false,
+        overview: {
+          title: 'Overview',
+          path: '#'
+        }
       }
     },
     computed: {
@@ -61,6 +67,8 @@
         }
 
         if (this.$page.path.includes('/docs/concepts/')) {
+          this.overview.title = 'Concepts';
+          this.overview.path = '/docs/concepts/';
           const conceptsRegex = /(\/docs\/concepts\/)[A-Za-z-]*\/$/;
           return _.chain(this.$site.pages)
           .filter(page => page.path.match(conceptsRegex))
@@ -70,6 +78,8 @@
         }
 
         if (this.$page.path.includes('/docs/reference/')) {
+          this.overview.title = 'Reference';
+          this.overview.path = '/docs/reference/';
           const referenceRegex = /(\/docs\/reference\/)[A-Za-z-]*\/$/;
           return _.chain(this.$site.pages)
           .filter(page => page.path.match(referenceRegex))
@@ -79,25 +89,27 @@
         }
 
         if (this.$page.path.includes('/docs/release-notes/')) {
-          const releaseNotesRegex = /(\/docs\/)[A-Za-z-]*\/$/;
-          return _.chain(this.$site.pages)
-          .filter(page => page.path.match(releaseNotesRegex))
-          .sortBy(page => page.title)
-          .map(page => {
-            if(page.path.includes('release-notes')) {
-              page.title = 'Release Notes';
-            }
-            if(page.path.includes('guides')) {
-              page.title = 'Guides';
-            }
-            if(page.path.includes('reference')) {
-              page.title = 'Reference';
-            }
-            return page;
-          })
-          .sortBy(page => page.title)
-          .value();
-
+          this.overview.title = 'Release Notes';
+          this.overview.path = '/docs/release-notes/';
+          // const releaseNotesRegex = /(\/docs\/)[A-Za-z-]*\/$/;
+          // return _.chain(this.$site.pages)
+          // .filter(page => page.path.match(releaseNotesRegex))
+          // .sortBy(page => page.title)
+          // .map(page => {
+          //   if(page.path.includes('release-notes')) {
+          //     page.title = 'Release Notes';
+          //   }
+          //   if(page.path.includes('guides')) {
+          //     page.title = 'Guides';
+          //   }
+          //   if(page.path.includes('reference')) {
+          //     page.title = 'Reference';
+          //   }
+          //   return page;
+          // })
+          // .sortBy(page => page.title)
+          // .value();
+          return false;
           
         }
 

--- a/packages/@okta/vuepress-theme-default/components/Sidebar.vue
+++ b/packages/@okta/vuepress-theme-default/components/Sidebar.vue
@@ -125,6 +125,9 @@
       },
 
       subLinks: function(link) {
+        if(link.path.includes('release-notes')) {
+          return false;
+        }
         let allCatPages = _.chain(this.$site.pages)
           .filter(page => page.path.includes(link.path))
           .filter(page => page.path != link.path)
@@ -132,22 +135,25 @@
           .value();
 
         if(allCatPages.length > 0) {
-          if(link.path.includes('release-notes')) {
-            allCatPages = _.chain(allCatPages)
-            .map(page => {
-              page.title = page.headers[0].title;
-              page.path = '/docs/release-notes/#_'+page.headers[0].title.replace(/\./g, '-');
-              return page;
-            })
-            .reverse()
-            .value();
-          }
+          // if(link.path.includes('release-notes')) {
+          //   allCatPages = _.chain(allCatPages)
+          //   .map(page => {
+          //     page.title = page.headers[0].title;
+          //     page.path = '/docs/release-notes/#_'+page.headers[0].title.replace(/\./g, '-');
+          //     return page;
+          //   })
+          //   .reverse()
+          //   .value();
+          // }
           return allCatPages;
         }
         return false;
       },
 
       showSublinks(link) {
+        if(link.path.includes('release-notes')) {
+            return false;
+          }
         const allCatPages = _.chain(this.$site.pages)
           .filter(page => page.path.includes(link.path))
           .filter(page => page.path != link.path)
@@ -155,6 +161,7 @@
           .value();
 
         if(allCatPages.length > 0) {
+          
           return allCatPages;
         }
 

--- a/packages/@okta/vuepress-theme-default/components/Sidebar.vue
+++ b/packages/@okta/vuepress-theme-default/components/Sidebar.vue
@@ -78,6 +78,29 @@
           .value();
         }
 
+        if (this.$page.path.includes('/docs/release-notes/')) {
+          const releaseNotesRegex = /(\/docs\/)[A-Za-z-]*\/$/;
+          return _.chain(this.$site.pages)
+          .filter(page => page.path.match(releaseNotesRegex))
+          .sortBy(page => page.title)
+          .map(page => {
+            if(page.path.includes('release-notes')) {
+              page.title = 'Release Notes';
+            }
+            if(page.path.includes('guides')) {
+              page.title = 'Guides';
+            }
+            if(page.path.includes('reference')) {
+              page.title = 'Reference';
+            }
+            return page;
+          })
+          .sortBy(page => page.title)
+          .value();
+
+          
+        }
+
         return this.$site.themeConfig.sidebars.main
       }
     },
@@ -102,13 +125,23 @@
       },
 
       subLinks: function(link) {
-        const allCatPages = _.chain(this.$site.pages)
+        let allCatPages = _.chain(this.$site.pages)
           .filter(page => page.path.includes(link.path))
           .filter(page => page.path != link.path)
           .sortBy(page => page.title)
           .value();
 
         if(allCatPages.length > 0) {
+          if(link.path.includes('release-notes')) {
+            allCatPages = _.chain(allCatPages)
+            .map(page => {
+              page.title = page.headers[0].title;
+              page.path = '/docs/release-notes/#_'+page.headers[0].title.replace(/\./g, '-');
+              return page;
+            })
+            .reverse()
+            .value();
+          }
           return allCatPages;
         }
         return false;

--- a/packages/@okta/vuepress-theme-default/components/Sidebar.vue
+++ b/packages/@okta/vuepress-theme-default/components/Sidebar.vue
@@ -151,7 +151,7 @@
       },
 
       showSublinks(link) {
-        if(link.path.includes('release-notes')) {
+        if(link.path && link.path.includes('release-notes')) {
             return false;
           }
         const allCatPages = _.chain(this.$site.pages)

--- a/packages/@okta/vuepress-theme-default/components/Sidebar.vue
+++ b/packages/@okta/vuepress-theme-default/components/Sidebar.vue
@@ -137,7 +137,7 @@
       },
 
       subLinks: function(link) {
-        if(link.path.includes('release-notes')) {
+        if(link.path && link.path.includes('release-notes')) {
           return false;
         }
         let allCatPages = _.chain(this.$site.pages)

--- a/packages/@okta/vuepress-theme-default/components/Sidebar.vue
+++ b/packages/@okta/vuepress-theme-default/components/Sidebar.vue
@@ -69,6 +69,15 @@
           .value();
         }
 
+        if (this.$page.path.includes('/docs/reference/')) {
+          const referenceRegex = /(\/docs\/reference\/)[A-Za-z-]*\/$/;
+          return _.chain(this.$site.pages)
+          .filter(page => page.path.match(referenceRegex))
+          .sortBy(page => page.title)
+          .sort()
+          .value();
+        }
+
         return this.$site.themeConfig.sidebars.main
       }
     },
@@ -84,10 +93,11 @@
         if (link.subLinks) {
           return false
         }
+        
         if (this.$page.path.includes('/code/')) {
           return this.$page.path.includes(link.activeCheck)
         }
-        console.log(this.$page.path, link.path, this.$page.path == link.path)
+        
         return this.$page.path == link.path
       },
 

--- a/packages/@okta/vuepress-theme-default/components/Sidebar.vue
+++ b/packages/@okta/vuepress-theme-default/components/Sidebar.vue
@@ -24,7 +24,7 @@
 
     <aside class="landing-navigation" v-else>
       <ul class="landing">
-        <li v-for="link in navigation" :key="link.title" :class="{ active: isActive(link) || link.overview == true, subnav: link.links}">
+        <li v-for="link in navigation" :key="link.title" :class="{ overview: link.overview, active: isActive(link), subnav: link.links}">
           <a :href="link.link" v-on:click="expandSubNav">{{link.title}}</a>
           <ol v-if="link.links" v-show="link.links && showSublinks(link)" class="sections" :id=link.subLinksId>
             <li v-for="subLink in link.links" :key="subLink.title" :class="{section: true}">
@@ -40,6 +40,8 @@
 </template>
 
 <script>
+  import _ from 'lodash';
+
   export default {
     name: 'Sidebar',
     props: {
@@ -59,8 +61,14 @@
           return this.$site.themeConfig.sidebars.codePages
         }
 
-        if (this.$page.path == '/docs/concepts/') {
-          return this.$site.themeConfig.sidebars.concepts
+        if (this.$page.path.includes('/docs/concepts/')) {
+
+          return _.chain(this.$site.pages)
+          .filter(page => page.path.includes('/docs/concepts/'))
+          .sort()
+          .value();
+
+          // return this.$site.themeConfig.sidebars.concepts
         }
 
         return this.$site.themeConfig.sidebars.main
@@ -82,7 +90,7 @@
           return this.$page.path.includes(link.activeCheck)
         }
 
-        return this.$page.path.includes(link.link)
+        return this.$page.path == link.link
       },
 
       showSublinks(link) {

--- a/packages/@okta/vuepress-theme-default/global-components/Breadcrumb.vue
+++ b/packages/@okta/vuepress-theme-default/global-components/Breadcrumb.vue
@@ -2,19 +2,34 @@
   <nav class="breadcrumb-nav" aria-label="breadcrumb">
     <ol class="breadcrumb Wrap" :style="wrapStyle">
       <li class="breadcrumb-item" v-for="crumb in breadcrumb" :key="crumb.path"><router-link :to="crumb.path">{{crumb.title}}</router-link></li>
+      <li class="breadcrumb-item show-contents" v-on:click="showSidebar = !showSidebar">Show Contents</li>
     </ol>
+    <div v-if="showSidebar" style="padding: 10px 25px;">
+    <Sidebar :oldNavigation=false />
+    </div>
   </nav>
 </template>
 
 <script>
   export default {
     name: "Breadcrumb",
+    components: {
+      Sidebar: () => import('../components/Sidebar.vue')
+    },
+
     props: {
       wrapStyle: {
         default: "",
         type: String
       }
     },
+
+    data() {
+      return {
+        showSidebar: false
+      }
+    },
+
     computed: {
       breadcrumb() {
 

--- a/packages/@okta/vuepress-theme-default/global-components/Breadcrumb.vue
+++ b/packages/@okta/vuepress-theme-default/global-components/Breadcrumb.vue
@@ -48,6 +48,14 @@
           return crumbs;
         }
 
+        if(this.$page.path.startsWith('/docs/release-notes/')) {
+          crumbs.push(
+            {path: '/docs/', title: 'Docs'},
+            {path: '/docs/release-notes/', title: 'Release Notes' },
+          );
+          return crumbs;
+        }
+
         if(this.$page.path == '/reference/' || this.$page.path.startsWith('/code/')) {
           crumbs.push({path: '/docs/', title: 'DOCS'})
           return crumbs

--- a/packages/@okta/vuepress-theme-default/layouts/Landing.vue
+++ b/packages/@okta/vuepress-theme-default/layouts/Landing.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="Page okta-landing">
+  <div :class="pageClasses" class="Page okta-landing">
     <TopNavigation />
     <Breadcrumb />
     <section class="PageContent NoPaddingTop">
       <!-- START Page Content -->
       <div class="PageContent-main">
         <div class="landing-wrap">
-          <div class="landing-page-content">
+          <div class="landing-page-content" >
             <Sidebar :oldNavigation=false />
             <div class="landing-content">
               <Content />
@@ -14,8 +14,14 @@
           </div>
         </div>
       </div>
+      
       <!-- END Page Content -->
+      
     </section>
+    <!-- Begin Table Of Contents -->
+      <TableOfContents v-if="showToc" class="TableOfContents"></TableOfContents>
+      <!-- End Table Of Contents -->
+    
     <Footer/>
   </div>
 </template>
@@ -25,7 +31,22 @@ export default {
   components: {
     TopNavigation: () => import('../components/TopNavigation.vue'),
     Footer: () => import('../components/Footer.vue'),
-    Sidebar: () => import('../components/Sidebar.vue')
+    Sidebar: () => import('../components/Sidebar.vue'),
+    TableOfContents: () => import('../components/TableOfContents.vue')
+  },
+
+  computed: {
+    showToc () {
+      if (this.$page.frontmatter.showToc === false) {
+        return false;
+      }
+
+      if (this.$page.path.includes('/code/')) {
+        return false;
+      }
+
+      return true;
+    }
   }
 }
 

--- a/packages/@okta/vuepress-theme-default/layouts/Landing.vue
+++ b/packages/@okta/vuepress-theme-default/layouts/Landing.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="pageClasses" class="Page okta-landing">
+  <div class="Page okta-landing">
     <TopNavigation />
     <Breadcrumb />
     <section class="PageContent NoPaddingTop">
@@ -8,19 +8,18 @@
         <div class="landing-wrap">
           <div class="landing-page-content" >
             <Sidebar :oldNavigation=false />
-            <div class="landing-content">
+            <div class="landing-content" :class="{'full-width': !showToc}">
               <Content />
             </div>
           </div>
         </div>
       </div>
-      
+      <!-- Begin Table Of Contents -->
+      <TableOfContents v-if="showToc" class="TableOfContents"></TableOfContents>
+      <!-- End Table Of Contents -->
       <!-- END Page Content -->
       
     </section>
-    <!-- Begin Table Of Contents -->
-      <TableOfContents v-if="showToc" class="TableOfContents"></TableOfContents>
-      <!-- End Table Of Contents -->
     
     <Footer/>
   </div>


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Adds a temporary prose style layout to concepts/references/release-notes
- **Is this PR related to a Monolith release?** no

### release-notes
<img width="3120" alt="Screen Shot 2019-11-11 at 4 11 59 PM" src="https://user-images.githubusercontent.com/1906920/68621681-5d9aee80-049e-11ea-9506-e9214e712719.png">

### concepts
<img width="3120" alt="Screen Shot 2019-11-11 at 4 13 55 PM" src="https://user-images.githubusercontent.com/1906920/68621689-625fa280-049e-11ea-9519-65bfd483a1f1.png">

### reference
<img width="3120" alt="Screen Shot 2019-11-11 at 4 14 03 PM" src="https://user-images.githubusercontent.com/1906920/68621658-51169600-049e-11ea-8a24-fd4b0dba1c87.png">




### Resolves:

* [OKTA-255232](https://oktainc.atlassian.net/browse/OKTA-255232)
* [OKTA-257095](https://oktainc.atlassian.net/browse/OKTA-257095)
