### PR TITLE
Fix U2F + WebAuthn Factors API doc placement and wording

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/factors/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/factors/index.md
@@ -2789,7 +2789,7 @@ curl -v -X POST \
 
 <ApiOperation method="post" url="/api/v1/users/${userId}/factors/${factorId}/verify" />
 
-Creates a new transaction and sends an asynchronous push notification to the device for the user to approve or reject.  You must [poll the transaction](#poll-for-verify-transaction-completion) to determine when it completes or expires.
+Creates a new transaction and sends an asynchronous push notification to the device for the user to approve or reject. You must [poll the transaction](#poll-for-verify-transaction-completion) to determine when it completes or expires.
 
 ##### Start new Transaction
 
@@ -3039,7 +3039,7 @@ curl -v -X POST \
 
 <ApiOperation method="post" url="/api/v1/users/${userId}/factors/${factorId}/verify" />
 
-Verifies an OTP for an `email` factor
+Verifies an OTP for an `email` factor.
 
 #### Request Parameters
 
@@ -3090,6 +3090,294 @@ curl -v -X POST \
 ```json
 {
   "factorResult": "SUCCESS"
+}
+```
+
+### Issue a U2F Factor Challenge
+
+<ApiOperation method="post" url="/api/v1/users/${userId}/factors/${factorId}/verify" />
+
+Initiates verification for a `u2f` factor by getting a challenge nonce string.
+
+Note:
+
+According to
+[FIDO
+spec](https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-appid-and-facets-v1.2-ps-20170411.html#h2_the-appid-and-facetid-assertions), activating and verifying a U2F device with appIds in different DNS zone is not allowed. For example, if a user activated a U2F device via the Factors API from a server hosted at `https://foo.example.com`, the user can verify the U2F factor from `https://foo.example.com`, but will not be able to verify it from Okta portal `https://company.okta.com`.  Here, the U2F device would return error code 4 - `DEVICE_INELIGIBLE`.
+
+#### Start Verification to Get Challenge Nonce
+
+Verification of the U2F factor starts with getting the challenge nonce and U2F token details and then using the client-side
+JavaScript API to get the signed assertion from the U2F token.
+
+#### Request Example
+
+```bash
+curl -v -X POST \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+"https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/fuf2rovRxogXJ0nDy0g4/verify"
+```
+
+#### Response Example
+
+```json
+{
+  "factorResult":"CHALLENGE",
+  "profile":{
+    "credentialId":"GAiiLsVab2m3-zL1Fi3bVtNrM9G6_MntUITHKjxkV24ktGKjLSCRnz72wCEdHCe18IvC69Aia0sE4UpsO0HpFQ",
+    "version":"U2F_V2"
+  },
+  "_links":{
+    "verify":{
+      "href":"https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/fuf2rovRxogXJ0nDy0g4/verify",
+      "hints":{
+        "allow":[
+          "POST"
+        ]
+      }
+    },
+    "factor":{
+      "href":"https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/fuf2rovRxogXJ0nDy0g4",
+      "hints":{
+        "allow":[
+          "GET",
+          "DELETE"
+        ]
+      }
+    }
+  },
+  "_embedded":{
+    "challenge":{
+      "nonce":"vQFwTt6zKzMV7HFPzjS2",
+      "timeoutSeconds":20
+    }
+  }
+}
+```
+
+#### Get the Signed Assertion from the U2F Token by calling the U2F Javascript API
+
+```html
+<!-- Get the u2f-api.js from https://github.com/google/u2f-ref-code/tree/master/u2f-gae-demo/war/js -->
+<script src="/u2f-api.js"></script>
+<script>
+  // Use the nonce from the challenge object
+  var challengeNonce = response._embedded.challenge.nonce;
+
+  // Use the origin of your app that is calling the factors API
+  var appId = "https://foo.example.com";
+
+  // Use the version and credentialId from factor profile object
+  var registeredKeys = [
+    {
+      version: factor.profile.version,
+      keyHandle: factor.profile.credentialId
+    }
+  ];
+
+  // Call the U2F javascript API to get signed assertion from the U2F token
+  u2f.sign(appId, factorData.challenge.nonce, registeredKeys, function (data) {
+    if (data.errorCode && data.errorCode !== 0) {
+      // Error from U2F platform
+    } else {
+      // Get the client data from callback result
+      var clientData = data.clientData;
+
+      // Get the signature data from callback result
+      var signatureData = data.signatureData;
+    }
+  });
+</script>
+```
+
+#### Post the signed assertion to Okta to complete verification
+
+
+### Verify a U2F Factor Challenge
+
+<ApiOperation method="post" url="/api/v1/users/${userId}/factors/${factorId}/verify" />
+
+Verifies a challenge for a `u2f` factor by posting a signed assertion using the challenge nonce.
+
+#### Request Example for Signed Assertion
+
+```bash
+curl -v -X POST \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+-d '{
+  "clientData":"eyJ0eXAiOiJuYXZpZ2F0b3IuaWQuZ2V0QXNzZXJ0aW9uIiwiY2hhbGxlbmdlIjoiS2NCLXRqUFU0NDY0ZThuVFBudXIiLCJvcmlnaW4iOiJodHRwczovL2xvY2FsaG9zdDozMDAwIiwiY2lkX3B1YmtleSI6InVudXNlZCJ9",
+  "signatureData":"AQAAACYwRgIhAKPktdpH0T5mlPSm_9uGW5w-VaUy-LhI9tIacexpgItkAiEAncRVZURVPOq7zDwIw-OM5LtSkdAxOkfv0ZDVUx3UFHc"
+}' "https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/fuf2rovRxogXJ0nDy0g4/verify"
+```
+
+#### Response of U2F Verification Example
+
+```json
+{
+  "factorResult":"SUCCESS",
+  "profile":{
+    "credentialId":"h1bFwJFU9wnelYkexJuQfoUHZ5lX3CgQMTZk4H3I8kM9Nn6XALiQ-BIab4P5EE0GQrA7VD-kAwgnG950aXkhBw",
+    "version":"U2F_V2"
+  }
+}
+```
+
+### Verify YubiKey Factor
+
+<ApiOperation method="post" url="/api/v1/users/${userId}/factors/${factorId}/verify" />
+Verifies a user with a [Yubico OTP](https://developers.yubico.com/OTP/OTPs_Explained.html) for a YubiKey `token:hardware` factor.
+
+#### Request Example for Verify YubiKey Factor
+
+```bash
+curl -v -X POST \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+-d '{
+"passCode": "123456"
+}' "https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/ostf17zuKEUMYQAQGCOV/verify"
+```
+
+#### Response Example for Verify YubiKey Factor
+
+```json
+{
+"factorResult": "SUCCESS"
+}
+```
+
+### Issue a WebAuthn Factor Challenge
+
+<ApiOperation method="post" url="/api/v1/users/${userId}/factors/${factorId}/verify" />
+
+Initiates verification for a `webauthn` factor by getting a challenge nonce string, as well as WebAuthn credential request options that are used to help select an appropriate authenticator using the WebAuthn API.
+This authenticator then generates an assertion, which may be used to verify the user.
+
+#### Start Verification to Get Challenge Nonce
+
+Verification of the WebAuthn factor starts with getting the WebAuthn credential request details (including the challenge nonce) then using the client-side
+JavaScript API to get the signed assertion from the WebAuthn authenticator.
+
+For more information about these credential request options, see the [WebAuthn spec for PublicKeyCredentialRequestOptions](https://www.w3.org/TR/webauthn/#dictionary-makecredentialoptions).
+
+#### Request Example
+
+```bash
+curl -v -X POST \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+"https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/fwf2rovRxogXJ0nDy0g4/verify"
+```
+
+#### Response Example
+
+```json
+{
+  "factorResult":"CHALLENGE",
+  "profile":{
+    "credentialId":"l3Br0n-7H3g047NqESqJynFtIgf3Ix9OfaRoNwLoloso99Xl2zS_O7EXUkmPeAIzTVtEL4dYjicJWBz7NpqhGA",
+    "authenticatorName":"MacBook Touch ID"
+  },
+  "_links":{
+    "verify":{
+      "href":"https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/fwf2rovRxogXJ0nDy0g4/verify",
+      "hints":{
+        "allow":[
+          "POST"
+        ]
+      }
+    },
+    "factor":{
+      "href":"https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/fwf2rovRxogXJ0nDy0g4",
+      "hints":{
+        "allow":[
+          "GET",
+          "DELETE"
+        ]
+      }
+    }
+  },
+  "_embedded":{
+    "challenge":{
+      "challenge":"vQFwTt6zKzMV7HFPzjS2",
+       "extensions":{
+       }
+    }
+  }
+}
+```
+
+#### Get the Signed Assertion from the WebAuthn Authenticator by calling the WebAuthn Javascript API
+
+```html
+<!-- Using CryptoUtil.js from https://github.com/okta/okta-signin-widget/blob/master/src/util/CryptoUtil.js -->
+<script>
+  // Convert activation object's challenge nonce from string to binary
+  response._embedded.challenge.challenge = CryptoUtil.strToBin(response._embedded.challenge.challenge); 
+
+  // Call the WebAuthn javascript API to get signed assertion from the WebAuthn authenticator
+  navigator.credentials.get({
+    publicKey: response._embedded.challenge
+  })
+    .then(function (assertion) {
+      // Get the client data, authenticator data, and signature data from callback result, convert from binary to string
+      var clientData = CryptoUtil.binToStr(assertion.response.clientDataJSON);
+      var authenticatorData = CryptoUtil.binToStr(assertion.response.authenticatorData);
+      var signatureData = CryptoUtil.binToStr(assertion.response.signature);
+    })
+    .fail(function (error) {
+      // Error from WebAuthn platform
+    });
+</script>
+```
+
+#### Post the signed assertion to Okta to complete verification
+
+### Verify a WebAuthn Factor Challenge
+
+<ApiOperation method="post" url="/api/v1/users/${userId}/factors/${factorId}/verify" />
+
+Verifies a challenge for a `webauthn` factor by posting a signed assertion using the challenge nonce.
+
+#### Request Parameters
+
+| Parameter      | Description                                         | Param Type | DataType | Required |
+| -------------- | --------------------------------------------------- | ---------- | -------- | -------- |
+| userId         | `id` of a user                                      | URL        | String   | TRUE     |
+| factorId       | `id` of factor returned from enrollment             | URL        | String   | TRUE     |
+| clientData     | base64-encoded client data from the WebAuthn authenticator       | Body       | String   | TRUE     |
+| authenticatorData | base64-encoded authenticator data from the WebAuthn authenticator    | Body       | String   | TRUE     |
+| signatureData  | base64-encoded signature data from the WebAuthn authenticator    | Body       | String   | TRUE     |
+
+#### Request Example
+
+```bash
+curl -v -X POST \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+-d '{
+  "clientData":"eyJ0eXAiOiJuYXZpZ2F0b3IuaWQuZ2V0QXNzZXJ0aW9uIiwiY2hhbGxlbmdlIjoiS2NCLXRqUFU0NDY0ZThuVFBudXIiLCJvcmlnaW4iOiJodHRwczovL2xvY2FsaG9zdDozMDAwIiwiY2lkX3B1YmtleSI6InVudXNlZCJ9",
+  "authenticatorData": "SBv04caJ+NLZ0bTeotGq9esMhHJ8YC5z4bMXXPbT95UFXbDsOg==",
+  "signatureData":"AQAAACYwRgIhAKPktdpH0T5mlPSm_9uGW5w-VaUy-LhI9tIacexpgItkAiEAncRVZURVPOq7zDwIw-OM5LtSkdAxOkfv0ZDVUx3UFHc"
+}' "https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/fwf2rovRxogXJ0nDy0g4/verify"
+```
+
+#### Response Example
+
+```json
+{
+  "factorResult":"SUCCESS",
+  "profile":{
+    "credentialId":"l3Br0n-7H3g047NqESqJynFtIgf3Ix9OfaRoNwLoloso99Xl2zS_O7EXUkmPeAIzTVtEL4dYjicJWBz7NpqhGA",
+    "authenticatorName":"MacBook Touch ID"
+  }
 }
 ```
 
@@ -3262,280 +3550,6 @@ curl -v -X POST \
 ```json
 {
   "factorResult": "SUCCESS"
-}
-```
-
-### Verify U2F Factor
-
-<ApiOperation method="post" url="/api/v1/users/${userId}/factors/${factorId}/verify" />
-
-Note:
-
-According to
-[FIDO
-spec](https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-appid-and-facets-v1.2-ps-20170411.html#h2_the-appid-and-facetid-assertions), activating and verifying a U2F device with appIds in different DNS zone is not allowed. For example, if a user activated a U2F device via the Factors API from a server hosted at `https://foo.example.com`, the user can verify the U2F factor from `https://foo.example.com`, but will not be able to verify it from Okta portal `https://company.okta.com`.  Here, the U2F device would return error code 4 - `DEVICE_INELIGIBLE`.
-
-#### Start Verification to Get Challenge Nonce
-
-Verification of the U2F factor starts with getting the challenge nonce and U2F token details and then using the client-side
-JavaScript API to get the signed assertion from the U2F token.
-
-#### Request Example for Verify U2F Factor
-
-```bash
-curl -v -X POST \
--H "Accept: application/json" \
--H "Content-Type: application/json" \
--H "Authorization: SSWS ${api_token}" \
-"https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/fuf2rovRxogXJ0nDy0g4/verify"
-```
-
-#### Response Example for Verify U2F Factor
-
-```json
-{
-  "factorResult":"CHALLENGE",
-  "profile":{
-    "credentialId":"GAiiLsVab2m3-zL1Fi3bVtNrM9G6_MntUITHKjxkV24ktGKjLSCRnz72wCEdHCe18IvC69Aia0sE4UpsO0HpFQ",
-    "version":"U2F_V2"
-  },
-  "_links":{
-    "verify":{
-      "href":"https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/fuf2rovRxogXJ0nDy0g4/verify",
-      "hints":{
-        "allow":[
-          "POST"
-        ]
-      }
-    },
-    "factor":{
-      "href":"https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/fuf2rovRxogXJ0nDy0g4",
-      "hints":{
-        "allow":[
-          "GET",
-          "DELETE"
-        ]
-      }
-    }
-  },
-  "_embedded":{
-    "challenge":{
-      "nonce":"vQFwTt6zKzMV7HFPzjS2",
-      "timeoutSeconds":20
-    }
-  }
-}
-```
-
-#### Get the Signed Assertion from the U2F Token by calling the U2F Javascript API
-
-```html
-<!-- Get the u2f-api.js from https://github.com/google/u2f-ref-code/tree/master/u2f-gae-demo/war/js -->
-<script src="/u2f-api.js"></script>
-<script>
-  // Use the nonce from the challenge object
-  var challengeNonce = response._embedded.challenge.nonce;
-
-  // Use the origin of your app that is calling the factors API
-  var appId = "https://foo.example.com";
-
-  // Use the version and credentialId from factor profile object
-  var registeredKeys = [
-    {
-      version: factor.profile.version,
-      keyHandle: factor.profile.credentialId
-    }
-  ];
-
-  // Call the U2F javascript API to get signed assertion from the U2F token
-  u2f.sign(appId, factorData.challenge.nonce, registeredKeys, function (data) {
-    if (data.errorCode && data.errorCode !== 0) {
-      // Error from U2F platform
-    } else {
-      // Get the client data from callback result
-      var clientData = data.clientData;
-
-      // Get the signature data from callback result
-      var signatureData = data.signatureData;
-    }
-  });
-</script>
-```
-
-#### Post the signed assertion to Okta to complete verification
-
-#### Request Example for Signed Assertion
-
-```bash
-curl -v -X POST \
--H "Accept: application/json" \
--H "Content-Type: application/json" \
--H "Authorization: SSWS ${api_token}" \
--d '{
-  "clientData":"eyJ0eXAiOiJuYXZpZ2F0b3IuaWQuZ2V0QXNzZXJ0aW9uIiwiY2hhbGxlbmdlIjoiS2NCLXRqUFU0NDY0ZThuVFBudXIiLCJvcmlnaW4iOiJodHRwczovL2xvY2FsaG9zdDozMDAwIiwiY2lkX3B1YmtleSI6InVudXNlZCJ9",
-  "signatureData":"AQAAACYwRgIhAKPktdpH0T5mlPSm_9uGW5w-VaUy-LhI9tIacexpgItkAiEAncRVZURVPOq7zDwIw-OM5LtSkdAxOkfv0ZDVUx3UFHc"
-}' "https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/fuf2rovRxogXJ0nDy0g4/verify"
-```
-
-#### Response of U2F Verification Example
-
-```json
-{
-  "factorResult":"SUCCESS",
-  "profile":{
-    "credentialId":"h1bFwJFU9wnelYkexJuQfoUHZ5lX3CgQMTZk4H3I8kM9Nn6XALiQ-BIab4P5EE0GQrA7VD-kAwgnG950aXkhBw",
-    "version":"U2F_V2"
-  }
-}
-```
-
-### Verify YubiKey Factor
-
-<ApiOperation method="post" url="/api/v1/users/${userId}/factors/${factorId}/verify" />
-Verifies a user with a [Yubico OTP](https://developers.yubico.com/OTP/OTPs_Explained.html) for a YubiKey `token:hardware` factor.
-
-#### Request Example for Verify YubiKey Factor
-
-```bash
-curl -v -X POST \
--H "Accept: application/json" \
--H "Content-Type: application/json" \
--H "Authorization: SSWS ${api_token}" \
--d '{
-"passCode": "123456"
-}' "https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/ostf17zuKEUMYQAQGCOV/verify"
-```
-
-#### Response Example for Verify YubiKey Factor
-
-```json
-{
-"factorResult": "SUCCESS"
-}
-```
-
-### Verify WebAuthn Factor
-
-<ApiOperation method="post" url="/api/v1/users/${userId}/factors/${factorId}/verify" />
-
-Verifies a user with a WebAuthn factor. The verification process starts with getting the WebAuthn credential request options that are used to help select an appropriate authenticator using the WebAuthn API.
-This authenticator then generates an assertion, which may be used to verify the user.
-
-#### Start Verification to Get Challenge Nonce
-
-Verification of the WebAuthn factor starts with getting the WebAuthn credential request details (including the challenge nonce) then using the client-side
-JavaScript API to get the signed assertion from the WebAuthn authenticator.
-
-For more information about these credential request options, see the [WebAuthn spec for PublicKeyCredentialRequestOptions](https://www.w3.org/TR/webauthn/#dictionary-makecredentialoptions).
-
-#### Request Example for Verify WebAuthn Factor
-
-```bash
-curl -v -X POST \
--H "Accept: application/json" \
--H "Content-Type: application/json" \
--H "Authorization: SSWS ${api_token}" \
-"https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/fwf2rovRxogXJ0nDy0g4/verify"
-```
-
-#### Response Example for Verify WebAuthn Factor
-
-```json
-{
-  "factorResult":"CHALLENGE",
-  "profile":{
-    "credentialId":"l3Br0n-7H3g047NqESqJynFtIgf3Ix9OfaRoNwLoloso99Xl2zS_O7EXUkmPeAIzTVtEL4dYjicJWBz7NpqhGA",
-    "authenticatorName":"MacBook Touch ID"
-  },
-  "_links":{
-    "verify":{
-      "href":"https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/fwf2rovRxogXJ0nDy0g4/verify",
-      "hints":{
-        "allow":[
-          "POST"
-        ]
-      }
-    },
-    "factor":{
-      "href":"https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/fwf2rovRxogXJ0nDy0g4",
-      "hints":{
-        "allow":[
-          "GET",
-          "DELETE"
-        ]
-      }
-    }
-  },
-  "_embedded":{
-    "challenge":{
-      "challenge":"vQFwTt6zKzMV7HFPzjS2",
-       "extensions":{
-       }
-    }
-  }
-}
-```
-
-#### Get the Signed Assertion from the WebAuthn Authenticator by calling the WebAuthn Javascript API
-
-```html
-<!-- Using CryptoUtil.js from https://github.com/okta/okta-signin-widget/blob/master/src/util/CryptoUtil.js -->
-<script>
-  // Convert activation object's challenge nonce from string to binary
-  response._embedded.challenge.challenge = CryptoUtil.strToBin(response._embedded.challenge.challenge); 
-
-  // Call the WebAuthn javascript API to get signed assertion from the WebAuthn authenticator
-  navigator.credentials.get({
-    publicKey: response._embedded.challenge
-  })
-    .then(function (assertion) {
-      // Get the client data, authenticator data, and signature data from callback result, convert from binary to string
-      var clientData = CryptoUtil.binToStr(assertion.response.clientDataJSON);
-      var authenticatorData = CryptoUtil.binToStr(assertion.response.authenticatorData);
-      var signatureData = CryptoUtil.binToStr(assertion.response.signature);
-    })
-    .fail(function (error) {
-      // Error from WebAuthn platform
-    });
-</script>
-```
-
-#### Post the signed assertion to Okta to complete verification
-
-#### Request Parameters for Verify WebAuthn Factor
-
-
-| Parameter      | Description                                         | Param Type | DataType | Required |
-| -------------- | --------------------------------------------------- | ---------- | -------- | -------- |
-| userId         | `id` of a user                                      | URL        | String   | TRUE     |
-| factorId       | `id` of factor returned from enrollment             | URL        | String   | TRUE     |
-| clientData     | base64-encoded client data from the WebAuthn authenticator       | Body       | String   | TRUE     |
-| authenticatorData | base64-encoded authenticator data from the WebAuthn authenticator    | Body       | String   | TRUE     |
-| signatureData  | base64-encoded signature data from the WebAuthn authenticator    | Body       | String   | TRUE     |
-
-#### Request Example for Signed Assertion
-
-```bash
-curl -v -X POST \
--H "Accept: application/json" \
--H "Content-Type: application/json" \
--H "Authorization: SSWS ${api_token}" \
--d '{
-  "clientData":"eyJ0eXAiOiJuYXZpZ2F0b3IuaWQuZ2V0QXNzZXJ0aW9uIiwiY2hhbGxlbmdlIjoiS2NCLXRqUFU0NDY0ZThuVFBudXIiLCJvcmlnaW4iOiJodHRwczovL2xvY2FsaG9zdDozMDAwIiwiY2lkX3B1YmtleSI6InVudXNlZCJ9",
-  "authenticatorData": "SBv04caJ+NLZ0bTeotGq9esMhHJ8YC5z4bMXXPbT95UFXbDsOg==",
-  "signatureData":"AQAAACYwRgIhAKPktdpH0T5mlPSm_9uGW5w-VaUy-LhI9tIacexpgItkAiEAncRVZURVPOq7zDwIw-OM5LtSkdAxOkfv0ZDVUx3UFHc"
-}' "https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/fwf2rovRxogXJ0nDy0g4/verify"
-```
-
-#### Response of WebAuthn Verification Example
-
-```json
-{
-  "factorResult":"SUCCESS",
-  "profile":{
-    "credentialId":"l3Br0n-7H3g047NqESqJynFtIgf3Ix9OfaRoNwLoloso99Xl2zS_O7EXUkmPeAIzTVtEL4dYjicJWBz7NpqhGA",
-    "authenticatorName":"MacBook Touch ID"
-  }
 }
 ```
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?**
  - Rearrange U2F and WebAuthn factor docs for the Factors API, as they require a challenge before verification
  - Also do some further clean-up and rewording per the new location
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->
  - No; this documents behavior that is already live

### Resolves:

* [OKTA-261942](https://oktainc.atlassian.net/browse/OKTA-261942)
