### PR TITLE
Clarification for CORS test

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/enable-cors/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/enable-cors/overview/index.md
@@ -39,7 +39,7 @@ You can also enable the **Redirect** setting, which allows for redirection to th
 Test your CORS configuration:
 
 1. Grant cross-origin access to `https://developer.okta.com`.
-2. Enter your Okta organization in the form below and click **Test**. Your Okta user profile displays below the form.
+2. In the same browser in which you have an active session in your Okta organization, enter your Okta subdomain in the form below and click **Test**. Your Okta user profile displays below the form.
 
 <CorsTest />
 


### PR DESCRIPTION
###  Description:
- **What's changed?** The CORS testing tool available on developer.okta.com does a CORS request on /api/v1/users/me endpoint. In case the user is not authenticated in the browser, a 403 error will occur and the Access-Control-Allow-Origin header will not be returned. This Doc Update adds a clarification for the tester to have an active session in Okta when testing the CORS functionality.
- **Is this PR related to a Monolith release?** No

### Resolves:

* OKTA-264154