### PR TITLE
Removing mention of IdP Discovery FF

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -1509,7 +1509,7 @@ The following conditions may be applied to the rules associated with Password Po
 
 The IdP Discovery Policy determines where to route users when they are attempting to log in to your org. Users can be routed to a variety of identity providers (`SAML2`, `IWA`, `AgentlessDSSO`, `X509`, `FACEBOOK`, `GOOGLE`, `LINKEDIN`, `MICROSOFT`, `OIDC`) based on multiple conditions listed below.
 
-> **Note:** All Okta orgs with `IDP_DISCOVERY` enabled contain one and only one IdP Discovery Policy with an immutable default rule routing to your org's login page.
+All Okta orgs contain one and only one IdP Discovery Policy, with an immutable default rule routing to your org's login page.
 
 ### Policy Conditions
 The following conditions may be applied to IdP Discovery Policy


### PR DESCRIPTION
## Description:
- **What's changed?** IdP Discovery is now GA, so removing mention of the Policy only existing in orgs that have the FF enabled.
- **Is this PR related to a Monolith release?** No

