### PR TITLE
OKTA-250368: made consent parameter as optional for AS create Scope API

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/authorization-servers/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/authorization-servers/index.md
@@ -665,7 +665,7 @@ When you use these API endpoints to create or modify a Scope resource, the respo
 
 | Property                                 | Description                                                                                             | Type      | Default        | Required for create or update              |
 | :-------------------------------------   | :------------------------------------------------------------------------------------------------------ | :-------- | :------------- | :----------------------------              |
-| consent <ApiLifecycle access="ea" />     | Indicates whether a consent dialog is needed for the scope. Valid values: `REQUIRED`, `IMPLICIT`.       | Enum      | `IMPLICIT`     | True unless this EA feature isn't enabled |
+| consent <ApiLifecycle access="ea" />     | Indicates whether a consent dialog is needed for the scope. Valid values: `REQUIRED`, `IMPLICIT`.       | Enum      | `IMPLICIT`     | True for update if this EA feature is enabled |
 | default                                  | Whether test the scope is a default scope                                                               | Boolean   |                | False                                      |
 | description                              | Description of the scope                                                                                | String    |                | False                                      |
 | displayName <ApiLifecycle access="ea" /> | Name of the end user displayed in a consent dialog window                                                      | String    |                | False                                      |


### PR DESCRIPTION
## Description:
- made consent parameter as optional for AS create Scope API
- 2019.12.0

### Resolves:

* [OKTA-250368](https://oktainc.atlassian.net/browse/OKTA-250368)
