### PR TITLE
Update Treenav to scroll with overflow

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_footer.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_footer.scss
@@ -6,6 +6,7 @@ footer {
   max-width: $container-width;
   margin: 0 auto;
   flex-direction: column;
+  z-index: 10;
 
   @include media('>tablet') {
     flex-direction: row;

--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_sidebar.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_sidebar.scss
@@ -3,6 +3,9 @@
   flex: 0 0 auto;
   border-right: 1px solid cv('gray', '400');
   color: cv('action');
+  position: sticky;
+  overflow-y: auto;
+  top: 200px;
 
   .router-link-active {
     font-weight: bold;

--- a/packages/@okta/vuepress-theme-prose/components/Sidebar.vue
+++ b/packages/@okta/vuepress-theme-prose/components/Sidebar.vue
@@ -1,5 +1,4 @@
 <template>
-
   <aside class="landing-navigation">
     <ul class="landing">
       <li :class="{overview: true}">
@@ -49,10 +48,17 @@
         }
       }
     },
+    mounted() {
+      this.handleScroll();
+      window.addEventListener('scroll', this.handleScroll);
+    },
+    beforeDestroy() {
+      window.removeEventListener('scroll', this.handleScroll);
+    },
     computed: {
       navigation() {
         if (this.$page.path.includes('/code/')) {
-          return this.$site.themeConfig.sidebars.codePages
+          // return this.$site.themeConfig.sidebars.codePages
         }
         if (this.$page.path.includes('/docs/concepts/')) {
           this.overview.title = 'Concepts';
@@ -80,7 +86,7 @@
           return false;
           
         }
-        return this.$site.themeConfig.sidebars.main
+        
       }
     },
     filters: {
@@ -153,6 +159,13 @@
           return;
         }
         event.preventDefault();
+      },
+      handleScroll: function (event) {
+        let maxHeight = document.querySelector('.tree-nav').clientHeight - window.scrollY
+        if(maxHeight > window.innerHeight) {
+          maxHeight = window.innerHeight - document.querySelector('.fixed-header').clientHeight - 60;
+        }
+        document.querySelector('.landing-navigation').style.height = maxHeight + 'px';
       }
     }
   }


### PR DESCRIPTION
TreeNav is now sticky and handles overflow scroll.

<img width="476" alt="Screen Shot 2019-12-10 at 1 21 14 PM" src="https://user-images.githubusercontent.com/1906920/70557026-072dd800-1b50-11ea-8a8e-4dd767b36983.png">
<img width="575" alt="Screen Shot 2019-12-10 at 1 20 59 PM" src="https://user-images.githubusercontent.com/1906920/70557027-072dd800-1b50-11ea-8c80-e9f8744da45f.png">
<img width="651" alt="Screen Shot 2019-12-10 at 1 20 32 PM" src="https://user-images.githubusercontent.com/1906920/70557029-072dd800-1b50-11ea-9734-fb270b9871ac.png">
