### PR TITLE
Making info about which flows support refresh token more prominent

### DIFF
--- a/packages/@okta/vuepress-site/docs/concepts/auth-overview/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/auth-overview/index.md
@@ -176,6 +176,8 @@ For web/native/mobile applications, the client secret cannot be stored in the ap
 
 PKCE is an extension to the regular Authorization Code flow, so the flow is very similar, except that PKCE elements are included at various steps in the flow.
 
+> **Note:** Unlike the regular Authorization Code Flow, the Authorization Code Flow with PKCE doesn't support refresh tokens.
+
 The PKCE-enhanced Authorization Code flow requires your application to generate a cryptographically random key called a "code verifier". A "code challenge" is then created from the verifier, and this challenge is passed along with the request for the authorization code.
 
 When the authorization code is sent in the access token request, the code verifier is sent as part of the request. The authorization server recomputes the challenge from the verifier using an agreed-upon hash algorithm and then compares that. If the two code challenges and verifier match, then it knows that both requests were sent by the same client.

--- a/packages/@okta/vuepress-site/docs/concepts/auth-overview/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/auth-overview/index.md
@@ -176,7 +176,7 @@ For web/native/mobile applications, the client secret cannot be stored in the ap
 
 PKCE is an extension to the regular Authorization Code flow, so the flow is very similar, except that PKCE elements are included at various steps in the flow.
 
-> **Note:** Unlike the regular Authorization Code Flow, the Authorization Code Flow with PKCE doesn't support refresh tokens.
+> **Note:** The Authorization Code Flow with PKCE doesn't support refresh tokens for SPAs and other browser-based apps.
 
 The PKCE-enhanced Authorization Code flow requires your application to generate a cryptographically random key called a "code verifier". A "code challenge" is then created from the verifier, and this challenge is passed along with the request for the authorization code.
 

--- a/packages/@okta/vuepress-site/docs/guides/refresh-tokens/get-refresh-token/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/refresh-tokens/get-refresh-token/index.md
@@ -4,7 +4,7 @@ title: Get a Refresh Token
 
 To get a refresh token, you send a request to your Okta Authorization Server.
 
-The only flows that support Refresh tokens are the resource owner password flow, and the authorization code flow (without PKCE). This means that the following combinations of grant type and scope, when sent to `/token` endpoint, will return a refresh token:
+The only flows that support Refresh tokens are the resource owner password flow, and the authorization code flow. This means that the following combinations of grant type and scope, when sent to `/token` endpoint, will return a refresh token:
 
 | Grant Type           | Scope                       |
 | -----------          | -----                       |
@@ -16,11 +16,17 @@ The only flows that support Refresh tokens are the resource owner password flow,
 
 ### Get a Refresh Token with the Code Flow
 
-In the case of the Authorization Code flow, you use the Authorization Server's `/authorize` endpoint to get an authorization code, specifying an `offline_access` scope. You then send this code to the `/token` endpoint to get an access token and a refresh token. For more information about this endpoint, see [Obtain an Authorization Grant from a User](/docs/reference/api/oidc/#authorize). For more information about the Authorization Code flow, see [Implementing the Authorization Code Flow](/docs/guides/implement-auth-code/).
+In the case of the Authorization Code flow, you use the Authorization Server's `/authorize` endpoint to get an authorization code, specifying an `offline_access` scope. You then send this code to the `/token` endpoint to get an access token and a refresh token.
+
+> **Note:**  Authorization code with PKCE requests will not return refresh tokens if they are sent from SPAs or other browser-based apps.
+
+For more information about this endpoint, see [Obtain an Authorization Grant from a User](/docs/reference/api/oidc/#authorize). For more information about the Authorization Code flow, see [Implementing the Authorization Code Flow](/docs/guides/implement-auth-code/).
 
 ### Get a Refresh Token with the Resource Owner Password Flow
 
-For the Resource Owner Password flow, you use the Authorization Server's `/token` endpoint directly. For more information about this endpoint, see [Request a Token](/docs/reference/api/oidc/#token). For more information about the Resource Owner Password flow, see [Implementing the Resource Owner Password Flow](/docs/guides/implement-password/).
+For the Resource Owner Password flow, you use the Authorization Server's `/token` endpoint directly.
+
+For more information about this endpoint, see [Request a Token](/docs/reference/api/oidc/#token). For more information about the Resource Owner Password flow, see [Implementing the Resource Owner Password Flow](/docs/guides/implement-password/).
 
 For example, with the `password` grant type you can include an `openid` scope alongside the `offline_access` scope:
 

--- a/packages/@okta/vuepress-site/docs/guides/refresh-tokens/get-refresh-token/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/refresh-tokens/get-refresh-token/index.md
@@ -4,15 +4,7 @@ title: Get a Refresh Token
 
 To get a refresh token, you send a request to your Okta Authorization Server.
 
-### Get a Refresh Token with the Code Flow
-
-In the case of the Authorization Code flow, you use the Authorization Server's `/authorize` endpoint to get an authorization code, specifying an `offline_access` scope. You then send this code to the `/token` endpoint to get an access token and a refresh token. For more information about this endpoint, see [Obtain an Authorization Grant from a User](/docs/reference/api/oidc/#authorize). For more information about the Authorization Code flow, see [Implementing the Authorization Code Flow](/docs/guides/implement-auth-code/).
-
-### Get a Refresh Token with the Resource Owner Password Flow
-
-For the Resource Owner Password flow, you use the Authorization Server's `/token` endpoint directly. For more information about this endpoint, see [Request a Token](/docs/reference/api/oidc/#token). For more information about the Resource Owner Password flow, see [Implementing the Resource Owner Password Flow](/docs/guides/implement-password/).
-
-The following combinations of grant type and scope, when sent to `/token` endpoint, will return a refresh token:
+The only flows that support Refresh tokens are the resource owner password flow, and the authorization code flow (without PKCE). This means that the following combinations of grant type and scope, when sent to `/token` endpoint, will return a refresh token:
 
 | Grant Type           | Scope                       |
 | -----------          | -----                       |
@@ -22,7 +14,15 @@ The following combinations of grant type and scope, when sent to `/token` endpoi
 
 > **Note:** The authorization code flow is unique, in that the `offline_access` scope has to be requested as part of the code request to the `/authorize` endpoint, and not the request sent to the `/token` endpoint.
 
-This table only shows the minimum requirements. For example, with the `password` grant type you can also include an `openid` scope alongside the `offline_access` scope:
+### Get a Refresh Token with the Code Flow
+
+In the case of the Authorization Code flow, you use the Authorization Server's `/authorize` endpoint to get an authorization code, specifying an `offline_access` scope. You then send this code to the `/token` endpoint to get an access token and a refresh token. For more information about this endpoint, see [Obtain an Authorization Grant from a User](/docs/reference/api/oidc/#authorize). For more information about the Authorization Code flow, see [Implementing the Authorization Code Flow](/docs/guides/implement-auth-code/).
+
+### Get a Refresh Token with the Resource Owner Password Flow
+
+For the Resource Owner Password flow, you use the Authorization Server's `/token` endpoint directly. For more information about this endpoint, see [Request a Token](/docs/reference/api/oidc/#token). For more information about the Resource Owner Password flow, see [Implementing the Resource Owner Password Flow](/docs/guides/implement-password/).
+
+For example, with the `password` grant type you can include an `openid` scope alongside the `offline_access` scope:
 
 ```
 POST https://${yourOktaDomain}/oauth2/default/v1/token


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Basically what it says in the title. Trying to make it as obvious as possible that only Password flow and Auth Code flow without PKCE support refresh tokens. Other requests will fail.
- **Is this PR related to a Monolith release?** No.

### Resolves:

* [OKTA-270840](https://oktainc.atlassian.net/browse/OKTA-270840)
