### PR TITLE
widget link updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "posttest": "yarn stop",
     "stop": "if-env CI=true && exit 0 || yarn test:stop-web-driver || echo 'done'",
     "stop-all": "if-env CI=true && exit 0 || pkill -f 'yarn' || echo 'done'",
-    "update-event-types": "bash scripts/update-event-types.sh",
-    "update-widget-version": "node scripts/update-widget-version"
+    "update-event-types": "bash scripts/update-event-types.sh"
   },
   "repository": "git@github.com:okta/okta.github.io",
   "author": "Brian Retterer <brian.retterer@okta.com>",

--- a/packages/@okta/vuepress-site/code/angular/okta_angular_sign-in_widget/index.md
+++ b/packages/@okta/vuepress-site/code/angular/okta_angular_sign-in_widget/index.md
@@ -74,7 +74,7 @@ First, update `src/app/app.component.html` to provide the Login logic:
 
 
 <!-- Latest CDN production CSS -->
-<link href="https://global.oktacdn.com/okta-signin-widget/3.2.0/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
+<link href="https://global.oktacdn.com/okta-signin-widget/-=OKTA_REPLACE_WITH_WIDGET_VERSION=-/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
 
 <button routerLink="/"> Home </button>
 <button *ngIf="!isAuthenticated" routerLink="/login"> Login </button>

--- a/packages/@okta/vuepress-site/code/javascript/okta_sign-in_widget/index.md
+++ b/packages/@okta/vuepress-site/code/javascript/okta_sign-in_widget/index.md
@@ -26,9 +26,9 @@ To use the CDN, include this in your HTML:
 
 ```html
 <!-- Latest CDN production Javascript and CSS -->
-<script src="https://global.oktacdn.com/okta-signin-widget/3.2.0/js/okta-sign-in.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/-=OKTA_REPLACE_WITH_WIDGET_VERSION=-/js/okta-sign-in.min.js" type="text/javascript"></script>
 
-<link href="https://global.oktacdn.com/okta-signin-widget/3.2.0/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/> 
+<link href="https://global.oktacdn.com/okta-signin-widget/-=OKTA_REPLACE_WITH_WIDGET_VERSION=-/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/> 
 ```
 
 More info, including the latest published version, can be found in the [Widget Documentation](https://github.com/okta/okta-signin-widget#using-the-okta-cdn).

--- a/packages/@okta/vuepress-site/quickstart-fragments/widget/default-example/index.md
+++ b/packages/@okta/vuepress-site/quickstart-fragments/widget/default-example/index.md
@@ -44,9 +44,9 @@ The easiest way to get started with the [Okta Sign-In Widget](https://github.com
 To use our CDN, include the following links to your HTML:
 
 ```html
-<script src="https://global.oktacdn.com/okta-signin-widget/3.2.0/js/okta-sign-in.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/-=OKTA_REPLACE_WITH_WIDGET_VERSION=-/js/okta-sign-in.min.js" type="text/javascript"></script>
 
-<link href="https://global.oktacdn.com/okta-signin-widget/3.2.0/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
+<link href="https://global.oktacdn.com/okta-signin-widget/-=OKTA_REPLACE_WITH_WIDGET_VERSION=-/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
 ```
 
 > The `okta-sign-in.min.js` file will expose a global `OktaSignIn` object that can bootstrap the widget.


### PR DESCRIPTION
## Description:
- **What's changed?** 
  - Uses the -=OKTA_REPLACE_WITH_WIDGET_VERSION=- magic replacement text to update the reference to the widget versions to always be the latest of the listed major version
![Screen Shot 2020-01-16 at 1 28 21 PM](https://user-images.githubusercontent.com/492300/72564217-206b2800-3864-11ea-9109-3ac752b37f75.png)


  - Removes an unused package.json script reference

- **Is this PR related to a Monolith release?** 
  - No

### Resolves:

* [OKTA-270399](https://oktainc.atlassian.net/browse/OKTA-270399)
