### PR TITLE
OKTA-274761 : API Doc: OAuth for /api/v1/policies

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta/scopes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta/scopes/index.md
@@ -32,6 +32,8 @@ The following table shows the scopes that are currently available as a part of E
 | `okta.users.read`        | Allows the app to read any user's profile and credential information      | [Users API](/docs/reference/api/users/#user-operations), [User Lifecycle Operations](/docs/reference/api/users/#lifecycle-operations) <br> The following operations are not OAuth-enabled: [User Consent Grant Operations](/docs/reference/api/users/#user-consent-grant-operations) |
 | `okta.users.manage.self` | Allows the app to manage the currently signed-in user's profile. Currently only supports user profile attribute updates. |   |
 | `okta.users.read.self`   | Allows the app to read the currently signed-in user's profile and credential information| [Users API](/docs/reference/api/users/#get-current-user) |
+| `okta.policies.manage`    | Allows the app to manage Policies in your Okta organization   | [Policy API](/docs/reference/api/policy/#getting-started)|
+| `okta.policies.read`      | Allows the app to read information about Policies in your Okta organization| [Policy API](/docs/reference/api/policy/#getting-started)|
 
 ## Scope Naming
 

--- a/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta/scopes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta/scopes/index.md
@@ -32,8 +32,8 @@ The following table shows the scopes that are currently available as a part of E
 | `okta.users.read`        | Allows the app to read any user's profile and credential information      | [Users API](/docs/reference/api/users/#user-operations), [User Lifecycle Operations](/docs/reference/api/users/#lifecycle-operations) <br> The following operations are not OAuth-enabled: [User Consent Grant Operations](/docs/reference/api/users/#user-consent-grant-operations) |
 | `okta.users.manage.self` | Allows the app to manage the currently signed-in user's profile. Currently only supports user profile attribute updates. |   |
 | `okta.users.read.self`   | Allows the app to read the currently signed-in user's profile and credential information| [Users API](/docs/reference/api/users/#get-current-user) |
-| `okta.policies.manage`    | Allows the app to manage Policies in your Okta organization   | [Policy API](/docs/reference/api/policy/#getting-started)|
-| `okta.policies.read`      | Allows the app to read information about Policies in your Okta organization| [Policy API](/docs/reference/api/policy/#getting-started)|
+| `okta.policies.manage`    | Allows the app to manage Policies in your Okta organization   | [Policy API](/docs/reference/api/policy/#policy-api-operations)|
+| `okta.policies.read`      | Allows the app to read information about Policies in your Okta organization| [Policy API](/docs/reference/api/policy/#policy-api-operations)|
 
 ## Scope Naming
 


### PR DESCRIPTION

<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- update https://developer.okta.com/docs/guides/implement-oauth-for-okta/scopes/ page with newly added policies scope
- **Is this PR related to a Monolith release?** yes, 2020.02.0 (Monolith CF Jan 31)

### Resolves:

* https://oktainc.atlassian.net/browse/OKTA-274761

@royalchan-okta 
@okta/developerdocs 