### PR TITLE
Correcting /integrate links

### DIFF
--- a/packages/@okta/vuepress-site/docs/concepts/authentication/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/authentication/index.md
@@ -37,7 +37,7 @@ The underlying foundation for the Sign-In Widget and Auth SDK is a comprehensive
 
 ## Building Apps That Support Single Sign-On
 
-For IT developers or ISVs who want to use Okta as an identity provider, Okta provides several options for secure SSO. SAML has been widely used as the single sign-on protocol by many ISVs and is supported by many identity management solutions. Okta provides comprehensive guidance for developers to implement a proper [SAML service provider](https://www.okta.com/integrate/documentation/saml/). For IT developers building internal apps that would like to support SSO, SAML is also a good option.
+For IT developers or ISVs who want to use Okta as an identity provider, Okta provides several options for secure SSO. SAML has been widely used as the single sign-on protocol by many ISVs and is supported by many identity management solutions. Okta provides comprehensive guidance for developers to implement a proper [SAML service provider](https://developer.okta.com/docs/concepts/saml). For IT developers building internal apps that would like to support SSO, SAML is also a good option.
 
 OpenID Connect is the emerging technology that provides an alternative implementation of SSO. Okta is a [Certified OpenID Connect provider](http://openid.net/certification/). Building on top of the OAuth 2.0 framework, OpenID Connect is a modern implementation to support authentication and SSO. If you are an Okta customer, our [OpenID Connect API](/docs/reference/api/oidc/) is a great way to support SSO and is a simpler alternative to SAML.
 

--- a/packages/@okta/vuepress-site/docs/concepts/authentication/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/authentication/index.md
@@ -37,7 +37,7 @@ The underlying foundation for the Sign-In Widget and Auth SDK is a comprehensive
 
 ## Building Apps That Support Single Sign-On
 
-For IT developers or ISVs who want to use Okta as an identity provider, Okta provides several options for secure SSO. SAML has been widely used as the single sign-on protocol by many ISVs and is supported by many identity management solutions. Okta provides comprehensive guidance for developers to implement a proper [SAML service provider](https://developer.okta.com/docs/concepts/saml). For IT developers building internal apps that would like to support SSO, SAML is also a good option.
+For IT developers or ISVs who want to use Okta as an identity provider, Okta provides several options for secure SSO. SAML has been widely used as the single sign-on protocol by many ISVs and is supported by many identity management solutions. Okta provides comprehensive guidance for developers to implement a proper [SAML service provider](https://developer.okta.com/docs/concepts/saml/). For IT developers building internal apps that would like to support SSO, SAML is also a good option.
 
 OpenID Connect is the emerging technology that provides an alternative implementation of SSO. Okta is a [Certified OpenID Connect provider](http://openid.net/certification/). Building on top of the OAuth 2.0 framework, OpenID Connect is a modern implementation to support authentication and SSO. If you are an Okta customer, our [OpenID Connect API](/docs/reference/api/oidc/) is a great way to support SSO and is a simpler alternative to SAML.
 

--- a/packages/@okta/vuepress-site/docs/concepts/authentication/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/authentication/index.md
@@ -37,7 +37,7 @@ The underlying foundation for the Sign-In Widget and Auth SDK is a comprehensive
 
 ## Building Apps That Support Single Sign-On
 
-For IT developers or ISVs who want to use Okta as an identity provider, Okta provides several options for secure SSO. SAML has been widely used as the single sign-on protocol by many ISVs and is supported by many identity management solutions. Okta provides comprehensive guidance for developers to implement a proper [SAML service provider](https://developer.okta.com/docs/concepts/saml/). For IT developers building internal apps that would like to support SSO, SAML is also a good option.
+For IT developers or ISVs who want to use Okta as an identity provider, Okta provides several options for secure SSO. SAML has been widely used as the single sign-on protocol by many ISVs and is supported by many identity management solutions. Okta provides comprehensive guidance for developers to implement a proper [SAML service provider](/docs/concepts/saml/). For IT developers building internal apps that would like to support SSO, SAML is also a good option.
 
 OpenID Connect is the emerging technology that provides an alternative implementation of SSO. Okta is a [Certified OpenID Connect provider](http://openid.net/certification/). Building on top of the OAuth 2.0 framework, OpenID Connect is a modern implementation to support authentication and SSO. If you are an Okta customer, our [OpenID Connect API](/docs/reference/api/oidc/) is a great way to support SSO and is a simpler alternative to SAML.
 

--- a/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/prepare-app/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/prepare-app/index.md
@@ -4,7 +4,7 @@ title: Integrate your SCIM service with an Okta app
 
 After you have a SCIM implementation that passes all of the Runscope tests, you need to create your SCIM integration directly within Okta.
 
-Begin by signing up for an [Okta developer account](https://developer.okta.com/signup).
+Begin by signing up for an [Okta developer account](https://developer.okta.com/signup/).
 
 1. After you request the developer account and have received the initial email, open the link to your developer org.
 1. Navigate to the Developer Console in your Okta org by clicking **Admin**.

--- a/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/prepare-app/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/prepare-app/index.md
@@ -4,7 +4,7 @@ title: Integrate your SCIM service with an Okta app
 
 After you have a SCIM implementation that passes all of the Runscope tests, you need to create your SCIM integration directly within Okta.
 
-Begin by signing up for an [Okta developer account](https://www.okta.com/integrate/signup/).
+Begin by signing up for an [Okta developer account](https://developer.okta.com/signup).
 
 1. After you request the developer account and have received the initial email, open the link to your developer org.
 1. Navigate to the Developer Console in your Okta org by clicking **Admin**.

--- a/packages/@okta/vuepress-site/docs/guides/build-sso-integration/integrate/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-sso-integration/integrate/index.md
@@ -7,7 +7,7 @@ title: Integrate Your App
 > If you are using the developer dashboard you will first need to switch to the Classic UI.
 > If you see a **Developer** prompt in the top left, click it and select **Classic UI** to switch to the Classic UI.
 
-* Sign up for an Okta [developer account](https://developer.okta.com/signup).
+* Sign up for an Okta [developer account](https://developer.okta.com/signup/).
 * In your Okta account (make sure you are signed in as an admin), use the [App Wizard](https://help.okta.com/en/prod/Content/Topics/Apps/Apps_App_Integration_Wizard.htm) to build a Single Sign-on integration with Okta.
 * When you are ready, navigate to the Feedback tab of the App Wizard:
     ![Feedback tab of SAML App Wizard](/img/oin/saml-step3.png "Feedback page for App wizard")

--- a/packages/@okta/vuepress-site/docs/guides/build-sso-integration/integrate/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-sso-integration/integrate/index.md
@@ -7,7 +7,7 @@ title: Integrate Your App
 > If you are using the developer dashboard you will first need to switch to the Classic UI.
 > If you see a **Developer** prompt in the top left, click it and select **Classic UI** to switch to the Classic UI.
 
-* Sign up for an Okta [developer account](https://www.okta.com/integrate/signup/).
+* Sign up for an Okta [developer account](https://developer.okta.com/signup).
 * In your Okta account (make sure you are signed in as an admin), use the [App Wizard](https://help.okta.com/en/prod/Content/Topics/Apps/Apps_App_Integration_Wizard.htm) to build a Single Sign-on integration with Okta.
 * When you are ready, navigate to the Feedback tab of the App Wizard:
     ![Feedback tab of SAML App Wizard](/img/oin/saml-step3.png "Feedback page for App wizard")

--- a/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
@@ -254,7 +254,7 @@ Adds a new `SAML2` type IdP to your organization
 Notes:
 
 * You must first add the IdP's signature certificate to the IdP key store before you can add a SAML 2.0 IdP with a `kid` credential reference.
-* Don't use `fromURI` to automatically redirect a user to a particular app after successfully authenticating with a third-party IdP. Instead, use [SAML Deep Links](#redirecting-with-saml-deep-links). Using `fromURI` is not tested and not supported. For more information about using deep links for SP-initiated sign on, see [Understanding SP-Initiated Login Flow](https://developer.okta.com/docs/concepts/saml/#understanding-sp-initiated-login-flow).
+* Don't use `fromURI` to automatically redirect a user to a particular app after successfully authenticating with a third-party IdP. Instead, use [SAML Deep Links](#redirecting-with-saml-deep-links). Using `fromURI` is not tested and not supported. For more information about using deep links for SP-initiated sign on, see [Understanding SP-Initiated Login Flow](/docs/concepts/saml/#understanding-sp-initiated-login-flow).
 
 ##### Request Example
 

--- a/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
@@ -254,7 +254,7 @@ Adds a new `SAML2` type IdP to your organization
 Notes:
 
 * You must first add the IdP's signature certificate to the IdP key store before you can add a SAML 2.0 IdP with a `kid` credential reference.
-* Don't use `fromURI` to automatically redirect a user to a particular app after successfully authenticating with a third-party IdP. Instead, use [SAML Deep Links](#redirecting-with-saml-deep-links). Using `fromURI` is not tested and not supported. For more information about using deep links for SP-initiated sign on, see [Understanding SP-Initiated Login Flow](https://www.okta.com/integrate/documentation/saml/#understanding-sp-initiated-login-flow).
+* Don't use `fromURI` to automatically redirect a user to a particular app after successfully authenticating with a third-party IdP. Instead, use [SAML Deep Links](#redirecting-with-saml-deep-links). Using `fromURI` is not tested and not supported. For more information about using deep links for SP-initiated sign on, see [Understanding SP-Initiated Login Flow](https://developer.okta.com/docs/concepts/saml/#understanding-sp-initiated-login-flow).
 
 ##### Request Example
 


### PR DESCRIPTION
## Description:
Changed to point users to developer.okta.com sites instead of to okta.com/integrate locations.
