### PR TITLE
The name of a user type cannot be changed

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/user-types/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/user-types/index.md
@@ -213,7 +213,9 @@ curl -s -XPOST -H "Content-Type: application/json" -H "Authorization: SSWS ${api
 
 <ApiOperation method="POST" url="/api/v1/meta/types/user/{typeId}" />
 
-Updates an existing User Type. A PUT is a full replace operation; a POST is a partial update. Only the `displayName` and `description` elements can be changed. The schema associated with this type is not editable with this API. If you want to edit the schema, use the [schema update API](/docs/reference/api/schemas/#add-property-to-user-profile-schema).
+Updates an existing User Type. A PUT is a full replace operation; a POST is a partial update. Only the `displayName` and `description` elements can be changed; the `name` of an existing User Type cannot be changed.
+
+The schema associated with this type is not editable with this API. If you want to edit the schema, use the [schema update API](/docs/reference/api/schemas/#add-property-to-user-profile-schema).
 
 ##### Request Parameters
 

--- a/packages/@okta/vuepress-site/docs/reference/api/user-types/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/user-types/index.md
@@ -213,7 +213,7 @@ curl -s -XPOST -H "Content-Type: application/json" -H "Authorization: SSWS ${api
 
 <ApiOperation method="POST" url="/api/v1/meta/types/user/{typeId}" />
 
-Updates an existing User Type. A PUT is a full replace operation; a POST is a partial update. The schema associated with this type is not editable with this API. If you want to edit the schema, use the [schema update API](/docs/reference/api/schemas/#add-property-to-user-profile-schema).
+Updates an existing User Type. A PUT is a full replace operation; a POST is a partial update. Only the `displayName` and `description` elements can be changed. The schema associated with this type is not editable with this API. If you want to edit the schema, use the [schema update API](/docs/reference/api/schemas/#add-property-to-user-profile-schema).
 
 ##### Request Parameters
 
@@ -351,7 +351,7 @@ The User Type model defines several properties:
 | ------------- | ------------------------------------------------- | -------------------------------------------------------------- | -------- | ------ | -------- |
 | id            | Unique key for the User Type                      | String                                                         | FALSE    | TRUE   | TRUE     |
 | displayName   | The display name for the type                     | String                                                         | FALSE    | FALSE  | FALSE    |
-| name          | The name for the type                             | String                                                         | FALSE    | TRUE   | FALSE    |
+| name          | The name for the type                             | String                                                         | FALSE    | TRUE   | TRUE     |
 | description   | A human-readable description of the type          | String                                                         | FALSE    | FALSE  | FALSE    |
 | createdBy     | The user id of the creator of this type           | String                                                         | FALSE    | FALSE  | TRUE     |
 | lastUpdatedBy | The user id of the last user to edit this type    | String                                                         | FALSE    | FALSE  | TRUE     |


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- The name of an existing user type cannot be changed
- This is tied to release 2020.02.0

### Resolves:

* [OKTA-276302](https://oktainc.atlassian.net/browse/OKTA-276302)
