### PR TITLE
[Prose]: IMG Height Reference Landing

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_reference.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_reference.scss
@@ -27,6 +27,7 @@
 
     img {
       width: 1.4em;
+      height: 1.4em;
       margin-right: 0.4em;
     }
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Fixes the img height for Safari on the reference landing pages.

Resolves #955 

TL: Brave
TR: Chrome
BL: Safari
BR: Firefox
<img width="2996" alt="Screen Shot 2020-02-19 at 9 33 57 AM" src="https://user-images.githubusercontent.com/1906920/74844201-1f159b00-52fb-11ea-80b8-402f6c589d31.png">
