### PR TITLE
[Prose]: Remove extra breadcrumb padding

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_breadcrumb.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_breadcrumb.scss
@@ -4,12 +4,17 @@
   border-bottom: $border-default;
 
   &--container {
+    padding: 0px;
+
+    @include media(">=tablet") {
+      padding: 0rem 1.5rem;
+    }
 
     ol {
       list-style: none;
       display: flex;
       align-items: center;
-      padding: 0em; 
+      padding: 0em;
 
       li {
         display: flex;


### PR DESCRIPTION

<img width="457" alt="Screen Shot 2020-02-19 at 10 24 05 PM" src="https://user-images.githubusercontent.com/1906920/74898010-9d5b5700-5366-11ea-8f93-721370699cae.png">
<img width="820" alt="Screen Shot 2020-02-19 at 10 26 58 PM" src="https://user-images.githubusercontent.com/1906920/74898125-f6c38600-5366-11ea-85c2-e979e5d45973.png">

resolves #953 
