### PR TITLE
Force submenu to be above search

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_top-bar.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_top-bar.scss
@@ -238,6 +238,7 @@
                 margin-bottom: 0rem;
                 box-shadow: rgba(0, 0, 0, 0.3) 0 2px 10px;
                 border-radius: 3px;
+                z-index: 100;
 
                 &::before {
                   border-bottom: solid 22px white;


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Updates the z-index for top-bar submenu to be over search bar
- **Is this PR related to a Monolith release?** no

resolves #986 

<img width="651" alt="Screen Shot 2020-02-20 at 1 05 24 PM" src="https://user-images.githubusercontent.com/1906920/74964639-c2d97680-53e1-11ea-843e-a3d26a6cede1.png">

