### PR TITLE
Case 00771223

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -2092,7 +2092,7 @@ curl -v -X GET \
 -H "Accept: application/json" \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
-"https://${yourOktaDomain}/api/v1/apps?filter=group.id+eq+\"00gckgEHZXOUDGDJLYLG\""
+"https://${yourOktaDomain}/api/v1/apps?filter=group.id+eq+"00gckgEHZXOUDGDJLYLG""
 ```
 
 ##### Response example


### PR DESCRIPTION
This is creating an invalid search filter in Postman and other applications. Yes, it should be escaped, but a working example command should be used. Not an invalid one.

<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
