### PR TITLE
Update max-width to fix firefox bug

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_content.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_content.scss
@@ -13,7 +13,7 @@
     flex-direction: row;
     margin-top: 4rem;
 
-    
+
     p, ol, ul {
       max-width: inherit;
     }
@@ -28,7 +28,7 @@
     @include media('>=tablet') {
       width: 18rem;
     }
-    
+
     @include media('<tablet') {
       width: 40rem;
 
@@ -48,10 +48,12 @@
     flex-wrap: wrap;
     margin-top: 4rem;
     width: 100%;
+    max-width: 100%;
 
     @include media('>=tablet') {
       margin: 0rem $big-spacing;
       width: 64%;
+      max-width: 64%;
     }
 
     a {
@@ -100,7 +102,7 @@
     h5 {
       margin-top: 2rem;
     }
-  
+
   }
 
   .on-this-page {


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Add max width to content area to fix firefox bug
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

#### Before
<img width="1489" alt="Screen Shot 2020-02-20 at 6 20 02 PM" src="https://user-images.githubusercontent.com/1906920/74989196-b79c4000-540d-11ea-8369-763762f34aad.png">

#### After
<img width="1487" alt="Screen Shot 2020-02-20 at 6 20 16 PM" src="https://user-images.githubusercontent.com/1906920/74989206-bec34e00-540d-11ea-84e7-03566eae17b4.png">

