### PR TITLE
Remove trailing slash for Issuer in OIDC IDP config

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/add-an-external-idp/configure-idp-in-okta/oktatookta/appidpinokta.md
+++ b/packages/@okta/vuepress-site/docs/guides/add-an-external-idp/configure-idp-in-okta/oktatookta/appidpinokta.md
@@ -11,7 +11,7 @@ In the **Endpoints** section:
 
 Add the following endpoint URLs for the Okta Identity Provider that you are configuring. In the Okta org that represents the Identity Provider, you can find the endpoints in the well-known configuration document (for example, `https://{theOktaIdPOrg}/.well-known/openid-configuration`.
 
-* **Issuer** - The identifier of the Okta Identity Provider. For example, the Okta org where you created the Identity Provider app: `https://{theOktaIdPOrg}/`
+* **Issuer** - The identifier of the Okta Identity Provider. For example, the Okta org where you created the Identity Provider app: `https://{theOktaIdPOrg}`
 * **Authorization endpoint** - The URL of the Okta Identity Provider's OAuth 2.0 authorization endpoint. For example: `https://{theOktaIdPOrg}/oauth2/v1/authorize`
 * **Token endpoint** - The URL of the Okta Identity Provider's token endpoint for obtaining access and ID tokens. For example: `https://{theOktaIdPOrg}/oauth2/v1/token`
 * **JWKS endpoint** - The URL of the Okta Identity Provider's JSON Web Key Set document. This document contains signing keys that are used to validate the signatures from the provider. For example: `https://{theOktaIdPOrg}/oauth2/v1/keys`


### PR DESCRIPTION
## Description:
- **What's changed?** Removed trailing slash for the Issuer example present in the OIDC Identity Provider configuration as the issuer generated by Okta as authorization server does not have a trailing slash 
- **Is this PR related to a Monolith release?** No
