### PR TITLE
Adds icons for OIDC and SAML to stack selector

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/okta/pages/guides.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/okta/pages/guides.scss
@@ -196,15 +196,6 @@ $big-spacing: 3rem;
   border-radius: 3px;
   overflow: hidden;
 
-  /* reduce icons to 24px */
-  .icon[class*='-32'] {
-    &:before,
-    &:after {
-      font-size: 24px;
-      line-height: 24px;
-    }
-  }
-
   nav.tabs ul {
     background: $gray-000;
     display: flex; /*fallback*/
@@ -232,6 +223,17 @@ $big-spacing: 3rem;
         &:hover {
           background: transparent;
           border-bottom-color: $action-base;
+        }
+      }
+
+      /* scale icons to 24px */
+      .icon {
+        width: 24px;
+        height: 24px;
+        &:before,
+        &:after {
+          font-size: 24px;
+          line-height: 24px;
         }
       }
 
@@ -263,6 +265,8 @@ $big-spacing: 3rem;
 
         .framework {
           padding-left: 10px;
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
       }
     }

--- a/packages/@okta/vuepress-theme-prose/util/frameworks.js
+++ b/packages/@okta/vuepress-theme-prose/util/frameworks.js
@@ -44,16 +44,23 @@ const COMMON_NAME_TO_FANCY_NAME = {
 };
 
 const COMMON_NAME_TO_ICON_NAME = {
-  reactnative: 'react',
-  netcore: 'dotnet',
-  aspnet: 'dotnet',
-  aspnetcore: 'dotnet',
-  aspnetcore3: 'dotnet',
-  springboot: 'spring',
-  nodeexpress: 'nodejs'
+  android: 'code-android-32',
+  angular: 'code-angular-32',
+  aspnet: 'code-dotnet-32',
+  aspnetcore: 'code-dotnet-32',
+  aspnetcore3: 'code-dotnet-32',
+  ios: 'code-ios-32',
+  netcore: 'code-dotnet-32',
+  nodeexpress: 'code-nodejs-32',
+  openidconnect: 'openid-16',
+  react: 'code-react-32',
+  reactnative: 'code-react-32',
+  saml2: 'advanced-sso-16-blue',
+  springboot: 'code-spring-32',
+  vue: 'code-vue-32'
 };
 
 export const commonify = framework => FRAMEWORK_TO_COMMON_NAME[framework] || framework.toLowerCase();
 export const fancify = framework => COMMON_NAME_TO_FANCY_NAME[framework] || framework.toUpperCase();
 export const iconify = framework => COMMON_NAME_TO_ICON_NAME[framework] || framework;
-export const cssForIcon = framework => `icon code-${iconify(framework)}-32`;
+export const cssForIcon = framework => `icon ${iconify(framework)}`;


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?**
  - Adds icons for OIDC and SAML to stack selector. These are the same icons used in the Developer and Admin Consoles.
  - When stack selector names are truncated in smaller viewports, adds an ellipsis to indicate.
- **Is this PR related to a Monolith release?** No.

<img width="582" alt="protocols" src="https://user-images.githubusercontent.com/26014482/75297749-bf286400-57d4-11ea-9193-a927a1e43999.png">
<img width="332" alt="truncation" src="https://user-images.githubusercontent.com/26014482/75297757-c3548180-57d4-11ea-9774-52091b8447d4.png">


### Supports:

* [OKTA-279189](https://oktainc.atlassian.net/browse/OKTA-279189)

cc @IanHakes-okta 
