### PR TITLE
Image links fix for books

### DIFF
--- a/packages/@okta/vuepress-site/books/api-security/authn/federated/index.md
+++ b/packages/@okta/vuepress-site/books/api-security/authn/federated/index.md
@@ -10,11 +10,8 @@ Federated identity is a way to use an account from one website to create an acco
 
 There are two main players in a federated identity system: an Identity Provider (IdP) and a Service Provider (SP). Often, the service provider is the application that you need to log in to, and the IdP is the provider of the users that can log in.
 
-<figure id="fig_authn_federated_identity">
-  <img /assets/img/books/federated-identity.png" alt="" style="width: 75%"/>
-  <figcaption>Federated Identity</figcaption>
-</figure>
 
+![Federated Identity](/img/books/api-security/authn/images/federated-identity.png "Federated Identity")
 
 ### OAuth 2.0 {#authn-oauth-2}
 
@@ -24,10 +21,7 @@ OAuth 2.0 is a delegated authorization framework which is ideal for APIs. It ena
 
 OAuth is like a hotel key card, but for apps. If you have a hotel key card, you can get access to your room, the business center, and potentially the gym. How do you get a hotel key card? You have to do an authentication process at the front desk to get it. After authenticating and obtaining the keycard, you can only access the places and things the hotel has authorized you to use.
 
-<figure id="fig_authn_hotel_key_card">
-  <img /assets/img/books/hotel-key-card.jpg" alt=""/>
-  <figcaption>OAuth is like a hotel key card, but for apps!</figcaption>
-</figure>
+![OAuth is like a hotel key card, but for apps!](/img/books/api-security/authn/images/hotel-key-card.jpg "OAuth is like a hotel key card, but for apps!")
 
 To break it down simply, OAuth is where:
 
@@ -41,10 +35,7 @@ Client applications can be public or confidential. There is a significant distin
 
 Public clients are browsers, mobile apps, and IoT devices. The code on these devices can be extracted, decompiled, and reviewed. Therefore, we can't store any sensitive information in the application itself and expect it to be protected. Do not embed a password or secret information - including URLs - of any form in these types of applications!
 
-<figure id="fig_authn_client_types">
-  <img /assets/img/books/client-types.png" alt="" />
-  <figcaption>Public vs confidential clients</figcaption>
-</figure>
+![Public vs confidential clients](/img/books/api-security/authn/images/client-types.png "Public vs confidential clients")
 
 The core OAuth specification describes two types of tokens: an access token and a refresh token. The client uses the access token to access an API (aka Resource Server). They're meant to be short-lived and work over a span of minutes or hours, not days or months. Due to this, the core OAuth specification doesn't have an approach to revoking access tokens but in many cases you will need to as a token could have been compromised or a subscription has expired. To address that [RFC 7009](https://oauth.net/2/token-revocation/) describes an additional endpoint to revoke a token. To be specific, this revokes it with the Authorization Server, not the Resource Server (API). Unless the Resource Server checks with the Authorization Server, it will not know the token has been revoked. This happens in the real world where you could still use your driver license to board a flight, even if it has been revoked.
 
@@ -78,10 +69,7 @@ To address the differences between web apps, mobile clients, IoT devices, and ev
 
 7. **Authorization Code Flow + PKCE** - the recommended flow for native apps on mobile devices. In this flow, the native app sends a PKCE code challenge along with the authentication request. This is described further in what's commonly known as the "[AppAuth spec](https://oauth.net/2/native-apps/)".
 
-<figure id="fig_authn_framework">
-  <img /assets/img/books/framework.png" alt="" />
-  <figcaption>Authorization Framework: Return of complexity through extensions</figcaption>
-</figure>
+![Authorization Framework: Return of complexity through extensions](/img/books/api-security/authn/images/framework.png "Authorization Framework: Return of complexity through extensions")
 
 There's a huge number of additions that happened to OAuth in the last several years. These add complexity back on top of OAuth to complete a variety of enterprise scenarios. In <a href="#fig_authn_framework" class="figref"></a>, you can see how JSON and OAuth are the foundation. JWT, JWK, JWE, and JWS can be used as interoperable tokens that can be signed and encrypted.
 
@@ -89,10 +77,7 @@ There's a huge number of additions that happened to OAuth in the last several ye
 
 OAuth 2.0 is not an authentication protocol. It explicitly says so in [its documentation](https://oauth.net/articles/authentication/).
 
-<figure id="fig_authn_oauth_not_authn">
-  <img /assets/img/books/oauth-not-authn.png" alt="" />
-  <figcaption>OAuth is not an authentication protocol (oauth.net)</figcaption>
-</figure>
+![OAuth is not an authentication protocol (oauth.net)](/img/books/api-security/authn/images/oauth-not-authn.png "OAuth is not an authentication protocol (oauth.net)")
 
 While it's easy to lose that distinction, note that everything so far has been about delegated authorization. OAuth 2.0 alone says absolutely nothing about the user such as how they authenticate or what information we have about them. We simply have a token to access a resource.
 Pseudo-Authentication with OAuth 2.0
@@ -120,10 +105,7 @@ Generally, an OpenID Connect flow involves the following steps:
 
 In terms of implementation, an ID token is a JSON Web Token (JWT) which adheres to the specification and is small enough to pass between devices
 
-<figure id="fig_authn_oidc">
-  <img /assets/img/books/openid-connect.png" alt="" />
-  <figcaption>OpenID Connect Flow</figcaption>
-</figure>
+![OpenID Connect Flow](/img/books/api-security/authn/images/openid-connect.png "OpenID Connect Flow")
 
 The Authorization Code Flow can also be used with Native apps. In this scenario, the native app sends a PKCE code challenge along with the authentication request. PKCE (pronounced "pixy") stands for Proof Key for Code Exchange and is defined by [RFC 7636](https://oauth.net/2/pkce/).
 

--- a/packages/@okta/vuepress-site/books/api-security/dos/what/index.md
+++ b/packages/@okta/vuepress-site/books/api-security/dos/what/index.md
@@ -11,10 +11,7 @@ There are three main types of DoS attacks:
 ### 1. Application-layer Flood
 In this attack type, an attacker simply floods the service with requests from a spoofed IP address in an attempt to slow or crash the service, illustrated in <a href="#fig_dos_flood" class="figref"></a>. This could take the form of millions of requests per second or a few thousand requests to a particularly resource-intensive service that eat up resources until the service is unable to continue processing the requests.
 
-<figure id="fig_dos_flood">
-  <img /assets/img/books/attack.png" alt=""/>
-  <figcaption>An attacker floods the service from a single IP address</figcaption>
-</figure>
+![An attacker floods the service from a single IP address](/img/books/api-security/dos/images/attack.png "An attacker floods the service from a single IP address")
 
 Preventing application-layer DoS attacks can be tricky. The best way to help mitigate these types of attacks is to outsource pattern detection and IP filtering to a third party (discussed later).
 
@@ -28,10 +25,7 @@ DDoS attacks are famously hard to mitigate, which is why outsourcing network fil
 ### 3. Unintended Denial of Service Attacks
 Not all DoS attacks are nefarious. The third attack type is the "unintended" Denial of Service attack. The canonical example of an unintended DDoS is called "[The Slashdot Effect](https://hup.hu/old/stuff/slashdotted/SlashDotEffect.html)". Slashdot is an internet news site where anyone can post news stories and link to other sites. If a linked story becomes popular, it can cause millions of users to visit the site overloading the site with requests. If the site isn't built to handle that kind of load, the increased traffic can slow or even crash the linked site. Reddit and "[The Reddit Hug of Death](https://thenextweb.com/socialmedia/2012/01/17/how-reddit-turned-one-congressional-candidates-campaign-upside-down/)" is another excellent example of an unintentional DoS.
 
-<figure id="fig_dos_ddos">
-  <img /assets/img/books/ddos.png" alt=""/>
-  <figcaption>An attacker uses zombie machines to launch a DDoS against the target</figcaption>
-</figure>
+![An attacker uses zombie machines to launch a DDoS against the target](/img/books/api-security/dos/images/ddos.png "An attacker uses zombie machines to launch a DDoS against the target")
 
 The only way to prevent these types of unintended DoS attacks is to architect your application for scale. Use patterns like edge-caching with CDNs, HTTP caching headers, auto-scaling groups, and other methods to ensure that even when you receive a large amount of burst-traffic, your site will not go down.
 

--- a/packages/@okta/vuepress-site/books/api-security/sanitizing/common-attacks/index.md
+++ b/packages/@okta/vuepress-site/books/api-security/sanitizing/common-attacks/index.md
@@ -40,10 +40,7 @@ A cross-site scripting attack (XSS) is an attack that executes code in a web pag
 
 There are [tons of resources online](https://www.owasp.org/index.php/Cross-site_Scripting_%28XSS%29) that cover this topic in great detail, so I'll only provide a basic example here. Earlier in this chapter the string `<img src onerror='alert("haxor")'>` was posted as a Reddit comment. If this string isn't correctly escaped it would have resulted in an annoying popup, shown in <a href="#fig_sanitizing_alert" class="figref"></a>.
 
-<figure id="fig_sanitizing_alert">
-  <img /assets/img/books/alert.png" alt="" style="width:80%;"/>
-  <figcaption>A JavaScript alert popup</figcaption>
-</figure>
+![A JavaScript alert popup](/img/books/api-security/sanitizing/images/alert.png "A JavaScript alert popup")
 
 You may see `alert()` used throughout examples when describing these attacks. The idea is if you can cause an alert to happen in the browser, you can execute other code that does something more malicious like sends your information (cookie, session ID, or other personal info) to a remote site.
 

--- a/packages/@okta/vuepress-site/books/api-security/sanitizing/index.md
+++ b/packages/@okta/vuepress-site/books/api-security/sanitizing/index.md
@@ -23,10 +23,7 @@ If this were rendered as is, in an HTML page, it would pop up an annoying messag
 
 which will make the comment appear as visible text instead of HTML, as shown in <a href="#fig_sanitizing_reddit" class="figref"></a>.
 
-<figure id="fig_sanitizing_reddit">
-  <img /assets/img/books/reddit.png" alt=""/>
-  <figcaption>Reddit properly escapes user input</figcaption>
-</figure>
+![Reddit properly escapes user input](/img/books/api-security/sanitizing/images/reddit.png "Reddit properly escapes user input")
 
 In this example the trust boundary is obvious as any user input should not be trusted.
 

--- a/packages/@okta/vuepress-site/books/api-security/tls/certificate-verification/index.md
+++ b/packages/@okta/vuepress-site/books/api-security/tls/certificate-verification/index.md
@@ -16,9 +16,6 @@ It's unlikely that the server's certificate is signed directly by a root certifi
 
 For each intermediate certificate, the client completes the same process: it verifies the issuer's name matches the certificate owner's name, and uses the signature and public key to verify that the certificate is properly signed.
 
-<figure id="fig_tls_certificate_chain">
-  <img /assets/img/books/certificate-chain.png" alt=""/>
-  <figcaption>Illustrating the chain of trust from a root CA through an intermediate certificate</figcaption>
-</figure>
+![Illustrating the chain of trust from a root CA through an intermediate certificate](/img/books/api-security/tls/images/certificate-chain.png "Illustrating the chain of trust from a root CA through an intermediate certificate")
 
 Eventually, in a successful transaction, the client will come to a self-signed root certificate that the client implicitly trusts. At this point, the client has built a cryptographic chain of trust to the server, and the SSL/TLS handshake can proceed.

--- a/packages/@okta/vuepress-site/books/api-security/tls/history/index.md
+++ b/packages/@okta/vuepress-site/books/api-security/tls/history/index.md
@@ -8,10 +8,7 @@ title: A Brief History of Secure Data Transport - Transport Layer Security
 
 Today we take for granted our ability to send data over the internet securely. When we purchase an item from Amazon or complete our taxes online, we place our trust in the infrastructure of the internet to securely share our data with only the systems and parties we intend.
 
-<figure id="fig_tls_siggaba">
-  <img /assets/img/books/SIGABA-labelled-2.jpg" alt=""/>
-  <figcaption style="font-size: 0.8em;">The SIGABA, a cipher machine used by the US during World War II</figcaption>
-</figure>
+![The SIGABA, a cipher machine used by the US during World War II](/img/books/api-security/tls/images/SIGABA-labelled-2.jpg "The SIGABA, a cipher machine used by the US during World War II")
 
 Historically, secure information exchange wasn't simple. Ciphers and cryptography were used in ancient times to encode sensitive messages. These schemes generally had to two main weaknesses: they relied on a shared code book or cipher to encode/decode the messages, and third parties could decode them through pattern analysis.
 

--- a/packages/@okta/vuepress-site/books/api-security/tls/how/index.md
+++ b/packages/@okta/vuepress-site/books/api-security/tls/how/index.md
@@ -20,10 +20,7 @@ Your client (browser or application) will initiate a TCP connection with the ser
 
 The SSL/TLS handshake takes place once a TCP connection is established.
 
-<figure id="fig_tls_sequence_diagram">
-  <img /assets/img/books/tls-sequence-diagram.png" alt=""/>
-  <figcaption>TLS Sequence Diagram</figcaption>
-</figure>
+![TLS Sequence Diagram](/img/books/api-security/tls/images/tls-sequence-diagram.png "TLS Sequence Diagram")
 
 **ClientHello**
 


### PR DESCRIPTION
## Description:
- **What's changed?** This PR fixes the links for images inside the API security books, issue reported [here](https://devforum.okta.com/t/broken-image-in-federated-identity-docs-page/8289/2)
- **Is this PR related to a Monolith release?** No