### PR TITLE
Add Email authn factor

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/public/docs/api/postman/authentication.json
+++ b/packages/@okta/vuepress-site/.vuepress/public/docs/api/postman/authentication.json
@@ -1,905 +1,1562 @@
 {
-	"id": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-	"name": "Authentication (Okta API)",
-	"description": "",
-	"order": [
-		"3501a028-d5ef-8536-af1c-42c0bb93ea4f",
-		"0afa959a-6869-d87f-5e3b-4db894fefbe9",
-		"2cd67c51-9e31-aa3a-c215-8c6b17a8b5cf"
-	],
-	"folders": [
+	"info": {
+		"_postman_id": "c2bd4453-4f12-444e-835e-21adbef9a686",
+		"name": "Authentication (Okta API)",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
 		{
-			"owner": "64678",
-			"lastUpdatedBy": "64678",
-			"lastRevision": 11617676,
-			"id": "cf0cfc29-2443-98b2-438e-2561239767a3",
 			"name": "Enroll",
-			"description": "",
-			"order": [
-				"4a3d39d4-ca07-8dc6-da5a-d9a159e2f950",
-				"75eb0509-884a-2b71-f2d1-044d3fe19c74",
-				"5ba88775-dfe3-efc7-49d3-c0ce44a36c85",
-				"bad6507a-8852-7b82-0044-183497c7ba26",
-				"fb111bae-04ef-2f47-9c47-f515db87e37c",
-				"14a24ef4-aa85-b8de-524d-9df220a0f034",
-				"b61d428a-8566-4822-6f4f-81ca1f6be5af",
-				"7ed210da-fc90-ea82-9557-35e635ea3560",
-				"df105fd2-d59a-fe88-c933-abf0b87acfb9",
-				"a0e8ca2c-132c-7c87-7148-7f3272a6ca52",
-				"793d1877-67e5-e797-be2e-120007079fac",
-				"a17077c9-4f2c-5512-4fe5-e07dd0a3815a",
-				"3f0a0380-9258-f2c6-9d56-61be1eed32ba"
+			"item": [
+				{
+					"name": "List Questions",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/api/v1/users/{{userId}}/factors/questions",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users",
+								"{{userId}}",
+								"factors",
+								"questions"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Enroll Question Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"factorType\": \"question\",\n  \"provider\": \"OKTA\",\n  \"profile\": {\n    \"question\": \"name_of_first_plush_toy\",\n    \"answer\": \"blah\"\n  }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Enroll SMS Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"factorType\": \"sms\",\n  \"provider\": \"OKTA\",\n  \"profile\": {\n    \"phoneNumber\" :  \"+1 415 555 5555\"\n  }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Enroll SMS Factor with New Number",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"factorType\": \"sms\",\n  \"provider\": \"OKTA\",\n  \"profile\": {\n    \"phoneNumber\":  \"+1 415 555 5555\"\n  }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors?updatePhone=true",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors"
+							],
+							"query": [
+								{
+									"key": "updatePhone",
+									"value": "true"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Enroll Email Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"factorType\": \"email\",\n  \"provider\": \"OKTA\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors"
+							]
+						},
+						"description": "This request does not specify the Email address to enroll;  implicitly the primary Email address from the user's profile is always used.\n\nIf the Email factor is REQUIRED by MFA enrollment policy then the Email factor will be enrolled (and activated) automatically, and these API calls to enroll and activate the Email factor are unnecessary;  generally these API calls are only pertinent if the Email factor is OPTIONAL."
+					},
+					"response": []
+				},
+				{
+					"name": "Enroll Okta TOTP Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\" : \"{{stateToken}}\",\n  \"factorType\": \"token:software:totp\",\n  \"provider\": \"OKTA\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Enroll Okta Verify Push  Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\" : \"{{stateToken}}\",\n  \"factorType\": \"push\",\n  \"provider\": \"OKTA\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Enroll Google Authenticator Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\" : \"{{stateToken}}\",\n  \"factorType\": \"token:software:totp\",\n  \"provider\": \"GOOGLE\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Enroll RSA SecurID Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"factorType\": \"token:hardware\",\n  \"provider\": \"YUBICO\",\n  \"passCode\": \"cccccceukngdfgkukfctkcvfidnetljjiknckkcjulji\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Enroll Symantec VIP Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"factorType\": \"token\",\n  \"provider\": \"SYMANTEC\",\n  \"profile\": {\n    \"credentialId\": \"VSMT14393584\"\n  },\n  \"passCode\": \"875498\",\n  \"nextPassCode\": \"678195\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Enroll YubiKey Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"factorType\": \"token\",\n  \"provider\": \"RSA\",\n  \"profile\": {\n    \"credentialId\": \"{{username}}\"\n  },\n  \"passCode\": \"5275875498\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Activate SMS Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"passCode\": \"679682\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors/{{factorId}}/lifecycle/activate",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors",
+								"{{factorId}}",
+								"lifecycle",
+								"activate"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Activate Email Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"passCode\": \"679682\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors/{{factorId}}/lifecycle/activate",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors",
+								"{{factorId}}",
+								"lifecycle",
+								"activate"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Activate TOTP Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"passCode\": \"679682\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors/{{factorId}}/lifecycle/activate",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors",
+								"{{factorId}}",
+								"lifecycle",
+								"activate"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Activate Push Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors/{{factorId}}/lifecycle/activate",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors",
+								"{{factorId}}",
+								"lifecycle",
+								"activate"
+							]
+						}
+					},
+					"response": []
+				}
 			],
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315"
+			"protocolProfileBehavior": {}
 		},
 		{
-			"owner": "64678",
-			"lastUpdatedBy": "64678",
-			"lastRevision": 11617678,
-			"id": "299e9d58-11f2-1691-c8f2-47fc6283bcb5",
 			"name": "Forgot Password",
-			"description": "",
-			"order": [
-				"ae7228c6-d912-3cf3-de22-cf60985cd895",
-				"3e57d8e9-fb44-cae4-cb18-0c21740eb55a",
-				"2572e149-a619-1d49-85f9-da8345fdecca",
-				"a614f393-08da-acaf-0fa1-ecb0d7ec9085",
-				"b8a621b9-4995-3ddc-88e0-0e1f18e91339",
-				"bd7abefe-0512-1f13-0c9d-5b275e4ba0d5",
-				"3bf335d5-896c-14ee-167f-c4f59a1ad0c4"
+			"item": [
+				{
+					"name": "Forgot Password with Email Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"username\": \"{{username}}\",\n  \"factorType\": \"EMAIL\",\n  \"relayState\": \"/myapp/some/deep/link/i/want/to/return/to\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/recovery/password",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"recovery",
+								"password"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Forgot Password with SMS Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"username\": \"{{username}}\",\n  \"factorType\": \"SMS\",\n  \"relayState\": \"/myapp/some/deep/link/i/want/to/return/to\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/recovery/password",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"recovery",
+								"password"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Forgot Password for Trusted Application",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "SSWS {{apikey}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"username\": \"{{username}}\",\n  \"relayState\": \"{{relayState}}\"\n}  "
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/recovery/password",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"recovery",
+								"password"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Verify SMS Recovery Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"passCode\": \"123456\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/recovery/factors/sms/verify",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"recovery",
+								"factors",
+								"sms",
+								"verify"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Verify Recovery Token",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"recoveryToken\": \"{{recoveryToken}}\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/recovery/token",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"recovery",
+								"token"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Answer Recovery Question",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"answer\": \"Annie Oakley\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/recovery/answer",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"recovery",
+								"answer"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Reset Password",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"newPassword\": \"Ch-ch-ch-ch-Chang3s!\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/credentials/reset_password",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"credentials",
+								"reset_password"
+							]
+						}
+					},
+					"response": []
+				}
 			],
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315"
+			"protocolProfileBehavior": {}
 		},
 		{
-			"owner": "64678",
-			"lastUpdatedBy": "64678",
-			"lastRevision": 11617679,
-			"id": "9304d459-4db6-272b-d9f6-db216b464c9f",
 			"name": "Self-Service Unlock",
-			"description": "",
-			"order": [
-				"c779e2a8-8b10-5f3b-339c-ef3bfb8c9ff8",
-				"88c21491-a1ee-adec-6ff4-02b1acdb28d7",
-				"3f281b85-6201-710d-8c40-03c537c060cd",
-				"2ce93cc9-20b9-b637-5ea2-27bddb3f7a00",
-				"98385035-4186-1423-6888-5925272a95c5",
-				"6d909d52-789e-b1bb-567c-5a8aac67fd45"
+			"item": [
+				{
+					"name": "Unlock Account with Email Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"username\": \"{{username}}\",\n  \"factorType\": \"EMAIL\",\n  \"relayState\": \"/myapp/some/deep/link/i/want/to/return/to\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/recovery/unlock",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"recovery",
+								"unlock"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Unlock Account with SMS Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"username\": \"{{username}}\",\n  \"factorType\": \"SMS\",\n  \"relayState\": \"/myapp/some/deep/link/i/want/to/return/to\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/recovery/unlock",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"recovery",
+								"unlock"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Unlock Account with  Trusted Application",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "SSWS {{apikey}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"username\": \"{{username}}\",\n  \"relayState\": \"{{relayState}}\"\n}  "
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/recovery/unlock",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"recovery",
+								"unlock"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Verify SMS Recovery Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"passCode\": \"123456\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/recovery/factors/sms/verify",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"recovery",
+								"factors",
+								"sms",
+								"verify"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Verify Recovery Token",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"recoveryToken\": \"{{recoveryToken}}\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/recovery/token",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"recovery",
+								"token"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Answer Recovery Question",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"answer\": \"Annie Oakley\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/recovery/answer",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"recovery",
+								"answer"
+							]
+						}
+					},
+					"response": []
+				}
 			],
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315"
+			"protocolProfileBehavior": {}
 		},
 		{
-			"id": "00cec151-3706-7dc3-6aed-e26fc31cbc53",
 			"name": "State Management",
-			"description": "",
-			"order": [
-				"16736904-ecc6-be4d-b831-96a0a5fbab1a",
-				"bda8b464-0f25-d187-f62c-088c37e2d176",
-				"dca594c7-cdec-a3e7-64f1-4404fda90eff",
-				"d0c213ca-bfbf-a5e3-0579-d01a11606f66"
+			"item": [
+				{
+					"name": "Get Transaction  State",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Skip Transaction State",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/skip",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"skip"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Previous Transaction State",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/previous",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"previous"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Cancel Transaction",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/cancel",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"cancel"
+							]
+						}
+					},
+					"response": []
+				}
 			],
-			"owner": "64678"
+			"protocolProfileBehavior": {}
 		},
 		{
-			"owner": "64678",
-			"lastUpdatedBy": "64678",
-			"lastRevision": 11617680,
-			"id": "83af8b34-4f6b-eb5b-809f-16de5ffb017b",
 			"name": "Verify",
-			"description": "",
-			"order": [
-				"5758ad1d-bb57-4d3b-d497-83bf1fa5e541",
-				"e03b987e-f843-d0e7-7dbf-d89e08ed5933",
-				"324ec1ce-9f14-089d-fad8-f63ec56e9556",
-				"4f6d98be-a823-94d9-c41a-ad5adbc7a7bc",
-				"59653e2b-9112-52d6-43dd-adc03b2b5e47",
-				"40dd5bfb-39b2-8fca-14ab-cb09b98d8071"
+			"item": [
+				{
+					"name": "Send SMS Challenge (OTP)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors/{{factorId}}/verify",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors",
+								"{{factorId}}",
+								"verify"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Send Email Challenge (OTP)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors/{{factorId}}/verify",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors",
+								"{{factorId}}",
+								"verify"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Verify Question Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"answer\": \"Annie Oakley\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors/{{factorId}}/verify",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors",
+								"{{factorId}}",
+								"verify"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Verify SMS Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"passCode\": \"029656\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors/{{factorId}}/verify",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors",
+								"{{factorId}}",
+								"verify"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Verify Email Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"passCode\": \"029656\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors/{{factorId}}/verify",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors",
+								"{{factorId}}",
+								"verify"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Verify TOTP Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"passCode\": \"029656\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors/{{factorId}}/verify",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors",
+								"{{factorId}}",
+								"verify"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": " Verify and Poll Push Factor",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors/{{factorId}}/verify",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors",
+								"{{factorId}}",
+								"verify"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Resend Challenge",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"stateToken\": \"{{stateToken}}\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/authn/factors/{{factorId}}/verify/resend",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"authn",
+								"factors",
+								"{{factorId}}",
+								"verify",
+								"resend"
+							]
+						}
+					},
+					"response": []
+				}
 			],
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315"
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "Primary Authentication ",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"username\": \"{{username}}\",\n  \"password\": \"{{password}}\",\n  \"options\": {\n    \"multiOptionalFactorEnroll\": true,\n    \"warnBeforePasswordExpired\": true\n  }  \n}"
+				},
+				"url": {
+					"raw": "{{url}}/api/v1/authn",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"authn"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Primary Authentication with Trusted Application",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "Authorization",
+						"value": "SSWS {{apikey}}"
+					},
+					{
+						"key": "X-Fowarded-For",
+						"value": "23.235.46.133",
+						"disabled": true
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"username\": \"{{username}}\",\n  \"password\" : \"{{password}}\",\n  \"relayState\": \"{{relayState}}\",\n  \"options\": {\n    \"multiOptionalFactorEnroll\": true,\n    \"warnBeforePasswordExpired\": true\n  },  \n  \"context\": {\n    \"deviceToken\": \"26q43Ak9Eh04p7H6Nnx0m69JqYOrfVBY\"\n  }\n}  "
+				},
+				"url": {
+					"raw": "{{url}}/api/v1/authn",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"authn"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Change Password",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"oldPassword\" : \"3EMaPQ7x\",\n  \"newPassword\" : \"Ch-ch-ch-ch-Chang3s!\"\n}  "
+				},
+				"url": {
+					"raw": "{{url}}/api/v1/authn/credentials/change_password",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"authn",
+						"credentials",
+						"change_password"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Poll for Factor enrollment",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"factorType\": \"push\",\n  \"provider\": \"OKTA\"\n}"
+				},
+				"url": {
+					"raw": "{{url}}/api/v1/authn/factors/{{factorId}}/lifecycle/activate/poll",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"authn",
+						"factors",
+						"{{factorId}}",
+						"lifecycle",
+						"activate",
+						"poll"
+					]
+				}
+			},
+			"response": []
 		}
 	],
-	"timestamp": 0,
-	"owner": "64678",
-	"remoteLink": "",
-	"public": false,
-	"requests": [
-		{
-			"id": "0afa959a-6869-d87f-5e3b-4db894fefbe9",
-			"headers": "Accept: application/json\nContent-Type: application/json\nAuthorization: SSWS {{apikey}}\n//X-Fowarded-For: 23.235.46.133\n",
-			"url": "{{url}}/api/v1/authn",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1448498178275,
-			"name": "Primary Authentication with Trusted Application",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"username\": \"{{username}}\",\n  \"password\" : \"{{password}}\",\n  \"relayState\": \"{{relayState}}\",\n  \"options\": {\n    \"multiOptionalFactorEnroll\": true,\n    \"warnBeforePasswordExpired\": true\n  },  \n  \"context\": {\n    \"deviceToken\": \"26q43Ak9Eh04p7H6Nnx0m69JqYOrfVBY\"\n  }\n}  "
-		},
-		{
-			"id": "14a24ef4-aa85-b8de-524d-9df220a0f034",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/factors",
-			"pathVariables": {},
-			"preRequestScript": "",
-			"method": "POST",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"data": [],
-			"dataMode": "raw",
-			"name": "Enroll Okta Verify Push  Factor",
-			"description": "",
-			"descriptionFormat": "html",
-			"time": 1447633706443,
-			"version": 2,
-			"responses": [],
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"folder": "cf0cfc29-2443-98b2-438e-2561239767a3",
-			"isFromCollection": true,
-			"collectionRequestId": "14a24ef4-aa85-b8de-524d-9df220a0f034",
-			"rawModeData": "{\n  \"stateToken\" : \"{{stateToken}}\",\n  \"factorType\": \"push\",\n  \"provider\": \"OKTA\"\n}"
-		},
-		{
-			"folder": "00cec151-3706-7dc3-6aed-e26fc31cbc53",
-			"id": "16736904-ecc6-be4d-b831-96a0a5fbab1a",
-			"name": "Get Transaction  State",
-			"dataMode": "raw",
-			"data": [],
-			"descriptionFormat": null,
-			"description": "",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"method": "POST",
-			"pathVariables": {},
-			"url": "{{url}}/api/v1/authn",
-			"preRequestScript": "",
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\"\n}"
-		},
-		{
-			"id": "2572e149-a619-1d49-85f9-da8345fdecca",
-			"folder": "299e9d58-11f2-1691-c8f2-47fc6283bcb5",
-			"name": "Forgot Password for Trusted Application",
-			"dataMode": "raw",
-			"data": [],
-			"descriptionFormat": null,
-			"description": "",
-			"headers": "Accept: application/json\nContent-Type: application/json\nAuthorization: SSWS {{apikey}}\n",
-			"method": "POST",
-			"pathVariables": {},
-			"url": "{{url}}/api/v1/authn/recovery/password",
-			"preRequestScript": "",
-			"tests": "",
-			"currentHelper": null,
-			"helperAttributes": "null",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"isFromCollection": true,
-			"collectionRequestId": "2572e149-a619-1d49-85f9-da8345fdecca",
-			"rawModeData": "{\n  \"username\": \"{{username}}\",\n  \"relayState\": \"{{relayState}}\"\n}  "
-		},
-		{
-			"id": "2cd67c51-9e31-aa3a-c215-8c6b17a8b5cf",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/credentials/change_password",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447053960002,
-			"name": "Change Password",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"oldPassword\" : \"3EMaPQ7x\",\n  \"newPassword\" : \"Ch-ch-ch-ch-Chang3s!\"\n}  "
-		},
-		{
-			"id": "2ce93cc9-20b9-b637-5ea2-27bddb3f7a00",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/recovery/factors/sms/verify",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447635571743,
-			"name": "Verify SMS Recovery Factor",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"responses": [],
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"passCode\": \"123456\"\n}"
-		},
-		{
-			"id": "324ec1ce-9f14-089d-fad8-f63ec56e9556",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/factors/{{factorId}}/verify",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447053935203,
-			"name": "Verify SMS Factor",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"passCode\": \"029656\"\n}"
-		},
-		{
-			"id": "3501a028-d5ef-8536-af1c-42c0bb93ea4f",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447044987068,
-			"name": "Primary Authentication ",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"username\": \"{{username}}\",\n  \"password\": \"{{password}}\",\n  \"options\": {\n    \"multiOptionalFactorEnroll\": true,\n    \"warnBeforePasswordExpired\": true\n  }  \n}"
-		},
-		{
-			"id": "3bf335d5-896c-14ee-167f-c4f59a1ad0c4",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/credentials/reset_password",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447053989274,
-			"name": "Reset Password",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"newPassword\": \"Ch-ch-ch-ch-Chang3s!\"\n}"
-		},
-		{
-			"id": "3e57d8e9-fb44-cae4-cb18-0c21740eb55a",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/recovery/password",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1440757339528,
-			"name": "Forgot Password with SMS Factor",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"folder": "299e9d58-11f2-1691-c8f2-47fc6283bcb5",
-			"isFromCollection": true,
-			"collectionRequestId": "3e57d8e9-fb44-cae4-cb18-0c21740eb55a",
-			"rawModeData": "{\n  \"username\": \"{{username}}\",\n  \"factorType\": \"SMS\",\n  \"relayState\": \"/myapp/some/deep/link/i/want/to/return/to\"\n}"
-		},
-		{
-			"id": "3f0a0380-9258-f2c6-9d56-61be1eed32ba",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/factors/{{factorId}}/lifecycle/activate",
-			"pathVariables": {},
-			"preRequestScript": "",
-			"method": "POST",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"data": [],
-			"dataMode": "raw",
-			"name": "Activate Push Factor",
-			"description": "",
-			"descriptionFormat": "html",
-			"time": 1447637182752,
-			"version": 2,
-			"responses": [],
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"folder": "cf0cfc29-2443-98b2-438e-2561239767a3",
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\"\n}"
-		},
-		{
-			"id": "aad66581-a251-c87b-395c-ca8e47892a66",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/factors/{{factorId}}/lifecycle/activate/poll",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1481758444646,
-			"name": "Poll for Factor enrollment",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"responses": [],
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"factorType\": \"push\",\n  \"provider\": \"OKTA\"\n}"
-		},
-		{
-			"id": "3f281b85-6201-710d-8c40-03c537c060cd",
-			"folder": "9304d459-4db6-272b-d9f6-db216b464c9f",
-			"name": "Unlock Account with  Trusted Application",
-			"dataMode": "raw",
-			"data": [],
-			"descriptionFormat": null,
-			"description": "",
-			"headers": "Accept: application/json\nContent-Type: application/json\nAuthorization: SSWS {{apikey}}\n",
-			"method": "POST",
-			"pathVariables": {},
-			"url": "{{url}}/api/v1/authn/recovery/unlock",
-			"preRequestScript": "",
-			"tests": "",
-			"currentHelper": null,
-			"helperAttributes": "null",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"isFromCollection": true,
-			"collectionRequestId": "3f281b85-6201-710d-8c40-03c537c060cd",
-			"rawModeData": "{\n  \"username\": \"{{username}}\",\n  \"relayState\": \"{{relayState}}\"\n}  "
-		},
-		{
-			"id": "40dd5bfb-39b2-8fca-14ab-cb09b98d8071",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/factors/{{factorId}}/verify/resend",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447053904072,
-			"name": "Resend Challenge",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"responses": [],
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\"\n}"
-		},
-		{
-			"id": "4a3d39d4-ca07-8dc6-da5a-d9a159e2f950",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/users/{{userId}}/factors/questions",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "GET",
-			"data": [],
-			"dataMode": "params",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447054013763,
-			"name": "List Questions",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315"
-		},
-		{
-			"id": "4f6d98be-a823-94d9-c41a-ad5adbc7a7bc",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/factors/{{factorId}}/verify",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447053926050,
-			"name": "Verify TOTP Factor",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"passCode\": \"029656\"\n}"
-		},
-		{
-			"id": "5758ad1d-bb57-4d3b-d497-83bf1fa5e541",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/factors/{{factorId}}/verify",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447053947934,
-			"name": "Send SMS Challenge (OTP)",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\"\n}"
-		},
-		{
-			"id": "59653e2b-9112-52d6-43dd-adc03b2b5e47",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/factors/{{factorId}}/verify",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447053918082,
-			"name": " Verify and Poll Push Factor",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"responses": [],
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\"\n}"
-		},
-		{
-			"id": "5ba88775-dfe3-efc7-49d3-c0ce44a36c85",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/factors",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447054029272,
-			"name": "Enroll SMS Factor",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"factorType\": \"sms\",\n  \"provider\": \"OKTA\",\n  \"profile\": {\n    \"phoneNumber\" :  \"+1 415 555 5555\"\n  }\n}"
-		},
-		{
-			"id": "6d909d52-789e-b1bb-567c-5a8aac67fd45",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/recovery/answer",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447635577858,
-			"name": "Answer Recovery Question",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"answer\": \"Annie Oakley\"\n}"
-		},
-		{
-			"id": "75eb0509-884a-2b71-f2d1-044d3fe19c74",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/factors",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447054018774,
-			"name": "Enroll Question Factor",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"factorType\": \"question\",\n  \"provider\": \"OKTA\",\n  \"profile\": {\n    \"question\": \"name_of_first_plush_toy\",\n    \"answer\": \"blah\"\n  }\n}"
-		},
-		{
-			"id": "793d1877-67e5-e797-be2e-120007079fac",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/factors/{{factorId}}/lifecycle/activate",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447054040907,
-			"name": "Activate SMS Factor",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"passCode\": \"679682\"\n}"
-		},
-		{
-			"id": "7ed210da-fc90-ea82-9557-35e635ea3560",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/factors",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447637522991,
-			"name": "Enroll RSA SecurID Factor",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"responses": [],
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"factorType\": \"token:hardware\",\n  \"provider\": \"YUBICO\",\n  \"passCode\": \"cccccceukngdfgkukfctkcvfidnetljjiknckkcjulji\"\n}"
-		},
-		{
-			"id": "88c21491-a1ee-adec-6ff4-02b1acdb28d7",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/recovery/unlock",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447635592211,
-			"name": "Unlock Account with SMS Factor",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"responses": [],
-			"rawModeData": "{\n  \"username\": \"{{username}}\",\n  \"factorType\": \"SMS\",\n  \"relayState\": \"/myapp/some/deep/link/i/want/to/return/to\"\n}"
-		},
-		{
-			"id": "98385035-4186-1423-6888-5925272a95c5",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/recovery/token",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447635583580,
-			"name": "Verify Recovery Token",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"recoveryToken\": \"{{recoveryToken}}\"\n}"
-		},
-		{
-			"id": "a0e8ca2c-132c-7c87-7148-7f3272a6ca52",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/factors",
-			"pathVariables": {},
-			"preRequestScript": "",
-			"method": "POST",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"data": [],
-			"dataMode": "raw",
-			"name": "Enroll YubiKey Factor",
-			"description": "",
-			"descriptionFormat": "html",
-			"time": 1447637450684,
-			"version": 2,
-			"responses": [],
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"folder": "cf0cfc29-2443-98b2-438e-2561239767a3",
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"factorType\": \"token\",\n  \"provider\": \"RSA\",\n  \"profile\": {\n    \"credentialId\": \"{{username}}\"\n  },\n  \"passCode\": \"5275875498\"\n}"
-		},
-		{
-			"id": "a17077c9-4f2c-5512-4fe5-e07dd0a3815a",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/factors/{{factorId}}/lifecycle/activate",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447054049336,
-			"name": "Activate TOTP Factor",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"passCode\": \"679682\"\n}"
-		},
-		{
-			"id": "a614f393-08da-acaf-0fa1-ecb0d7ec9085",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/recovery/factors/sms/verify",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447187336416,
-			"name": "Verify SMS Recovery Factor",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"passCode\": \"123456\"\n}"
-		},
-		{
-			"id": "ae7228c6-d912-3cf3-de22-cf60985cd895",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/recovery/password",
-			"pathVariables": {},
-			"preRequestScript": "",
-			"method": "POST",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"data": [],
-			"dataMode": "raw",
-			"name": "Forgot Password with Email Factor",
-			"description": "",
-			"descriptionFormat": "html",
-			"time": 1440760288498,
-			"version": 2,
-			"responses": [],
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"folder": "299e9d58-11f2-1691-c8f2-47fc6283bcb5",
-			"isFromCollection": true,
-			"collectionRequestId": "ae7228c6-d912-3cf3-de22-cf60985cd895",
-			"rawModeData": "{\n  \"username\": \"{{username}}\",\n  \"factorType\": \"EMAIL\",\n  \"relayState\": \"/myapp/some/deep/link/i/want/to/return/to\"\n}"
-		},
-		{
-			"id": "b61d428a-8566-4822-6f4f-81ca1f6be5af",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/factors",
-			"pathVariables": {},
-			"preRequestScript": "",
-			"method": "POST",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"data": [],
-			"dataMode": "raw",
-			"name": "Enroll Google Authenticator Factor",
-			"description": "",
-			"descriptionFormat": "html",
-			"time": 1447637365615,
-			"version": 2,
-			"responses": [],
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"folder": "cf0cfc29-2443-98b2-438e-2561239767a3",
-			"rawModeData": "{\n  \"stateToken\" : \"{{stateToken}}\",\n  \"factorType\": \"token:software:totp\",\n  \"provider\": \"GOOGLE\"\n}"
-		},
-		{
-			"id": "b8a621b9-4995-3ddc-88e0-0e1f18e91339",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/recovery/token",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447053976166,
-			"name": "Verify Recovery Token",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"recoveryToken\": \"{{recoveryToken}}\"\n}"
-		},
-		{
-			"id": "bad6507a-8852-7b82-0044-183497c7ba26",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/factors?updatePhone=true",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447054035208,
-			"name": "Enroll SMS Factor with New Number",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"factorType\": \"sms\",\n  \"provider\": \"OKTA\",\n  \"profile\": {\n    \"phoneNumber\":  \"+1 415 555 5555\"\n  }\n}"
-		},
-		{
-			"id": "bd7abefe-0512-1f13-0c9d-5b275e4ba0d5",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/recovery/answer",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447053982726,
-			"name": "Answer Recovery Question",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"answer\": \"Annie Oakley\"\n}"
-		},
-		{
-			"id": "bda8b464-0f25-d187-f62c-088c37e2d176",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/skip",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447639393282,
-			"name": "Skip Transaction State",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"responses": [],
-			"folder": "00cec151-3706-7dc3-6aed-e26fc31cbc53",
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\"\n}"
-		},
-		{
-			"id": "c779e2a8-8b10-5f3b-339c-ef3bfb8c9ff8",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/recovery/unlock",
-			"pathVariables": {},
-			"preRequestScript": "",
-			"method": "POST",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"data": [],
-			"dataMode": "raw",
-			"name": "Unlock Account with Email Factor",
-			"description": "",
-			"descriptionFormat": "html",
-			"time": 1440762848489,
-			"version": 2,
-			"responses": [],
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"folder": "9304d459-4db6-272b-d9f6-db216b464c9f",
-			"isFromCollection": true,
-			"collectionRequestId": "c779e2a8-8b10-5f3b-339c-ef3bfb8c9ff8",
-			"rawModeData": "{\n  \"username\": \"{{username}}\",\n  \"factorType\": \"EMAIL\",\n  \"relayState\": \"/myapp/some/deep/link/i/want/to/return/to\"\n}"
-		},
-		{
-			"folder": "00cec151-3706-7dc3-6aed-e26fc31cbc53",
-			"id": "d0c213ca-bfbf-a5e3-0579-d01a11606f66",
-			"name": "Cancel Transaction",
-			"dataMode": "raw",
-			"data": [],
-			"descriptionFormat": null,
-			"description": "",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"method": "POST",
-			"pathVariables": {},
-			"url": "{{url}}/api/v1/authn/cancel",
-			"preRequestScript": "",
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\"\n}"
-		},
-		{
-			"folder": "00cec151-3706-7dc3-6aed-e26fc31cbc53",
-			"id": "dca594c7-cdec-a3e7-64f1-4404fda90eff",
-			"name": "Previous Transaction State",
-			"dataMode": "raw",
-			"data": [],
-			"descriptionFormat": null,
-			"description": "",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"method": "POST",
-			"pathVariables": {},
-			"url": "{{url}}/api/v1/authn/previous",
-			"preRequestScript": "",
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\"\n}"
-		},
-		{
-			"id": "df105fd2-d59a-fe88-c933-abf0b87acfb9",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/factors",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447637287315,
-			"name": "Enroll Symantec VIP Factor",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"responses": [],
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"factorType\": \"token\",\n  \"provider\": \"SYMANTEC\",\n  \"profile\": {\n    \"credentialId\": \"VSMT14393584\"\n  },\n  \"passCode\": \"875498\",\n  \"nextPassCode\": \"678195\"\n}"
-		},
-		{
-			"id": "e03b987e-f843-d0e7-7dbf-d89e08ed5933",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/factors/{{factorId}}/verify",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447053942401,
-			"name": "Verify Question Factor",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"stateToken\": \"{{stateToken}}\",\n  \"answer\": \"Annie Oakley\"\n}"
-		},
-		{
-			"id": "fb111bae-04ef-2f47-9c47-f515db87e37c",
-			"headers": "Accept: application/json\nContent-Type: application/json\n",
-			"url": "{{url}}/api/v1/authn/factors",
-			"preRequestScript": "",
-			"pathVariables": {},
-			"method": "POST",
-			"data": [],
-			"dataMode": "raw",
-			"version": 2,
-			"tests": "",
-			"currentHelper": "normal",
-			"helperAttributes": {},
-			"time": 1447054024781,
-			"name": "Enroll Okta TOTP Factor",
-			"description": "",
-			"collectionId": "2100a81e-0e91-ead1-f440-8db8fed2f315",
-			"rawModeData": "{\n  \"stateToken\" : \"{{stateToken}}\",\n  \"factorType\": \"token:software:totp\",\n  \"provider\": \"OKTA\"\n}"
-		}
-	]
+	"protocolProfileBehavior": {}
 }

--- a/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
@@ -37,7 +37,7 @@ Trusted applications are backend applications that act as authentication broker 
 2. For more advanced use cases, learn [the Okta API basics](/code/rest/).
 3. Explore the Authentication API:
 
-    [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/f9684487e584101f25a3)
+    [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/6f4f9ca4145db4d80270)
 
 ## Authentication operations
 

--- a/packages/@okta/vuepress-site/docs/reference/postman-collections/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/postman-collections/index.md
@@ -14,7 +14,7 @@ Import any Okta API collection for Postman from the following list:
 | Administrator Roles                 | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/04f5ec85685ac6f2827e)                   |
 | API Access Management (OAuth 2.0)   | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/52edf1dcddc70269b77d)                   |
 | Apps                                | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/18dd817ee8abace68dd8)                   |
-| Authentication                      | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/f9684487e584101f25a3)                   |
+| Authentication                      | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/6f4f9ca4145db4d80270)                   |
 | Authorization Server                | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/145f5d5fb42a04e22c3e)                   |
 | Client Registration                 | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/291ba43cde74844dd4a7)                   |
 | Custom SMS Templates                | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/d71f7946d8d56ccdaa06)                   |


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->


## Description:
- **What's changed?**
  - Add Email factor in /authn API -- enroll, activate, send verification challenge (OTP), verify
  - Enrollment / activation is new in the 2020.03.0 release.  (Verification was supported in the Early Access release but not previously included in this collection)

- **Is this PR related to a Monolith release?**
  - 2020.03.0

### Resolves:

* [OKTA-272973](https://oktainc.atlassian.net/browse/OKTA-272973)
