### PR TITLE
OKTA-286819: Add Sessions API scopes to implement oauth for okta guide

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta/scopes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta/scopes/index.md
@@ -30,6 +30,8 @@ The following table shows the scopes that are currently available as a part of E
 | `okta.logs.read`         | Allows the app to read information about System Log entries in your Okta organization| [System Log API](/docs/reference/api/system-log/)|
 | `okta.schemas.manage`    | Allows the app to create and manage Schemas in your Okta organization   | [Schemas API](/docs/reference/api/schemas/#getting-started)|
 | `okta.schemas.read`      | Allows the app to read information about Schemas in your Okta organization| [Schemas API](/docs/reference/api/schemas/#getting-started)|
+| `okta.sessions.manage`      | Allows the app to manage all sessions in your Okta organization | [Sessions API](/docs/reference/api/sessions/#session-operations) |
+| `okta.sessions.read`        | Allows the app to read all sessions in your Okta organization | [Sessions API](/docs/reference/api/sessions/#session-operations) |
 | `okta.users.manage`      | Allows the app to create and manage users and read all profile and credential information for users| [Users API](/docs/reference/api/users/#user-operations), [User Lifecycle Operations](/docs/reference/api/users/#lifecycle-operations), [User Consent Grant Operations](/docs/reference/api/users/#user-consent-grant-operations) |
 | `okta.users.read`        | Allows the app to read any user's profile and credential information      | [Users API](/docs/reference/api/users/#user-operations), [User Lifecycle Operations](/docs/reference/api/users/#lifecycle-operations), [User Consent Grant Operations](/docs/reference/api/users/#user-consent-grant-operations) |
 | `okta.users.manage.self` | Allows the app to manage the currently signed-in user's profile. Currently only supports user profile attribute updates. |   |


### PR DESCRIPTION
Updated scopes section of the Implement OAuth for Okta giude

## Description:
- Add okta.sessions.manage
- Add okta.sessions.read

- **Is this PR related to a Monolith release?** 2020.05.0

### Resolves:

* [OKTA-286819](https://oktainc.atlassian.net/browse/OKTA-286819)
