### PR TITLE
OKTA-290657: OAuth for Okta for Custom Templates & Trusted Origins

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta/scopes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta/scopes/index.md
@@ -30,6 +30,10 @@ The following table shows the scopes that are currently available:
 | `okta.logs.read`         | Allows the app to read information about System Log entries in your Okta organization| [System Log API](/docs/reference/api/system-log/)|
 | `okta.schemas.manage`    | Allows the app to create and manage Schemas in your Okta organization   | [Schemas API](/docs/reference/api/schemas/#getting-started)|
 | `okta.schemas.read`      | Allows the app to read information about Schemas in your Okta organization| [Schemas API](/docs/reference/api/schemas/#getting-started)|
+| `okta.templates.manage` | Allows the app to manage all custom templates in your Okta organization | [Custom Templates API](/docs/reference/api/templates/#template-operations) |
+| `okta.templates.read` | Allows the app to read all custom templates in your Okta organization | [Custom Templates API](/docs/reference/api/templates/#template-operations) |
+| `okta.trustedOrigins.manage` | Allows the app to manage all Trusted Origins in your Okta organization | [Trusted Origins API](/docs/reference/api/trusted-origins/#trusted-origins-api-operations) |
+| `okta.trustedOrigins.read` | Allows the app to read all Trusted Origins in your Okta organization | [Trusted Origins API](/docs/reference/api/trusted-origins/#trusted-origins-api-operations) |
 | `okta.users.manage`      | Allows the app to create and manage users and read all profile and credential information for users| [Users API](/docs/reference/api/users/#user-operations), [User Lifecycle Operations](/docs/reference/api/users/#lifecycle-operations), [User Consent Grant Operations](/docs/reference/api/users/#user-consent-grant-operations) |
 | `okta.users.read`        | Allows the app to read any user's profile and credential information      | [Users API](/docs/reference/api/users/#user-operations), [User Lifecycle Operations](/docs/reference/api/users/#lifecycle-operations), [User Consent Grant Operations](/docs/reference/api/users/#user-consent-grant-operations) |
 | `okta.users.manage.self` | Allows the app to manage the currently signed-in user's profile. Currently only supports user profile attribute updates. |   |


### PR DESCRIPTION
Add scopes for Custom Templates and Trusted Origins APIs to implement oauth for okta guide

## Description:

- Add 4 new scopes 
  - okta.trustedOrigins.manage
  - Add okta.trustedOrigins.read
  - Add okta.templates.manage
  - Add okta.templates.read
- **Is this PR related to a Monolith release?** Yes, 2020.05.0

### Resolves:

* [OKTA-290657](https://oktainc.atlassian.net/browse/OKTA-290657)
