### PR TITLE
OKTA-291221: v1 event types no longer tracking v2 event types update

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/event-types/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/event-types/index.md
@@ -16,7 +16,7 @@ Event types are the primary method of categorization within the Okta eventing pl
 The following is a full listing of event types used in the [System Log API](/docs/reference/api/system-log/) with associated description and related metadata. For migration purposes it also includes a mapping to the equivalent event type in the legacy [Events API](/docs/reference/api/events/).
 The relationship between System Log API and Events API event types is generally one-to-many. Note that there are currently some System Log API event types which do not have an Events API equivalent.
 
-> **Important:** In the future the Events API will not be tracking new event types added to the System Log API. For this reason we highly recommend migrating to the System Log API.
+> **Important:** As of April 20th, 2020, the Events API does not track new event types added to the System Log API. For this reason we highly recommend migrating to the System Log API.
 <br>
 
 <EventTypes />

--- a/packages/@okta/vuepress-site/docs/reference/api/event-types/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/event-types/index.md
@@ -16,7 +16,7 @@ Event types are the primary method of categorization within the Okta eventing pl
 The following is a full listing of event types used in the [System Log API](/docs/reference/api/system-log/) with associated description and related metadata. For migration purposes it also includes a mapping to the equivalent event type in the legacy [Events API](/docs/reference/api/events/).
 The relationship between System Log API and Events API event types is generally one-to-many. Note that there are currently some System Log API event types which do not have an Events API equivalent.
 
-> **Important:** As of April 20th, 2020, the Events API does not track new event types added to the System Log API. For this reason we highly recommend migrating to the System Log API.
+> **Important:** As of April 20th, 2020, the Events API does not track new event types added to the System Log API. For this reason we highly recommend migrating to the System Log API. For more information, see our [Events API End of Life FAQ](https://support.okta.com/help/s/article/FAQ-Events-API-End-of-Life).
 <br>
 
 <EventTypes />

--- a/packages/@okta/vuepress-site/docs/reference/api/events/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/events/index.md
@@ -8,7 +8,7 @@ deprecated: true
 
 The Okta Events API provides read access to your organization's system log. [Export event data](https://support.okta.com/help/Documentation/Knowledge_Article/Exporting-Okta-Log-Data) as a batch job from your organization to another system for reporting or analysis.
 
-> **Important:** The [System Log API](/docs/reference/api/system-log/) will eventually replace the Events API and contains much more [structured data](/docs/reference/api/system-log/#logevent-object). As of Jan 7, 2019 developers of new projects are unable to access the Events API and should use the System Log API. As of April 20, 2020, no new event types will be added for the Events API. For information on migrating from the Events API to the System Log API please see [Events API Migration](/docs/concepts/events-api-migration/).
+> **Important:** The [System Log API](/docs/reference/api/system-log/) will eventually replace the Events API and contains much more [structured data](/docs/reference/api/system-log/#logevent-object). As of Jan 7, 2019 developers of new projects are unable to access the Events API and should use the System Log API. As of April 20, 2020, no new event types will be added for the Events API. Information about migrating from the Events API to the System Log API can be found on the [Events API Migration page](/docs/concepts/events-api-migration/). Other information can be found in the [Events API End of Life FAQ](https://support.okta.com/help/s/article/FAQ-Events-API-End-of-Life)
 
 ## Getting Started
 

--- a/packages/@okta/vuepress-site/docs/reference/api/events/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/events/index.md
@@ -8,7 +8,7 @@ deprecated: true
 
 The Okta Events API provides read access to your organization's system log. [Export event data](https://support.okta.com/help/Documentation/Knowledge_Article/Exporting-Okta-Log-Data) as a batch job from your organization to another system for reporting or analysis.
 
-> **Important:** the [System Log API](/docs/reference/api/system-log/) will eventually replace the Events API and contains much more [structured data](/docs/reference/api/system-log/#logevent-object). As of Jan 7, 2019 developers of new projects are unable to access the Events API and should use the System Log API. For information on migrating from the Events API to the System Log API please see [Events API Migration](/docs/concepts/events-api-migration/).
+> **Important:** the [System Log API](/docs/reference/api/system-log/) will eventually replace the Events API and contains much more [structured data](/docs/reference/api/system-log/#logevent-object). As of Jan 7, 2019 developers of new projects are unable to access the Events API and should use the System Log API. As of April 20, 2020, No new event types will be added for the Events API. For information on migrating from the Events API to the System Log API please see [Events API Migration](/docs/concepts/events-api-migration/).
 
 ## Getting Started
 

--- a/packages/@okta/vuepress-site/docs/reference/api/events/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/events/index.md
@@ -8,7 +8,7 @@ deprecated: true
 
 The Okta Events API provides read access to your organization's system log. [Export event data](https://support.okta.com/help/Documentation/Knowledge_Article/Exporting-Okta-Log-Data) as a batch job from your organization to another system for reporting or analysis.
 
-> **Important:** the [System Log API](/docs/reference/api/system-log/) will eventually replace the Events API and contains much more [structured data](/docs/reference/api/system-log/#logevent-object). As of Jan 7, 2019 developers of new projects are unable to access the Events API and should use the System Log API. As of April 20, 2020, No new event types will be added for the Events API. For information on migrating from the Events API to the System Log API please see [Events API Migration](/docs/concepts/events-api-migration/).
+> **Important:** The [System Log API](/docs/reference/api/system-log/) will eventually replace the Events API and contains much more [structured data](/docs/reference/api/system-log/#logevent-object). As of Jan 7, 2019 developers of new projects are unable to access the Events API and should use the System Log API. As of April 20, 2020, no new event types will be added for the Events API. For information on migrating from the Events API to the System Log API please see [Events API Migration](/docs/concepts/events-api-migration/).
 
 ## Getting Started
 


### PR DESCRIPTION
## Description:
- **What's changed?** As of the upcoming Monolith release, we will not be enforcing event type parity between the Events and Logs APIs. No new Events API event types will be added from here on out, while the Logs API will continue to add new event types.
- **Is this PR related to a Monolith release?** No.

### Resolves:

* [OKTA-291221](https://oktainc.atlassian.net/browse/OKTA-291221)

### Reviewers:
* @bobtiernay-okta 
* @okta/developerdocs 