### PR TITLE
doc: update react-native doc to only support version above 0.60 - OKTA-292803

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app/configure-packages/react-native/installsdk.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app/configure-packages/react-native/installsdk.md
@@ -2,52 +2,25 @@
 
 ```bash
 $ npm install @okta/okta-react-native --save
-$ react-native link @okta/okta-react-native
 ```
 
 ### Install iOS OIDC SDK
 
-1. [**CocoaPods**](https://guides.cocoapods.org/using/getting-started.html)
+[**CocoaPods**](https://guides.cocoapods.org/using/getting-started.html)
 
-***React Native >= 0.60***: With React Native 0.60 pods are added to podfile automatically. Run the `pod install` command to install dependencies:
+Run the `pod install` command to install dependencies:
 ```
 cd ios
 pod install
 ```
-***React Native < 0.60***: Make sure that your `Podfile` looks like this:
-```   
-platform :ios, '11.0'
-
-target '{YourTargetName}' do
-
-pod 'OktaOidc', '~> 3.0'
-
-end
-```
-Then run `pod install`.
-
-2. [**Carthage**](https://github.com/Carthage/Carthage)
-```
-github "okta/okta-oidc-ios" ~> 3.5.0
-```
-Then run `carthage update --platform iOS`.
-
-Open project settings and choose your application target. Then open `Build Phases` and add `OktaOidc.framework` from `ios/Carthage/Build/iOS` into the `Embed Frameworks` section.
 
 ### Install Android OIDC SDK
 
-1. Add this line to `android/build.gradle`, under `allprojects` -> `repositories`.
-```
-maven {
-url  "https://dl.bintray.com/okta/com.okta.android"
-}
-```
+1. Make sure that your `minSdkVersion` is `19` in `android/build.gradle`.
 
-2. Make sure that your `minSdkVersion` is `19` in `android/build.gradle`.
-
-3. Add the redirect scheme in `android/app/build.gradle`, under `android` -> `defaultConfig`:
+2. Add the redirect scheme in `android/app/build.gradle`, under `android` -> `defaultConfig`:
 ```
 manifestPlaceholders = [
-appAuthRedirectScheme: 'com.sampleapplication'
+appAuthRedirectScheme: "{com.sampleapplication}"
 ]
 ```


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
As the minimum `react-native` version supported in `okta-react-native` is v0.60, the configuration guide for `react-native` under v0.60 will not be needed anymore. 
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-292803](https://oktainc.atlassian.net/browse/OKTA-292803)
