### PR TITLE
Uppercase g where there shouldn't be

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
@@ -348,7 +348,7 @@ curl -v -X GET \
 -H "Accept: application/json" \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
-"https://${yourOktaDomain}/api/v1/Groups?q=West&limit=10"
+"https://${yourOktaDomain}/api/v1/groups?q=West&limit=10"
 ```
 
 ##### Response example


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** `/Groups` -> `/groups`
- **Is this PR related to a Monolith release?** No

### Resolves:

* Reader feedbacj
