### PR TITLE
OKTA-296678: Updates System Log API docs to include mention about time references

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
@@ -582,8 +582,8 @@ The table below summarizes the supported query parameters:
 
 | Parameter   | Description                                                                                                                             | Format                                                                                                                                                                                    | Default                 |
 | ----------- | -----------------------------------------------------------------------------------------------------                                   | --------------------------------------------------------                                                                                                                                  | ----------------------- |
-| `since`     | Filters the lower time bound of the log events `published` property                                                                     | The [Internet Date/Time Format profile of ISO 8601](https://tools.ietf.org/html/rfc3339#page-8). An example: `2017-05-03T16:22:18Z`                                                       | 7 days prior to `until` |
-| `until`     | Filters the upper time bound of the log events `published` property                                                                     | The [Internet Date/Time Format profile of ISO 8601](https://tools.ietf.org/html/rfc3339#page-8). An example: `2017-05-03T16:22:18Z`                                                       | Current time            |
+| `since`     | Filters the lower time bound of the log events `published` property for bounded queries or persistence time for polling queries                                                          | The [Internet Date/Time Format profile of ISO 8601](https://tools.ietf.org/html/rfc3339#page-8). An example: `2017-05-03T16:22:18Z`                                                       | 7 days prior to `until` |
+| `until`     | Filters the upper time bound of the log events `published` property for bounded queries or persistence time for polling queries                                                          | The [Internet Date/Time Format profile of ISO 8601](https://tools.ietf.org/html/rfc3339#page-8). An example: `2017-05-03T16:22:18Z`                                                       | Current time            |
 | `after`     | Used to retrieve the next page of results. Okta returns a link in the HTTP Header (`rel=next`) that includes the after query parameter. | Opaque token                                                                                                                                                                              |                         |
 | `filter`    | [Filter Expression](#expression-filter) that filters the results                                                                        | [SCIM Filter expression](/docs/reference/api-overview/#filtering). All [operators](https://tools.ietf.org/html/rfc7644#section-3.4.2.2) except `ew`, `ne`, `not`, and `[ ]`  are supported |                         |
 | `q`         | Filters the log events results by one or more exact [keywords](#keyword-filter)                                                         | URL encoded string. Max length is 40 characters per keyword, with a maximum of 10 keyword filters per query (before encoding)                                                             |                         |
@@ -609,6 +609,7 @@ For a request to be a _polling_ request it must meet the following request param
 
 Polling requests to the `/api/v1/logs` API have the following semantics:
   - They return every event that occurs in your organization.
+  - They are time-filtered by their internal "persistence time" to avoid skipping records due to system delays (unlike [Bounded Requests](#bounded-requests)).
   - They may return events out of order according to the `published` field.
   - They have an infinite number of pages. That is, a [`next` `Link` relation header](#next-link-response-header) is always present, even if there are no new events (the event list may be empty).
 
@@ -624,6 +625,7 @@ For a request to be a _bounded_ request it must meet the following request param
   - `until` must be specified.
 
 Bounded requests to the `/api/v1/logs` API have the following semantics:
+  - They are time-filtered by their `published` field (unlike [Polling Requests](#polling-requests)).
   - The returned events are guaranteed to be in order according to the `published` field.
   - They have a finite number of pages. That is, the last page does not contain a [`next` `Link` relation header](#next-link-response-header).
   - Not all events for the specified time range may be present— events may be delayed. Such delays are rare but possible.

--- a/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
@@ -609,7 +609,7 @@ For a request to be a _polling_ request it must meet the following request param
 
 Polling requests to the `/api/v1/logs` API have the following semantics:
   - They return every event that occurs in your organization.
-  - They are time-filtered by their internal "persistence time" to avoid skipping records due to system delays (unlike [Bounded Requests](#bounded-requests)).
+  - The returned events are time-filtered by their internal "persistence time" to avoid skipping records due to system delays (unlike [Bounded Requests](#bounded-requests)).
   - They may return events out of order according to the `published` field.
   - They have an infinite number of pages. That is, a [`next` `Link` relation header](#next-link-response-header) is always present, even if there are no new events (the event list may be empty).
 
@@ -625,7 +625,7 @@ For a request to be a _bounded_ request it must meet the following request param
   - `until` must be specified.
 
 Bounded requests to the `/api/v1/logs` API have the following semantics:
-  - They are time-filtered by their `published` field (unlike [Polling Requests](#polling-requests)).
+  - The returned events are time-filtered by their associated `published` field (unlike [Polling Requests](#polling-requests)).
   - The returned events are guaranteed to be in order according to the `published` field.
   - They have a finite number of pages. That is, the last page does not contain a [`next` `Link` relation header](#next-link-response-header).
   - Not all events for the specified time range may be present— events may be delayed. Such delays are rare but possible.

--- a/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
@@ -584,7 +584,7 @@ The table below summarizes the supported query parameters:
 | ----------- | -----------------------------------------------------------------------------------------------------                                   | --------------------------------------------------------                                                                                                                                  | ----------------------- |
 | `since`     | Filters the lower time bound of the log events `published` property for bounded queries or persistence time for polling queries                                                          | The [Internet Date/Time Format profile of ISO 8601](https://tools.ietf.org/html/rfc3339#page-8). An example: `2017-05-03T16:22:18Z`                                                       | 7 days prior to `until` |
 | `until`     | Filters the upper time bound of the log events `published` property for bounded queries or persistence time for polling queries                                                          | The [Internet Date/Time Format profile of ISO 8601](https://tools.ietf.org/html/rfc3339#page-8). An example: `2017-05-03T16:22:18Z`                                                       | Current time            |
-| `after`     | Used to retrieve the next page of results. Okta returns a link in the HTTP Header (`rel=next`) that includes the after query parameter. | Opaque token                                                                                                                                                                              |                         |
+| `after`     | Used to retrieve the next page of results. Okta returns a link in the HTTP Header (`rel=next`) that includes the after query parameter | Opaque token                                                                                                                                                                              |                         |
 | `filter`    | [Filter Expression](#expression-filter) that filters the results                                                                        | [SCIM Filter expression](/docs/reference/api-overview/#filtering). All [operators](https://tools.ietf.org/html/rfc7644#section-3.4.2.2) except `ew`, `ne`, `not`, and `[ ]`  are supported |                         |
 | `q`         | Filters the log events results by one or more exact [keywords](#keyword-filter)                                                         | URL encoded string. Max length is 40 characters per keyword, with a maximum of 10 keyword filters per query (before encoding)                                                             |                         |
 | `sortOrder` | The order of the returned events sorted by `published`                                                                                  | `ASCENDING` or `DESCENDING`                                                                                                                                                               | `ASCENDING`             |
@@ -609,7 +609,7 @@ For a request to be a _polling_ request it must meet the following request param
 
 Polling requests to the `/api/v1/logs` API have the following semantics:
   - They return every event that occurs in your organization.
-  - The returned events are time-filtered by their internal "persistence time" to avoid skipping records due to system delays (unlike [Bounded Requests](#bounded-requests)).
+  - The returned events are time filtered by their internal "persistence time" to avoid skipping records due to system delays (unlike [Bounded Requests](#bounded-requests)).
   - They may return events out of order according to the `published` field.
   - They have an infinite number of pages. That is, a [`next` `Link` relation header](#next-link-response-header) is always present, even if there are no new events (the event list may be empty).
 
@@ -625,7 +625,7 @@ For a request to be a _bounded_ request it must meet the following request param
   - `until` must be specified.
 
 Bounded requests to the `/api/v1/logs` API have the following semantics:
-  - The returned events are time-filtered by their associated `published` field (unlike [Polling Requests](#polling-requests)).
+  - The returned events are time filtered by their associated `published` field (unlike [Polling Requests](#polling-requests)).
   - The returned events are guaranteed to be in order according to the `published` field.
   - They have a finite number of pages. That is, the last page does not contain a [`next` `Link` relation header](#next-link-response-header).
   - Not all events for the specified time range may be present— events may be delayed. Such delays are rare but possible.


### PR DESCRIPTION
## Description:
- **What's changed?** Updates System Log API docs to include mention about time references
- **Is this PR related to a Monolith release?** No

![image](https://user-images.githubusercontent.com/25536705/81728064-d97af100-9457-11ea-9f56-4487a535be73.png)
![image](https://user-images.githubusercontent.com/25536705/81728179-0af3bc80-9458-11ea-8d51-09ad7471e608.png)
![image](https://user-images.githubusercontent.com/25536705/81728129-f9aab000-9457-11ea-9553-688bb0bd5267.png)

### Resolves:

* [OKTA-296678](https://oktainc.atlassian.net/browse/OKTA-296678)
