### PR TITLE
Updates to SCIM guide

### DIFF
--- a/packages/@okta/vuepress-site/docs/concepts/scim/faqs/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/scim/faqs/index.md
@@ -21,14 +21,14 @@ In addition to OAuth, Okta also supports connections with basic auth and header 
 
 Use the OAuth 2.0 Authorization Code grant flow, so that you know exactly which token the customer is using.
 
-Another option is when the customer configures your app in Okta, Okta can prompt them to add their unique subdomain for your app.
+Another option is when the customer configures your Okta integration, Okta can prompt them to add their unique subdomain for your cloud application.
 
 Okta can use part of this URL in the SCIM endpoint for that customer, for example:
 
 * `http://www.company.com/**tenantA**/scim`
 * `http://www.company.com/**tenantB**/scim`
 
-This subdomain field can be configured in consultation with Okta after you submit your app for Okta review.
+This subdomain field can be configured in consultation with Okta after you submit your integration for Okta review.
 
 **Q: I only have one email/phone number/address in my user profile. Do I need to use an array for it?**
 
@@ -50,42 +50,42 @@ If your integration doesn't need to distinguish between canonical entries, you c
 
 **Q: Why doesn't Okta support DELETE /Users?**
 
-Okta users aren't deleted for compliance and audit purposes; Okta user profiles are marked as "deactivated". Because of this, Okta never makes a DELETE request to a user resource on your SCIM API. Instead, Okta sends a request to set the `active` value to `false`. You'll need to support the concept of an "active" and "inactive" user within your app.
+In Okta, user profiles are marked as "deactivated". This fact means that Okta never makes a DELETE request against a user resource through your SCIM API. Instead, Okta sends a request to set the `active` value to `false`. You'll need to support the concept of an "active" and "inactive" user within your application.
 
-**Q: How does data validation work with SCIM provisioning? For example, if my app requires the phone number in a specific format, how do I ensure that Okta passes the attribute in that format? If a data validation error issue occurs, how does error reporting work?**
+**Q: How does data validation work with SCIM provisioning? For example, if my application requires the phone number in a specific format, how do I ensure that Okta passes the attribute in that format? If a data validation error issue occurs, how does error reporting work?**
 
-The SCIM spec specifies valid data formats for a given user profile attribute, however Okta doesn't rigorously validate that the customer has submitted values meeting those requirements to preserve flexibility.
+The SCIM specification identifies valid data formats for a given user profile attribute; however, to preserve flexibility, Okta doesn't rigorously validate that the customer has submitted values that meet those requirements.
 
-Therefore, data validation should be handled by your app's SCIM server. When Okta provisions a user profile to your server, your app should check that the data is valid according to any special requirements. Error messages sent in response from your app are surfaced to the Okta administrator through alerts and tasks in the Okta interface.
+Therefore, data validation should be handled by your application. When Okta provisions a user profile to your server, your application should check that the data is valid according to any special requirements. Error messages sent in response from your application are surfaced to the Okta administrator through alerts and tasks in the Okta interface.
 
-You should also specify your data requirements in the configuration document you provide for using your app.
+You should also specify your data requirements in the configuration document you provide for using your integration.
 
 **Q: How much support is required for filtering results?**
 
-The filtering capabilities in the SCIM protocol are pretty broad, but the common filtering use case with Okta is quite narrow. Okta determines if a newly created user already exists in your app based on a matching identifier. This means the `eq` (equals) operator is all you really need to support.
+The filtering capabilities in the SCIM protocol are pretty broad, but the common filtering use case with Okta is quite narrow. Okta determines if a newly created user already exists in your application based on a matching identifier. This means the `eq` (equals) operator is all you really need to support.
 
 **Q: How do I import users?**
 
 User import operations are initiated by Okta, either manually or on a schedule. To run an import for your SCIM users, go into the Okta Admin Console:
 
-1. Select your SCIM application from your list of applications.
+1. Select your SCIM integration from the list of integrations in your Okta org.
 1. Under the **Import** tab, click **To Okta** and **Import Now** to do a one-time import.
 1. Okta prompts you to review and confirm assignments for any users that aren't automatically matched to existing Okta users.
 
 To set up a regular schedule for importing users, go into the Okta Admin Console:
 
-1. Select your SCIM application from your list of applications.
+1. Select your SCIM integration from the list of integrations in your Okta org.
 1. Under the **Provisioning** tab, click **To Okta** and **Edit** in the General section.
 1. In the **Full Import Schedule** drop down, you can choose from hourly, daily, or weekly imports.
 
-For more details on the import functionality of Okta, see [Import users from an app](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Importing_People) in our Product Help documentation.
+For more details on the import functionality of Okta, see [Import users](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Importing_People) in our Product Help documentation.
 
-**Q: How do I get my SCIM app to use `PUT` requests instead of `PATCH` when updating users and groups?**
+**Q: How do I get my SCIM integration to use `PUT` requests instead of `PATCH` when updating users and groups?**
 
-SCIM integrations that are created using the template apps from the OIN catalog have `PATCH` enabled by default. However, if your SCIM server doesn't support `PATCH`, you can send an email to <developers@okta.com> and request to change your integration to use `PUT` for updates.
+SCIM integrations that are created using the templates from the OIN catalog have `PATCH` enabled by default. However, if your SCIM server doesn't support `PATCH`, you can send an email to <developers@okta.com> and request to change your integration to use `PUT` for updates.
 
 SCIM integrations that are created using the Application Integration Wizard use `PUT` by default. They can't be reconfigured to use `PATCH` for updates.
 
-**Q: How do I get a SCIM app to integrate with Okta from inside my corporate firewall?**
+**Q: How do I get a SCIM application that resides inside my corporate firewall to integrate with Okta?**
 
-The Okta [SCIM provisioning guide](/docs/guides/build-provisioning-integration/) instructions target cloud-based applications, but Okta does have a solution for on-premise applications. For more details  about the Okta agent-based provisioning solution, see [Configuring On Premises Provisioning](https://support.okta.com/help/s/article/29448976-Configuring-On-Premises-Provisioning).
+The [Build a SCIM provisioning integration](/docs/guides/build-provisioning-integration/) instructions target cloud-based applications, but Okta does have a solution for on-premise applications. For more details about the Okta agent-based provisioning solution, see [Configuring On Premises Provisioning](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_OPP_configure).

--- a/packages/@okta/vuepress-site/docs/concepts/scim/faqs/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/scim/faqs/index.md
@@ -52,6 +52,8 @@ If your integration doesn't need to distinguish between canonical entries, you c
 
 In Okta, user profiles are marked as "deactivated". This fact means that Okta never makes a DELETE request against a user resource through your SCIM API. Instead, Okta sends a request to set the `active` value to `false`. You'll need to support the concept of an "active" and "inactive" user within your application.
 
+For a detailed explanation on deleting user profiles, see [Delete (Deprovision)](/docs/concepts/scim/#delete-deprovision).
+
 **Q: How does data validation work with SCIM provisioning? For example, if my application requires the phone number in a specific format, how do I ensure that Okta passes the attribute in that format? If a data validation error issue occurs, how does error reporting work?**
 
 The SCIM specification identifies valid data formats for a given user profile attribute; however, to preserve flexibility, Okta doesn't rigorously validate that the customer has submitted values that meet those requirements.

--- a/packages/@okta/vuepress-site/docs/concepts/scim/faqs/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/scim/faqs/index.md
@@ -56,11 +56,11 @@ For a detailed explanation on deleting user profiles, see [Delete (Deprovision)]
 
 **Q: How does data validation work with SCIM provisioning? For example, if my application requires the phone number in a specific format, how do I ensure that Okta passes the attribute in that format? If a data validation error issue occurs, how does error reporting work?**
 
-The SCIM specification identifies valid data formats for a given user profile attribute; however, to preserve flexibility, Okta doesn't rigorously validate that the customer has submitted values that meet those requirements.
+The SCIM specification identifies valid data formats for a given user profile attribute. However, to preserve flexibility, Okta doesn't rigorously validate that the customer has submitted values that meet those requirements.
 
 Therefore, data validation should be handled by your application. When Okta provisions a user profile to your server, your application should check that the data is valid according to any special requirements. Error messages sent in response from your application are surfaced to the Okta administrator through alerts and tasks in the Okta interface.
 
-You should also specify your data requirements in the configuration document you provide for using your integration.
+You should also specify your data requirements in the configuration document that you provide for using your integration.
 
 **Q: How much support is required for filtering results?**
 
@@ -90,4 +90,4 @@ SCIM integrations that are created using the Application Integration Wizard use 
 
 **Q: How do I get a SCIM application that resides inside my corporate firewall to integrate with Okta?**
 
-The [Build a SCIM provisioning integration](/docs/guides/build-provisioning-integration/) instructions target cloud-based applications, but Okta does have a solution for on-premise applications. For more details about the Okta agent-based provisioning solution, see [Configuring On Premises Provisioning](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_OPP_configure).
+The [Build a SCIM provisioning integration](/docs/guides/build-provisioning-integration/) instructions target cloud-based applications, but Okta does have a solution for on-premises applications. For more details about the Okta agent-based provisioning solution, see the [On-Premises Provisioning](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_OPP_configure) configuration guide.

--- a/packages/@okta/vuepress-site/docs/concepts/scim/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/scim/index.md
@@ -9,7 +9,7 @@ meta:
 
 This topic covers the concepts and use cases for SCIM and Okta.
 
-If you are ready to start creating a SCIM integration, see our [Build a SCIM provisioning integration](/docs/guides/build-provisioning-integration/) guide, and our technical references on how the [SCIM protocol is implemented with Okta](/docs/reference/scim/).
+If you are ready to start creating a SCIM integration, see our [Build a SCIM provisioning integration](/docs/guides/build-provisioning-integration/) guide and our technical references on how the [SCIM protocol is implemented with Okta](/docs/reference/scim/).
 
 ## What is SCIM for?
 
@@ -17,7 +17,7 @@ SCIM, or the [System for Cross-domain Identity Management](http://www.simpleclou
 
 The goal of SCIM is to securely automate the exchange of user identity data between your company's cloud applications and any service providers, such as enterprise SaaS applications.
 
-Managing user lifecycles in your organization is a fundamental business problem. Hiring new employees is just the first step - you also need to provision the applications that they need for their job, enforce the corporate security policies, and update their user accounts as they advance through their time with your company. At the end of their employment period, you need to make sure that all access is quickly and thoroughly revoked across all applications. Handling all of this can be time consuming and error prone if done manually.
+Managing user lifecycles in your organization is a fundamental business problem. Hiring new employees is just the first step - you also need to provision the applications that they need for their job, enforce the corporate security policies, and update their user accounts as they advance through their time with your company. At the end of their employment period, you need to make sure that all access is quickly and thoroughly revoked across all applications. Handling all of this can be a time-consuming and error-prone process if done manually.
 
 ![SCIM Lifecycle](/img/oin/scim_lifecycle.png "User lifecycle diagram: 1 - new employee 2 - provision applications 3 - enforce security 4 - update user information 5 - offboard")
 
@@ -65,12 +65,12 @@ The deletion or deprovisioning of end-user profiles in SCIM operations depends o
 
 * If an admin deprovisions an end-user's profile inside Okta, the user resource inside your SCIM application is updated with `active=false`. If that user needs to be reprovisioned at a later date (for example, a return from parental leave or if a contractor is rehired), then the `active` attribute can be switched back to `true`.
 
-   Deactivated end-user accounts lose access to their provisioned Okta integrations. Your application can run different actions to after deprovisioning a user, such as changing user access permissions, removing a license, or completely disabling the user account.
-* If an admin deletes a deactivated end-user profile inside Okta, the user resource inside your SCIM application is not changed. The initial deactivation step already set `active=false`. Okta does not send a request to delete the user resource inside the customer's SCIM application.
+   Deactivated end-user accounts lose access to their provisioned Okta integrations. Your application can run different actions after deprovisioning a user, such as changing user access permissions, removing a license, or completely disabling the user account.
+* If an admin deletes a deactivated end-user profile inside Okta, the user resource inside your SCIM application isn't changed. The initial deactivation step already set `active=false`. Okta doesn't send a request to delete the user resource inside the customer's SCIM application.
 * Conversely, if an end-user profile is marked with `active=false` inside your SCIM application, and the Okta integration is mastered by that SCIM application, then when an import from your SCIM application is run, the user's profile is marked as deactivated inside Okta.
 * Similarly, if an end-user profile is deleted from inside your SCIM application, and the end user is mastered by that SCIM application, then when an import from your SCIM application is run, the user's profile is deleted inside Okta.
 
-### Syncing Passwords
+### Sync passwords
 
 Outside of the base CRUD operations, Okta supports additional provisioning features like syncing passwords.
 
@@ -78,7 +78,7 @@ Password synchronization helps you coordinate Okta-mastered users to ensure that
 
 This option sets the user's password for your integration to match the Okta password or to be assigned a randomly generated password. For more information about this functionality and how to configure it in the Okta product, see [Synchronize passwords from Okta to Active Directory](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Security_Using_Sync_Password).
 
-### Profile Attribute Mappings
+### Map profile attributes
 
 Another provisioning feature supported by Okta is the mapping of user profile attributes.
 
@@ -86,7 +86,7 @@ After provisioning is enabled, you can set an application to be the "source" fro
 
 Okta uses a Profile Editor to map specific user attributes from the source application to the Okta user profile.
 
-## Lifecycle Management Using Profile Mastering
+## Lifecycle management using profile mastering
 
 Profile mastering defines the flow and maintenance of user attributes. When a profile is mastered using a source outside of Okta (for example, an HR application, Active Directory, or LDAP), then the Okta user's attributes and lifecycle state are derived exclusively from that resource. The SCIM protocol is used to handle the secure exchange of user identity data between the profile master and Okta. In this scenario, the profile isn't editable in Okta by the user or an Okta admin.
 
@@ -97,7 +97,7 @@ For more information about profile mastering and how to configure it in the Okta
 * [Profile mastering](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Directory_Profile_Masters)
 * [Provisioning and Deprovisioning](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Provisioning_Deprovisioning_Overview)
 
-## Provisioning Use Cases
+## Provisioning use cases
 
 Provisioning actions can be combined to solve for end-to-end use cases. Okta supports these common Provisioning use cases:
 
@@ -106,7 +106,7 @@ Provisioning actions can be combined to solve for end-to-end use cases. Okta sup
 * Remove an employee's access to downstream applications automatically on termination or leave.
 * Link existing downstream application users with Okta users using a one-time import.
 
-## Publishing SCIM-based Provisioning Integrations
+## Publish SCIM-based provisioning integrations
 
 For your customers to use your SCIM provisioning integration with Okta, you need to publish it through the [Okta Integration Network](https://www.okta.com/integrations/).
 

--- a/packages/@okta/vuepress-site/docs/concepts/scim/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/scim/index.md
@@ -61,9 +61,14 @@ User attributes can be mapped from your source into Okta and conversely, an attr
 
 ### Delete (Deprovision)
 
-For audit purposes, Okta users are never deleted. Instead, they are deprovisioned by setting an `active` attribute to "false". Then, if an existing user needs to be re-provisioned at a later date (for example, returning from parental leave or if a contractor is re-hired), then the attribute can be switched back to "true".
+The deletion or deprovisioning of end-user profiles in SCIM operations depends on whether Okta or your SCIM application functions as the source of truth for user profile information.
 
-Deprovisioning a user removes their access to the downstream application. Your application can specify different results for deprovisioning a user, such as changing user access permissions, removing a user license, or completely disabling the user account.
+* If an admin deprovisions an end-user's profile inside Okta, the user resource inside your SCIM application is updated with `active=false`. If that user needs to be reprovisioned at a later date (for example, a return from parental leave or if a contractor is rehired), then the `active` attribute can be switched back to `true`.
+
+   Deactivated end-user accounts lose access to their provisioned Okta integrations. Your application can run different actions to after deprovisioning a user, such as changing user access permissions, removing a license, or completely disabling the user account.
+* If an admin deletes a deactivated end-user profile inside Okta, the user resource inside your SCIM application is not changed. The initial deactivation step already set `active=false`. Okta does not send a request to delete the user resource inside the customer's SCIM application.
+* Conversely, if an end-user profile is marked with `active=false` inside your SCIM application, and the Okta integration is mastered by that SCIM application, then when an import from your SCIM application is run, the user's profile is marked as deactivated inside Okta.
+* Similarly, if an end-user profile is deleted from inside your SCIM application, and the end user is mastered by that SCIM application, then when an import from your SCIM application is run, the user's profile is deleted inside Okta.
 
 ### Syncing Passwords
 
@@ -77,9 +82,9 @@ This option sets the user's password for your integration to match the Okta pass
 
 Another provisioning feature supported by Okta is the mapping of user profile attributes.
 
-After provisioning is enabled, you can set a profile master to be the "source" application from which users are imported or the target application to which attributes are sent.
+After provisioning is enabled, you can set an application to be the "source" from which users profiles are imported or the "target" to which attributes are sent.
 
-Okta uses a Profile Editor to map user attributes from the source of truth to the Okta user profile.
+Okta uses a Profile Editor to map specific user attributes from the source application to the Okta user profile.
 
 ## Lifecycle Management Using Profile Mastering
 

--- a/packages/@okta/vuepress-site/docs/concepts/scim/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/scim/index.md
@@ -9,7 +9,7 @@ meta:
 
 This topic covers the concepts and use cases for SCIM and Okta.
 
-If you are ready to start creating a SCIM app, see our [Guide to Build a SCIM provisioning integration](/docs/guides/build-provisioning-integration/), and our technical references on how the [SCIM protocol is implemented with Okta](https://developer.okta.com/docs/reference/scim/).
+If you are ready to start creating a SCIM integration, see our [Build a SCIM provisioning integration](/docs/guides/build-provisioning-integration/) guide, and our technical references on how the [SCIM protocol is implemented with Okta](/docs/reference/scim/).
 
 ## What is SCIM for?
 
@@ -17,31 +17,31 @@ SCIM, or the [System for Cross-domain Identity Management](http://www.simpleclou
 
 The goal of SCIM is to securely automate the exchange of user identity data between your company's cloud applications and any service providers, such as enterprise SaaS applications.
 
-Managing user lifecycles in your organization is a fundamental business problem. Hiring new employees is just the first step - you also need to provision the apps that they need for their job, enforce the corporate security policies, and update their user accounts as they advance through their time with your company. At the end of their employment period, you need to make sure that all access is quickly and thoroughly revoked across all applications. Handling all of this can be time consuming and error prone if done manually.
+Managing user lifecycles in your organization is a fundamental business problem. Hiring new employees is just the first step - you also need to provision the applications that they need for their job, enforce the corporate security policies, and update their user accounts as they advance through their time with your company. At the end of their employment period, you need to make sure that all access is quickly and thoroughly revoked across all applications. Handling all of this can be time consuming and error prone if done manually.
 
-![SCIM Lifecycle](/img/oin/scim_lifecycle.png "User lifecycle diagram: 1 - new employee 2 - provision apps 3 - enforce security 4 - update user information 5 - offboard")
+![SCIM Lifecycle](/img/oin/scim_lifecycle.png "User lifecycle diagram: 1 - new employee 2 - provision applications 3 - enforce security 4 - update user information 5 - offboard")
 
 As your company grows, the number of user accounts and provisioned software applications increases exponentially. Requests to add and remove users, reset passwords, change permissions, and add new types of accounts all take up valuable IT department time.
 
-With the SCIM protocol, user data is stored in a consistent way and can be shared with different apps. Since data is transferred automatically, complex exchanges are simplified and the risk of error is reduced.
+With the SCIM protocol, user data is stored in a consistent way and can be shared with different applications. Since data is transferred automatically, complex exchanges are simplified and the risk of error is reduced.
 
-Adopting SCIM for domain management improves overall security for your company. Employees no longer need to sign in to each of their accounts. As teams develop new workflows and adopt new apps, your company can ensure security policy compliance across all accounts.
+Adopting SCIM for domain management improves overall security for your company. Employees no longer need to sign in to each of their accounts. As teams develop new workflows and adopt new applications, your company can ensure security policy compliance across all accounts.
 
 ## How does Okta help?
 
 [Okta Lifecycle Management](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_prov_con_okta_prov) is a platform solution to provision and manage user accounts in cloud-based applications. Okta serves as a universal directory for identity-related information, giving the following benefits:
 
 * IT departments can manage the user provisioning lifecycle through a single system.
-* New employees are automatically provisioned with a user account for their apps.
+* New employees are automatically provisioned with a user account for their applications.
 * Employee accounts can be created either directly from Okta accounts, or shared from external systems like HR applications or Active Directory.
 * Any profile updates - like department changes - populate automatically.
-* Inactive employees are automatically deactivated from their apps.
+* Inactive employees are automatically deactivated from their applications.
 
 ## How does SCIM work?
 
-Provisioning consists of a set of actions between a service provider - like Okta - and the cloud-based integration (the SCIM client). Using REST style architecture and JSON objects, the SCIM protocol communicates data about users or groups.  As an app developer, you define the use cases needed and then build the corresponding SCIM actions into your integration.
+Provisioning consists of a set of actions between a service provider - like Okta - and the cloud-based integration (the SCIM client). Using REST style architecture and JSON objects, the SCIM protocol communicates data about users or groups.  As an application developer, you define the use cases needed and then build the corresponding SCIM actions into your integration.
 
-By implementing support for the SCIM standard, an application in the Okta Integration Network can be notified when a user is created, updated, or removed from their application in Okta.
+By implementing support for the SCIM standard, an integration in the Okta Integration Network can be notified when a user is created, updated, or removed from their application in Okta.
 
 The provisioning actions performed by an integration are described using the database operation acronym "CRUD": Create, Read, Update, and Delete. The four CRUD operations are the building blocks that combine to solve your end-to-end use cases:
 
@@ -57,7 +57,7 @@ Information about user and group resources can be queried from your application 
 
 If a resource in your application needs to be updated based on data changed in Okta, this operation updates existing user or group attributes. Alternatively, if your application functions as the source of truth for specific attributes of a user identity, this action updates the Okta user profile.
 
-User attributes can be mapped from your source into Okta and conversely, an attribute can be mapped from Okta to a target attribute in your app.
+User attributes can be mapped from your source into Okta and conversely, an attribute can be mapped from Okta to a target attribute in your application.
 
 ### Delete (Deprovision)
 
@@ -77,7 +77,7 @@ This option sets the user's password for your integration to match the Okta pass
 
 Another provisioning feature supported by Okta is the mapping of user profile attributes.
 
-After provisioning is enabled, you can set a profile master to be the "source" app from which users are imported or the target app to which attributes are sent.
+After provisioning is enabled, you can set a profile master to be the "source" application from which users are imported or the target application to which attributes are sent.
 
 Okta uses a Profile Editor to map user attributes from the source of truth to the Okta user profile.
 
@@ -96,25 +96,25 @@ For more information about profile mastering and how to configure it in the Okta
 
 Provisioning actions can be combined to solve for end-to-end use cases. Okta supports these common Provisioning use cases:
 
-* Provision downstream apps automatically when a new employee joins the company.
-* Update your downstream app automatically when employee profile attributes change.
-* Remove an employee's access to downstream apps automatically on termination or leave.
-* Link existing downstream app users with Okta users using a one-time import.
+* Provision downstream applications automatically when a new employee joins the company.
+* Update your downstream applications automatically when employee profile attributes change.
+* Remove an employee's access to downstream applications automatically on termination or leave.
+* Link existing downstream application users with Okta users using a one-time import.
 
 ## Publishing SCIM-based Provisioning Integrations
 
 For your customers to use your SCIM provisioning integration with Okta, you need to publish it through the [Okta Integration Network](https://www.okta.com/integrations/).
 
-After you have built and tested your SCIM application, read through our guide on [Publishing an app integration with the OIN](/docs/guides/submit-app/overview/).
+After you have built and tested your SCIM application, read through our [Submit an app integration](/docs/guides/submit-app/overview/) guide.
 
 ## Additional background
 
-If you want to read more about how to use the Okta Admin Console for provisioning in your app integration or have additional questions about SCIM, visit the following links:
+If you want to read more about how to use the Okta Admin Console to set up provisioning in your integration or have additional questions about SCIM, visit the following links:
 
 * [Okta Lifecycle Management User Provisioning](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_prov_okta_lcm_user_provision)
 * [SCIM Technical FAQs](/docs/concepts/scim/faqs/)
 * [Build a SCIM provisioning integration](/docs/guides/build-provisioning-integration/overview/)
-* The "SCIM Applications" section of [Using the App Integration Wizard](https://help.okta.com/en/prod/Content/Topics/Apps/Apps_App_Integration_Wizard.htm)
+* [Create a SCIM integration using AIW](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Apps_App_Integration_Wizard-scim)
 * [Provisioning Concepts](https://support.okta.com/help/s/article/Provisioning-Concepts-and-Methods)
 * [Configuring On-Premises Provisioning](https://support.okta.com/help/s/article/29448976-Configuring-On-Premises-Provisioning)
 * IETF [Overview and Specification of the SCIM Protocol](http://www.simplecloud.info/)

--- a/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/attribute-mapping/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/attribute-mapping/index.md
@@ -4,9 +4,9 @@ title: Check the attributes and corresponding mappings
 
 When you add a SCIM template integration to your development org, it comes with base attributes set by default. The user schema in your SCIM application might not support all of these attributes. It is important that you go through the steps below to ensure that the integration you're submitting to Okta for review reflects the attributes supported by your application.
 
->**Note:** If you don't confirm your attributes and mappings before you submit your integration for review, the Okta App Analyst will return your submission with a request to update your attributes.
+>**Note:** Confirm your attributes and mappings before you submit your integration for review, or your submission will be returned by the Okta App Analyst with a request to update your attributes.
 
-## Delete Attributes
+## Delete attributes
 
 Before you can delete an attribute, you first need to remove the mapping for that attribute.
 
@@ -44,7 +44,7 @@ B. Delete attributes from your attribute list
   1. Click **Delete Attribute** to confirm that you want to remove the attribute.
     ![Profile Editor - Delete Attribute](/img/oin/scim_check-attributes-8.png "Profile Editor - Delete Attribute")
 
-## Add Attributes
+## Add attributes
 
 1. From the Admin Console, open your SCIM integration.
 
@@ -63,7 +63,7 @@ B. Delete attributes from your attribute list
 
 1. After adding an attribute, you can add a mapping for that new attribute.
 
-## Map Attributes
+## Map attributes
 
 1. From the Admin Console, open your SCIM integration.
 
@@ -93,7 +93,7 @@ B. Delete attributes from your attribute list
 
 You only want to include the attributes that you support in your current user schema. To ensure that the attributes are being sent properly to and from Okta:
 
-1. When assigning a user to the SCIM integration you added in your dev org, ensure that all expected attributes are populated for that user.
+1. When assigning a user to the SCIM integration that you added in your dev org, ensure that all expected attributes are populated for that user.
 
 1. After the user is pushed to your SCIM application, check that all attributes are populated in your SCIM repository.
 

--- a/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/attribute-mapping/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/attribute-mapping/index.md
@@ -2,9 +2,9 @@
 title: Check the attributes and corresponding mappings
 ---
 
-When you add a SCIM template app to your development org, it comes with base attributes set by default. Your SCIM implementation's user schema might not support all of these attributes. It is important that you go through the steps below to ensure that the app you're submitting to Okta for review reflects the attributes you support.
+When you add a SCIM template integration to your development org, it comes with base attributes set by default. The user schema in your SCIM application might not support all of these attributes. It is important that you go through the steps below to ensure that the integration you're submitting to Okta for review reflects the attributes supported by your application.
 
->**Note:** The Okta App Analyst team will reject your app submission with a request to update your attributes if you don't confirm these attributes and mappings before you submit your app for review.
+>**Note:** If you don't confirm your attributes and mappings before you submit your integration for review, the Okta App Analyst will return your submission with a request to update your attributes.
 
 ## Delete Attributes
 
@@ -12,7 +12,7 @@ Before you can delete an attribute, you first need to remove the mapping for tha
 
 A. Remove the mapping
 
-  1. From the Admin Console, open your SCIM app.
+  1. From the Admin Console, open your SCIM integration.
 
   1. Go to the **Provisioning** tab. Under the **SETTINGS** section, click **To App**.
     ![Provisioning to App tab](/img/oin/scim_check-attributes-1.png "Provisioning Tab: Provisioning to App")
@@ -46,7 +46,7 @@ B. Delete attributes from your attribute list
 
 ## Add Attributes
 
-1. From the Admin Console, open your SCIM app.
+1. From the Admin Console, open your SCIM integration.
 
 1. Go to the **Provisioning** tab. Under the **SETTINGS** section, click **To App**.
   ![Provisioning to App tab](/img/oin/scim_check-attributes-1.png "Provisioning Tab: Provisioning to App")
@@ -65,7 +65,7 @@ B. Delete attributes from your attribute list
 
 ## Map Attributes
 
-1. From the Admin Console, open your SCIM app.
+1. From the Admin Console, open your SCIM integration.
 
 1. Go to the **Provisioning** tab. Under the **SETTINGS** section, click **To App**.
   ![Provisioning to App tab](/img/oin/scim_check-attributes-1.png "Provisioning Tab: Provisioning to App")
@@ -76,9 +76,9 @@ B. Delete attributes from your attribute list
 1. In the dialog that appears, there are two drop-down fields. In the first drop-down menu, select **Map from Okta Profile**. In the second drop-down menu, choose the Okta profile attribute that you would like to map the SCIM attribute from. Click **Save**.
   ![Attributes - Map Attribute](/img/oin/scim_check-attributes-14.png "Attributes - Map Attribute")
 
-1. Repeat for all other SCIM attributes where you would like to modify the mapping (from Okta to app).
+1. Repeat for all other SCIM attributes where you would like to modify the mapping (from Okta to your application).
 
-1. After updating the mappings from Okta to your app, click **To Okta** under the settings section.
+1. After updating the mappings from Okta to your application, click **To Okta** under the settings section.
   ![Provisioning to Okta tab](/img/oin/scim_check-attributes-4.png "Provisioning Tab: Provisioning to Okta")
 
 1. Scroll to the **Attribute Mappings** section. Look for the attribute that you want to update and click **Edit**.
@@ -87,17 +87,17 @@ B. Delete attributes from your attribute list
 1. In the dialog that appears, there are two drop-down fields. In the first drop-down menu, select **Map from {App Name} App Profile**. In the second drop-down menu, choose the Okta profile attribute you would like to map the SCIM attribute to. Click **Save**.
   ![Attribute Dialog - Map Attribute](/img/oin/scim_check-attributes-17.png "Attribute Dialog - Map Attribute")
 
-1. Repeat for all other SCIM attributes that you would like to modify the mapping (from App to Okta).
+1. Repeat for all other SCIM attributes that you would like to modify the mapping (from your application to Okta).
 
 ## Attribute support
 
 You only want to include the attributes that you support in your current user schema. To ensure that the attributes are being sent properly to and from Okta:
 
-1. When assigning a user to the SCIM app you added in your dev org, ensure that all expected attributes are populated for that user.
+1. When assigning a user to the SCIM integration you added in your dev org, ensure that all expected attributes are populated for that user.
 
-1. After the user is pushed to your SCIM app, check that all attributes are populated in your SCIM repository.
+1. After the user is pushed to your SCIM application, check that all attributes are populated in your SCIM repository.
 
-1. If your app supports User Imports, try importing one user from your app. Check the imported user and ensure that the values for supported attributes are reflected in that imported user's account in Okta.
+1. If your integration supports User Imports, try importing one user from your application. Check the imported user and ensure that the values for supported attributes are reflected in that imported user's account in Okta.
 
     1. Go to your Admin Console.
     1. Click **Directory** > **People**.

--- a/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/index.md
@@ -3,7 +3,7 @@ title: OIN - Build a SCIM provisioning integration
 excerpt: Create a provisioning integration using SCIM.
 meta:
   - name: description
-    content: Use this guide to learn how to build an application integration that uses SCIM to handle user provisioning.
+    content: Use this guide to learn how to build an Okta integration that uses SCIM to handle user provisioning.
 layout: Guides
 sections:
  - overview

--- a/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/next-steps/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/next-steps/index.md
@@ -1,10 +1,10 @@
 ---
 title: Next Steps
 ---
-You should now have a SCIM app integration that has been successfully built and tested.
+You should now have a SCIM integration that has been successfully built and tested.
 
 If you have any problems with your integration, contact <developers@okta.com>, or post a question in our [Developer Forum](https://devforum.okta.com).
 
-After you have completed your testing and your app is working as expected, you can start the submission process to have your app included in the [Okta Integration Network](https://www.okta.com/okta-integration-network/) (OIN).
+After you have completed your testing and your integration is working as expected, you can start the submission process to have your integration included in the [Okta Integration Network](https://www.okta.com/okta-integration-network/) (OIN).
 
-Our [OIN - Submit an app integration guide](/docs/guides/submit-app) takes you through the steps required to submit your SCIM integration through the OIN Manager site.
+Our [Submit an app integration](/docs/guides/submit-app) guide takes you through the steps required to submit your SCIM integration through the OIN Manager site.

--- a/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/overview/index.md
@@ -2,7 +2,7 @@
 title: Overview
 ---
 
-Whether you are an independent software vendor (ISV), an existing Okta customer, an IT systems administrator, or a developer new to Okta, you need to know how to set up and test your cloud-based application and API endpoints in order to successfully deploy an Okta integration using SCIM provisioning.
+Whether you are an independent software vendor (ISV), an existing Okta customer, an IT systems administrator, or a developer new to Okta, you need to know how to set up and test your cloud-based application and API endpoints to successfully deploy an Okta integration using SCIM provisioning.
 
 If you need more detail on the concepts behind lifecycle management with SCIM and Okta, see [Understanding SCIM](/docs/concepts/scim/).
 

--- a/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/overview/index.md
@@ -2,16 +2,16 @@
 title: Overview
 ---
 
-Whether you are an independent software vendor (ISV), an existing Okta customer, an IT systems administrator, or a developer new to Okta, you need to know how to set up and test your API service and application so that you can successfully deploy a provisioning integration using SCIM with Okta.
+Whether you are an independent software vendor (ISV), an existing Okta customer, an IT systems administrator, or a developer new to Okta, you need to know how to set up and test your cloud-based application and API endpoints in order to successfully deploy an Okta integration using SCIM provisioning.
 
 If you need more detail on the concepts behind lifecycle management with SCIM and Okta, see [Understanding SCIM](/docs/concepts/scim/).
 
-While many ISVs have custom APIs for managing user accounts, Okta recommends that you use the [System for Cross-domain Identity Management](http://www.simplecloud.info) (SCIM) protocol, an industry standard that supports all of the needed features for lifecycle provisioning. For more technical details on how you can take advantage of the SCIM API with Okta, see our [SCIM Protocol reference](/docs/reference/scim/).
+While many ISVs have custom APIs for managing user accounts, this guide assumes that you use the [System for Cross-domain Identity Management](http://www.simplecloud.info) (SCIM) protocol, an industry standard that supports all of the needed features for lifecycle provisioning. For more technical details on how you can take advantage of the SCIM API with Okta, see our [SCIM Protocol reference](/docs/reference/scim/).
 
-Your app integration can also use Single Sign-On (SSO) to initiate end-user authentication to your provisioning app. Learn how to set up your integration with SSO in our [Build a Single Sign-On (SSO) integration](/docs/guides/build-sso-integration/) guide.
+Your Okta integration should use Single Sign-On (SSO) to initiate end-user authentication. Learn how to set up your integration with SSO in our [Build a Single Sign-On (SSO) integration](/docs/guides/build-sso-integration/) guide.
 
 If you need help, read through our [SCIM FAQ](/docs/concepts/scim/faqs/) page, post your question on the [Okta Developer Forums](https://devforum.okta.com/), or email us at <developers@okta.com>.
 
-After you have prepared and tested your SCIM integration, if you want to make your integration public, you can [submit your app](/docs/guides/submit-app) for publication in the [Okta Integration Network (OIN) catalog](https://www.okta.com/integrations/).
+After you have prepared and tested your SCIM integration, and you want to make it public, you can follow the steps in our [Submit an app integration](/docs/guides/submit-app) guide to have it published in the [Okta Integration Network (OIN) catalog](https://www.okta.com/integrations/).
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/prepare-api/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/prepare-api/index.md
@@ -39,9 +39,9 @@ Okta supports authentication against SCIM APIs using any one of the following me
 - [Basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication)
 - A custom HTTP header
 
-If you are using OAuth 2.0, then after successfully authorizing Okta to use your SCIM API, your app's authorization server redirects the user back to Okta, with either an authorization code or an access token.
+If you are using OAuth 2.0, then after successfully authorizing Okta to use your SCIM API, your application's authorization server redirects the user back to Okta, with either an authorization code or an access token.
 
-If you are going to publish your app to the OIN catalog, Okta requires that all SCIM applications support all of the following [redirect URIs](https://tools.ietf.org/html/rfc6749#section-3.1.2):
+If you are going to publish your integration to the OIN catalog, Okta requires that all SCIM applications support all of the following [redirect URIs](https://tools.ietf.org/html/rfc6749#section-3.1.2):
 
 - `https://system-admin.okta.com/admin/app/cpc/{appName}/oauth/callback`
 - `https://system-admin.okta-emea.com/admin/app/cpc/{appName}/oauth/callback`
@@ -92,8 +92,8 @@ In addition to the basic user schema attributes, your SCIM API must also specify
 
 [Section 3.1](https://tools.ietf.org/html/rfc7643#section-3.1) of the SCIM specification asserts that the `id` attribute is used to uniquely identify resources. This unique identifier:
 
-- Is assigned a value by the service provider (your app) for each SCIM resource
-- Is always issued by the service provider (your app) and not specified by the client (Okta)
+- Is assigned a value by the service provider (your application) for each SCIM resource
+- Is always issued by the service provider (your application) and not specified by the client (Okta)
 - Must be included in every representation of the resource
 - Cannot be empty
 - Must be unique across the SCIM service provider's entire set of resources
@@ -112,7 +112,7 @@ Okta user management requires that your SCIM API supports an `active` attribute 
 
 ## SCIM facade
 
-Sometimes it isn't feasible for your cloud-based application to natively support a SCIM API. An alternative option is to build and host your own SCIM facade middleware that translates between the Okta SCIM API connection and the cloud app's proprietary API. The Okta integration connection is then made to this SCIM facade.
+Sometimes it isn't feasible for your cloud-based application to natively support a SCIM API. An alternative option is to build and host your own SCIM facade middleware that translates between the Okta SCIM API connection and the cloud application's proprietary API. The Okta integration connection is then made to this SCIM facade.
 
 ## Provisioning to on-premises applications
 

--- a/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/prepare-api/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/prepare-api/index.md
@@ -114,7 +114,7 @@ Okta user management requires that your SCIM API supports an `active` attribute 
 
 Sometimes it isn't feasible for your cloud-based application to natively support a SCIM API. An alternative option is to build and host your own SCIM facade middleware that translates between the Okta SCIM API connection and the cloud application's proprietary API. The Okta integration connection is then made to this SCIM facade.
 
-## Provisioning to on-premises applications
+## Provision to on-premises applications
 
 This provisioning guide targets cloud-based applications, but Okta does have a solution for on-premise applications. See [Configuring On Premises Provisioning](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_OPP_configure) for details about the Okta agent-based provisioning solution.
 

--- a/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/prepare-app/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/prepare-app/index.md
@@ -18,8 +18,8 @@ Begin by signing up for an [Okta developer account](https://developer.okta.com/s
 1. Search for "SCIM 2.0" or "SCIM 1.1" (your choice depends on which version your SCIM server supports). You'll see three different SCIM template applications, one for each of the three authentication methods that you can use to connect to your SCIM implementation (Basic Auth, Header Auth, or OAuth Bearer Token).
   ![SCIM 2.0 Templates](/img/oin/scim_app-templates.png "List of SCIM templates")
   Click **Add** on the template you want to use.
-1. In the **General Settings** screen, give your integration a descriptive name, and specify whether you want it to be hidden from general and mobile users. Additionally, you can decide if you want to have your users automatically be logged in when they reach the landing page in their web browser. Click **Next**.
-1. In the **Sign-On Options** screen, you specify how your users sign in to your integration. You can select either SAML or SWA. See the [Applications topic](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Apps_Apps) in the Okta product documentation if you need guidance on which single sign-on access method to choose. Click **Done** to create the integration.
+1. On the **General Settings** page, give your integration a descriptive name and specify whether you want it to be hidden from general and mobile users. Additionally, you can decide if you want to have your users automatically be logged in when they reach the landing page in their web browser. Click **Next**.
+1. On the **Sign-On Options** page, you specify how your users sign in to your integration. You can select either SAML or SWA. See the [Applications topic](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Apps_Apps) in the Okta product documentation if you need guidance on which single sign-on access method to choose. Click **Done** to create the integration.
 1. After the integration is created, click the **Provisioning** tab, and in the main panel, click **Configure API Integration**. Select the **Enable API Integration** check box.
   ![SCIM Integration - Enable API](/img/oin/scim_app-enable-api.png "Enable the API integration for your integration")
   Enter the base URL for your SCIM server.
@@ -56,7 +56,7 @@ Select the type of integration you want to create, choosing either **SWA** or **
 1. In the Authentication Mode section, you can choose which mode you want to use for Okta to connect to your SCIM application.
 
     - Basic Auth: To authenticate using Basic Auth mode, you need to provide the username and password for the account that handles the create, update, and deprovisioning actions on your SCIM server.
-    - HTTP Header: To authenticate using HTTP Header, you need to provide a bearer token that will provide authorization against your SCIM application. See [Create an API token](/docs/guides/create-an-api-token/) for instructions on how to generate a token.
+    - HTTP Header: To authenticate using the HTTP Header, enter a bearer token to provide authorization against your SCIM application. See [Create an API token](/docs/guides/create-an-api-token/) for instructions on how to generate a token.
     - OAuth2: To authenticate using OAuth2, you need to provide the access token and authorization endpoints for your SCIM server, along with a client ID and a client secret.
 Click **Test Connector Configuration** to confirm that Okta can connect to your SCIM server.
 

--- a/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/prepare-app/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/prepare-app/index.md
@@ -1,5 +1,5 @@
 ---
-title: Integrate your SCIM service with an Okta app
+title: Integrate your SCIM service with an Okta integration
 ---
 
 After you have a SCIM implementation that passes all of the Runscope tests, you need to create your SCIM integration directly within Okta.
@@ -16,30 +16,30 @@ Begin by signing up for an [Okta developer account](https://developer.okta.com/s
 1. Click **Add Application**.
   ![Create New Application](/img/oin/scim_create-app.png "Create App button")
 1. Search for "SCIM 2.0" or "SCIM 1.1" (your choice depends on which version your SCIM server supports). You'll see three different SCIM template applications, one for each of the three authentication methods that you can use to connect to your SCIM implementation (Basic Auth, Header Auth, or OAuth Bearer Token).
-  ![SCIM 2.0 Template Apps](/img/oin/scim_app-templates.png "List of SCIM template apps")
+  ![SCIM 2.0 Templates](/img/oin/scim_app-templates.png "List of SCIM templates")
   Click **Add** on the template you want to use.
-1. In the **General Settings** screen, give your app a descriptive name, and specify whether you want the app to be hidden from general and mobile users. Additionally, you can decide if you want to have your users automatically be logged in when they reach the landing page in their web browser. Click **Next**.
-1. In the **Sign-On Options** screen, you specify how your users sign in to your app. You can select either SAML or SWA. See the [Applications topic](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Apps_Apps) in the Okta product documentation if you need guidance on which single sign-on access method to choose. Click **Done** to create the app.
-1. After the app is created, click the **Provisioning** tab, and in the main panel, click **Configure API Integration**. Select the **Enable API Integration** check box.
-  ![SCIM App Enable API](/img/oin/scim_app-enable-api.png "Enable the API integration for your app")
+1. In the **General Settings** screen, give your integration a descriptive name, and specify whether you want it to be hidden from general and mobile users. Additionally, you can decide if you want to have your users automatically be logged in when they reach the landing page in their web browser. Click **Next**.
+1. In the **Sign-On Options** screen, you specify how your users sign in to your integration. You can select either SAML or SWA. See the [Applications topic](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Apps_Apps) in the Okta product documentation if you need guidance on which single sign-on access method to choose. Click **Done** to create the integration.
+1. After the integration is created, click the **Provisioning** tab, and in the main panel, click **Configure API Integration**. Select the **Enable API Integration** check box.
+  ![SCIM Integration - Enable API](/img/oin/scim_app-enable-api.png "Enable the API integration for your integration")
   Enter the base URL for your SCIM server.
-  The credential options vary depending on your choice of authentication method for the app:
+  The credential options vary depending on your choice of authentication method:
     - Basic Auth: To authenticate using Basic Auth mode, you need to provide the username and password for the account that handles the create, update, and deprovisioning actions on your SCIM implementation.
     - HTTP Header: To authenticate using HTTP Header, you need to provide a bearer token to access your SCIM implementation.
     - OAuth: To authenticate using OAuth, you need to provide the OAuth access token to access your SCIM implementation.
 
-    Fill in this information and click **Test API Credentials** to test whether the Okta app can connect to your SCIM API.
+    Fill in this information and click **Test API Credentials** to test whether the Okta integration can connect to your SCIM API.
 
     Click **Save** to complete the API integration.
 
 <!-- Saving these instructions for when we switch over to the Okta App Integration Wizard
-1. Click **Add Application** to open the OIN App Catalog.
+1. Click **Add Application** to open the OIN Catalog.
 1. Click **Create New App** to start the Application Integration Wizard.
-Select the type of app you want to create, choosing either **SWA** or **SAML 2.0**. To decide which option is right for you, see the [Overview of Managing Apps and SSO](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Apps_Overview_of_Managing_Apps_and_SSO) topic in the Okta product documentation. Adding SCIM provisioning to an app that uses the OpenID Connect (OIDC) sign-on mode isn't supported.
+Select the type of integration you want to create, choosing either **SWA** or **SAML 2.0**. To decide which option is right for you, see the [Overview of Managing Apps and SSO](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Apps_Overview_of_Managing_Apps_and_SSO) topic in the Okta product documentation. Adding SCIM provisioning to an SSO integration that uses the OpenID Connect (OIDC) sign-on mode isn't supported.
 
     >**Note:** A detailed description of creating SWA and SAML applications is available in the [Using the App Integration Wizard](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Apps_App_Integration_Wizard) topic in the Okta product documentation.
 
-1. After your app is created, open it from the **Applications** dashboard, and click the **General** tab.
+1. After your integration is created, open it from the **Applications** dashboard, and click the **General** tab.
 1. Click **Edit**, then scroll down to the **Provisioning** section.
   ![Add SCIM](/img/oin/admin_console-app_integration_wizard-scim_app.png "Add SCIM provisioning")
 1. Select **SCIM**, then click **Save**.
@@ -49,18 +49,18 @@ Select the type of app you want to create, choosing either **SWA** or **SAML 2.0
 1. Under **Supported provisioning actions**, choose the provisioning actions supported by your SCIM server.
 
     - Import New Users and Profile Updates: This option populates the **Settings > To Okta** page. You can specify the details of how Okta imports new users and user profile updates.
-    - Push New Users: This option populates the **Settings > To App** page, and contains settings for all the user information that flows from Okta into an app.
-    - Push Profile Updates: This option populates the **Settings > To App** page, and contains settings for all profile information that flows from Okta into an app.
-    - Push Groups: This option populates the Settings > To App page, and contains settings for all group information that flows from Okta into an app.
+    - Push New Users: This option populates the **Settings > To App** page, and contains settings for all the user information that flows from Okta into an application.
+    - Push Profile Updates: This option populates the **Settings > To App** page, and contains settings for all profile information that flows from Okta into an application.
+    - Push Groups: This option populates the Settings > To App page, and contains settings for all group information that flows from Okta into an application.
 
-1. In the Authentication Mode section, you can choose which mode you want to use for Okta to connect to your SCIM app.
+1. In the Authentication Mode section, you can choose which mode you want to use for Okta to connect to your SCIM application.
 
     - Basic Auth: To authenticate using Basic Auth mode, you need to provide the username and password for the account that handles the create, update, and deprovisioning actions on your SCIM server.
-    - HTTP Header: To authenticate using HTTP Header, you need to provide a bearer token that will provide authorization against your SCIM app. See [Create an API token](/docs/guides/create-an-api-token/) for instructions on how to generate a token.
+    - HTTP Header: To authenticate using HTTP Header, you need to provide a bearer token that will provide authorization against your SCIM application. See [Create an API token](/docs/guides/create-an-api-token/) for instructions on how to generate a token.
     - OAuth2: To authenticate using OAuth2, you need to provide the access token and authorization endpoints for your SCIM server, along with a client ID and a client secret.
 Click **Test Connector Configuration** to confirm that Okta can connect to your SCIM server.
 
-1. Click **Save** to complete the SCIM app setup.
+1. Click **Save** to complete the SCIM integration setup.
 -->
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/test-qa/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/test-qa/index.md
@@ -2,7 +2,7 @@
 title: Run through OIN QA tests
 ---
 
-If your SCIM integration has passed all the Runscope tests, and you are planning to publish your SCIM app integration in the OIN catalog, you can now run through the OIN quality assurance test cases in this spreadsheet.
+If your SCIM integration has passed all the Runscope tests, and you are planning to publish your SCIM integration in the OIN catalog, you can now run through the OIN quality assurance test cases in this spreadsheet.
 
 * [Okta SCIM Test Plan](/standards/SCIM/SCIMFiles/okta-scim-test-plan.xlsx)
 

--- a/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/test-scim-app/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/test-scim-app/index.md
@@ -4,7 +4,7 @@ title: Test your Okta integration
 
 This second suite of [Runscope](https://www.runscope.com) tests checks that your SCIM application can handle actual requests to **C**reate, **R**ead, **U**pdate and **D**elete (CRUD) user profile information.
 
->**Note:** Okta doesn't delete user profiles, but instead marks them as `active=false` to deactivate them.
+>**Note:** Okta doesn't delete user profiles in your application, but instead marks the user record with `active=false` to deactivate them. For a detailed explanation on deleting user profiles, see [Delete (Deprovision)](/docs/concepts/scim/#delete-deprovision).
 
 ### Runscope tests for CRUD
 

--- a/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/test-scim-app/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/test-scim-app/index.md
@@ -2,7 +2,7 @@
 title: Test your Okta integration
 ---
 
-This second suite of [Runscope](https://www.runscope.com) tests checks that your SCIM app can handle actual requests to **C**reate, **R**ead, **U**pdate and **D**elete (CRUD) user profile information.
+This second suite of [Runscope](https://www.runscope.com) tests checks that your SCIM application can handle actual requests to **C**reate, **R**ead, **U**pdate and **D**elete (CRUD) user profile information.
 
 >**Note:** Okta doesn't delete user profiles, but instead marks them as `active=false` to deactivate them.
 
@@ -12,18 +12,18 @@ If you are not familiar with Runscope, follow the detailed instructions in the [
 
 This suite runs the following tests:
 
-1. Checks that the app exists in your Okta org.
+1. Checks that the integration exists in your Okta org.
 1. Adds a new random user in Okta.
-1. Assigns that user to the app in Okta.
+1. Assigns that user to the integration in Okta.
 1. Verifies that the user was created on your SCIM server.
 1. Updates the user `firstName` attribute in Okta.
 1. Verifies that the user attribute was updated on your SCIM server.
 1. Deactivates the user in Okta.
 1. Verifies that the user was deactivated on your SCIM server.
 1. Reactivates the user in Okta.
-1. Reassigns your app to the user in Okta.
+1. Reassigns your integration to the user in Okta.
 1. Verifies the user was reactivated and assigned on your SCIM server.
-1. Removes your app from the user in Okta.
+1. Removes your integration from the user in Okta.
 1. Verifies that user is deactivated on your SCIM server.
 
 ### Configure and run tests
@@ -31,19 +31,19 @@ This suite runs the following tests:
 To configure and run the SCIM CRUD tests:
 
 1. Download the Okta SCIM CRUD test file.
-    * If you are using SCIM 2.0 for your app: [Okta SCIM 2.0 CRUD test file](/standards/SCIM/SCIMFiles/Okta-SCIM-20-CRUD-Test.json)
-    * If you are using SCIM 1.1 for your app: [Okta SCIM 1.1 CRUD test file](/standards/SCIM/SCIMFiles/Okta-SCIM-11-CRUD-Test.json)
+    * If you are using SCIM 2.0: [Okta SCIM 2.0 CRUD test file](/standards/SCIM/SCIMFiles/Okta-SCIM-20-CRUD-Test.json)
+    * If you are using SCIM 1.1: [Okta SCIM 1.1 CRUD test file](/standards/SCIM/SCIMFiles/Okta-SCIM-11-CRUD-Test.json)
 1. In Runscope, click **Import Test**.
 1. Select **Runscope API Tests** as the import format.
 1. Click **Choose File** and select the Okta SCIM 2.0 CRUD JSON test file.
 1. Click **Import API Test**.
 1. In this new test bucket, click **Editor** from the left hand navigation menu.
 1. Click **Test Settings** and then click **Initial Variables**.
-1. Add the following variables with values that match your SCIM app:
-    * `oktaAppId` - the unique identifier randomly assigned to your Okta app. You can see this value in the **App Embed Link** panel under the **General** tab for your Okta app.
+1. Add the following variables with values that match your SCIM integration:
+    * `oktaAppId` - the unique identifier randomly assigned to your Okta integration. You can see this value in the **App Embed Link** panel under the **General** tab for your Okta integration.
     * `oktaOrgUrl` - the base URL for your Okta org. Include the `https://` prefix.
     ![Dev Window](/img/oin/scim_crud-test-identifiers.png "Browser bar showing the oktaOrgUrl location")
-    * `oktaToken` - the security token used to connect to your Okta app API. You can generate a token for your app inside your Okta org:
+    * `oktaToken` - the security token used to connect to your API. You can generate a token for your integration inside your Okta org:
         * Click **Security** > **API**.
         * Click on **Tokens** and **Create Token**.
         * Give the token a name click **Create Token**.

--- a/packages/@okta/vuepress-site/docs/reference/scim/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/scim/index.md
@@ -18,7 +18,7 @@ For a developer's guide to implementing the SCIM REST API with Okta and your app
 
 Okta currently supports both Version 2.0 and Version 1.1 of the SCIM protocol specifications. If you haven't yet implemented SCIM, Okta recommends that you implement SCIM 2.0.
 
-In order to have a SCIM application work with Okta, the application must reside on a SCIM server consisting of RESTful endpoints that are constructed according to [V2.0](https://tools.ietf.org/html/rfc7644) or [V1.1](http://www.simplecloud.info/specs/draft-scim-api-01.html) SCIM protocol specifications. The URL of your SCIM server is plugged into the SCIM application in Okta. Okta then communicates with the endpoints through a series of HTTP requests and responses using POST, GET, PUT, and PATCH operations.
+In order to work with Okta, your SCIM application must use RESTful endpoints constructed according to either the [V2.0](https://tools.ietf.org/html/rfc7644) or [V1.1](http://www.simplecloud.info/specs/draft-scim-api-01.html) SCIM protocol specification. The URL of your SCIM server is plugged into the SCIM integration in your Okta org. Okta then communicates with the endpoints through a series of HTTP requests and responses using POST, GET, PUT, and PATCH operations.
 
 ### Differences between Version 2.0 and 1.1
 

--- a/packages/@okta/vuepress-site/docs/reference/scim/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/scim/index.md
@@ -18,9 +18,9 @@ For a developer's guide to implementing the SCIM REST API with Okta and your app
 
 Okta currently supports both Version 2.0 and Version 1.1 of the SCIM protocol specifications. If you haven't yet implemented SCIM, Okta recommends that you implement SCIM 2.0.
 
-In order to work with Okta, your SCIM application must use RESTful endpoints constructed according to either the [V2.0](https://tools.ietf.org/html/rfc7644) or [V1.1](http://www.simplecloud.info/specs/draft-scim-api-01.html) SCIM protocol specification. The URL of your SCIM server is plugged into the SCIM integration in your Okta org. Okta then communicates with the endpoints through a series of HTTP requests and responses using POST, GET, PUT, and PATCH operations.
+To work with Okta, your SCIM application must use RESTful endpoints constructed according to either the [V2.0](https://tools.ietf.org/html/rfc7644) or [V1.1](http://www.simplecloud.info/specs/draft-scim-api-01.html) SCIM protocol specification. The URL of your SCIM server is plugged into the SCIM integration in your Okta org. Okta then communicates with the endpoints through a series of HTTP requests and responses using POST, GET, PUT, and PATCH operations.
 
-### Differences between Version 2.0 and 1.1
+### Differences between version 2.0 and 1.1
 
 * Different namespaces means that Version 2.0 URIs are not backwards compatible with 1.1:
   * V2.0:

--- a/packages/@okta/vuepress-site/docs/reference/scim/scim-11/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/scim/scim-11/index.md
@@ -17,11 +17,11 @@ To better understand SCIM and the specific implementation of SCIM using Okta, se
 
 ## SCIM User operations
 
-### Creating users
+### Create users
 
-![Flowchart - create user](/img/oin/scim_flow-user-create.png "Simple flow diagram for create user process")
+![Flowchart - create User](/img/oin/scim_flow-user-create.png "Simple flow diagram for create User process")
 
-The User creation operation brings the user's application profile from Okta over to the Service Provider. A user's application profile represents the key-value attributes defined on the **Profile** tab when a user is added.
+The User creation operation brings the user's application profile from Okta over to the Service Provider. A user's application profile represents the key-value attributes defined on the **Profile** tab when a User object is added.
 
 To enable user provisioning, you must configure the provisioning options in the Okta Admin Console. In the Okta Admin Console:
 
@@ -49,18 +49,18 @@ Authorization: <Authorization credentials>
 
 > **Note:** The query parameters that Okta sends at this point are always constant.
 
-After you complete this step, whenever a user is assigned to the Okta integration, the following operation requests are made against the SCIM server:
+After you complete this step, whenever a User is assigned to the Okta integration, the following operation requests are made against the SCIM server:
 
-* Determine if the user already exists
-* Create the user if the user isn't found
+* Determine if the User object already exists
+* Create the User if the User object isn't found
 
-#### Determine if the user already exists
+#### Determine if the User already exists
 
 **GET** /Users
 
-Okta checks that the user exists on the SCIM server through a GET operation with the `filter=userName` parameter (or any other filter parameter that was configured with the SCIM integration). This check is performed using the `eq` (equal) operator and is the only one necessary to successfully provision users with Okta.
+Okta checks that the User object exists on the SCIM server through a GET operation with the `filter=userName` parameter (or any other filter parameter that was configured with the SCIM integration). This check is performed using the `eq` (equal) operator and is the only one necessary to successfully provision users with Okta.
 
-> **Note:** The filter must check an attribute that is _unique_ for all users in the Service Provider profiles.
+> **Note:** The filter must check an attribute that is _unique_ for all Users in the Service Provider profiles.
 
 For Okta Integration Network (OIN) integrations, this filter is configured with the help of the assigned Okta App Analyst during the submission process. Integration submissions are handled through the [OIN Manager](https://oinmanager.okta.com).
 
@@ -72,7 +72,7 @@ User-Agent: Okta SCIM Client 1.0.0
 Authorization: <Authorization credentials>
 ```
 
-The SCIM application checks the filter provided and returns an empty response if no users match the filter criteria. For example:
+The SCIM application checks the filter provided and returns an empty response if no Users match the filter criteria. For example:
 
 ```http
 HTTP/1.1 200 OK
@@ -88,7 +88,7 @@ Content-Type: application/json
 }
 ```
 
-If the SCIM server does return a user, Okta automatically matches the result with the user in Okta, sending the user application profile to the SCIM server.
+If the SCIM server does return a User object, Okta automatically matches the result with the User in Okta, sending the user's application profile to the SCIM server.
 
 **PUT** /Users/*$userID*
 
@@ -118,11 +118,11 @@ Authorization: <Authorization credentials>
 }
 ```
 
-#### Create the user
+#### Create the User
 
 **POST** /Users
 
-If the user isn't found on the SCIM server, then Okta attempts to create it through a POST operation that contains the user application profile. The request looks like the following:
+If the User object isn't found on the SCIM server, then Okta attempts to create it through a POST operation that contains the user's application profile. The request looks like the following:
 
 ```http
 POST /scim/v1/Users HTTP/1.1
@@ -150,7 +150,7 @@ Authorization: <Authorization credentials>
 }
 ```
 
-The response from the SCIM server contains the created user profile:
+The response from the SCIM server contains the created user's profile:
 
 ```http
 HTTP/1.1 201 Created
@@ -187,7 +187,7 @@ If the SCIM server returns an empty response body to the provisioning request, t
 
 "Automatic provisioning of user `userName` to app `AppName` failed: Error while creating user `displayName`: Create new user returned empty user."
 
-If the user that Okta tries to create already exists in the Service Provider application, then the Service Provider needs to respond with an error schema to stop the provisioning job. The response looks like the following:
+If the User that Okta tries to create already exists in the Service Provider application, then the Service Provider needs to respond with an error schema to stop the provisioning job. The response looks like the following:
 
 ```http
 HTTP/1.1 409 Conflict
@@ -202,11 +202,11 @@ Content-Type: application/json
 }
 ```
 
-### Retrieving users
+### Retrieve Users
 
 **GET** /Users
 
-When importing users from the SCIM server, Okta accesses the `/Users` endpoint and processes them page by page, using `startIndex`, `count`, and `totalResults` as pagination references. Similarly, when returning large lists of resources, your SCIM implementation must support pagination. Using a limit of `count` results and an offset of `startIndex` returns smaller groupings of resources in a request.
+When importing Users from the SCIM server, Okta accesses the `/Users` endpoint and processes them page by page, using `startIndex`, `count`, and `totalResults` as pagination references. Similarly, when returning large lists of resources, your SCIM implementation must support pagination. Using a limit of `count` results and an offset of `startIndex` returns smaller groupings of resources in a request.
 
 > **Note:** The `itemsPerPage`, `startIndex`, and `totalResults` values need to be exchanged as integers, not as strings.
 
@@ -214,7 +214,7 @@ Okta uses `count=100` as the pagination reference to return up to 100 elements. 
 
 The SCIM server must consistently return the same ordering of results for the requests, regardless of which values are provided for the `count` and `startIndex` pagination references. For more information on pagination, see [Section 3.2.2.3](http://www.simplecloud.info/specs/draft-scim-api-01.html#query-resources) of the V1.1 specification.
 
-A sample request from Okta to retrieve the users from the SCIM application:
+A sample request from Okta to retrieve the Users from the SCIM application:
 
 ```http
 GET /scim/v1/Users?startIndex=1&count=100 HTTP/1.1
@@ -222,13 +222,13 @@ User-Agent: Okta SCIM Client 1.0.0
 Authorization: <Authorization credentials>
 ```
 
-The response to this request is a JSON listing of all the resources found in the SCIM application.
+The response to this request is a JSON list of all the resources found in the SCIM application.
 
-### Retrieving a specific user
+### Retrieve a specific User
 
 **GET** /Users/*$userID*
 
-Okta can also run a GET operation to check if a specific user still exists on the SCIM server. The request looks like the following:
+Okta can also run a GET operation to check if a specific User still exists on the SCIM server. The request looks like the following:
 
 ```http
 GET /scim/v1/Users/48e0a2da-0999-4f2c-87f4-80432cfe6617 HTTP/1.1
@@ -236,7 +236,7 @@ User-Agent: Okta SCIM Client 1.0.0
 Authorization: <Authorization credentials>
 ```
 
-The response from the server is the user profile:
+The response from the server is the user's profile:
 
 ```http
 HTTP/1.1 200 OK
@@ -269,23 +269,23 @@ Content-Type: text/json;charset=UTF-8
 }
 ```
 
-### Updating a specific user (PUT)
+### Update a specific User (PUT)
 
-![Flowchart - update user (PUT)](/img/oin/scim_flow-user-update-put.png "Simple flow diagram for updating a user with a PUT operation")
+![Flowchart - update User (PUT)](/img/oin/scim_flow-user-update-put.png "Simple flow diagram for updating a User with a PUT operation")
 
-Updating a user refers to modifying an attribute in the Okta user profile that is mapped to an attribute in the SCIM application.
+Updating a User refers to modifying an attribute in the Okta user's profile that is mapped to an attribute in the SCIM application.
 
-To update a user, you need to enable the functionality in the Okta Admin Console:
+To update a User, you need to enable the functionality in the Okta Admin Console:
 
 1. Select your SCIM integration from the list of integrations in your Okta org.
 1. Under the **Provisioning** tab, click **To App**.
 1. In the **Update User Attributes** option, click **Enable** and then **Save**.
 
-#### Retrieve the user profile
+#### Retrieve the User profile
 
 **GET** /Users/*$userID*
 
-To update a user profile, Okta first makes a GET request to `/Users/${userID}` and retrieves the body of the user's SCIM profile:
+To update a User profile, Okta first makes a GET request to `/Users/${userID}` and retrieves the body of the user's SCIM profile:
 
 ```http
 GET /scim/v1/Users/48e0a2da-0999-4f2c-87f4-80432cfe6617 HTTP/1.1
@@ -326,7 +326,7 @@ Content-Type: text/json;charset=UTF-8
 }
 ```
 
-#### Update the user profile
+#### Update the User profile
 
 **PUT** /Users/*$userID*
 
@@ -396,29 +396,29 @@ Content-Type: text/json;charset=UTF-8
 }
 ```
 
-### Updating a specific user (PATCH)
+### Update a specific User (PATCH)
 
-![Flowchart - update user (PATCH)](/img/oin/scim_flow-user-update-patch.png "Simple flow diagram for updating a user with a PATCH operation")
+![Flowchart - update User (PATCH)](/img/oin/scim_flow-user-update-patch.png "Simple flow diagram for updating a User with a PATCH operation")
 
 **PATCH** /Users/*$userID*
 
-A user resource can be updated through a PATCH operation for the following actions:
+A User object can be updated through a PATCH operation for the following actions:
 
-* Activating a user
-* Deactivating a user
-* Syncing the user password
+* Activating a User
+* Deactivating a User
+* Syncing the User password
 
 The `active` attribute in a user profile represents the user's current status.
 
-Other updates to attributes in a user profile should be handled through a PUT operation.
+Other updates to attributes in a user's profile should be handled through a PUT operation.
 
-To deactivate users, you need to enable the functionality in the Okta Admin Console:
+To deactivate Users, you need to enable the functionality in the Okta Admin Console:
 
 1. Select your SCIM integration from the list of integrations in your Okta org.
 1. Under the **Provisioning** tab, click **To App** and **Edit**.
 1. In the **Deactivate Users** option, click **Enable** and then **Save**.
 
-When a user is deactivated, Okta sends this request:
+When a User is deactivated, Okta sends this request:
 
 ```http
 PATCH /scim/v1/Users/48e0a2da-0999-4f2c-87f4-80432cfe6617 HTTP/1.1
@@ -467,32 +467,32 @@ Content-Type: text/json;charset=UTF-8
 
 > **Note:** The SCIM server response to PATCH operation requests can also be a HTTP 204 response, with no body returned.
 
-### Deleting users
+### Delete Users
 
-![Flowchart - deprovision user](/img/oin/scim_flow-user-deprovision.png "Simple flow diagram for deprovisioning a user")
+![Flowchart - deprovision User](/img/oin/scim_flow-user-deprovision.png "Simple flow diagram for deprovisioning a User")
 
 **DELETE** /Users/*$userID*
 
-Okta doesn't perform DELETE operations on users in your SCIM application.
+Okta doesn't perform DELETE operations on User objects in your SCIM application.
 
-If a user is suspended, deactivated, or removed from your integration inside Okta, then Okta sends a PATCH request to your SCIM application to set the `active` attribute to `false`.
+If a User is suspended, deactivated, or removed from your integration inside Okta, then Okta sends a PATCH request to your SCIM application to set the `active` attribute to `false`.
 
 For a detailed explanation on deleting user profiles, see [Delete (Deprovision)](/docs/concepts/scim/#delete-deprovision).
 
 ## SCIM Group operations
 
-### Creating groups
+### Create Groups
 
 **POST** /Groups
 
-To create a group on the SCIM server, you need to push the group using the Okta Admin Console:
+To create a Group on the SCIM server, you need to push the Group using the Okta Admin Console:
 
 1. Select your SCIM integration from the list of integrations in your Okta org.
 1. On the **Push Groups** tab, click **Push Groups**.
 
-You can select which existing Okta group to push, either by specifying a name or a rule. For more information, see the [Using Group Push topic](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Directory_Using_Group_Push) in the Okta Help Center.
+You can select which existing Okta Group to push, either by specifying a name or a rule. For more information, see the [Using Group Push topic](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Directory_Using_Group_Push) in the Okta Help Center.
 
-After the group is selected, Okta makes a POST request to the Service Provider:
+After the Group is selected, Okta makes a POST request to the Service Provider:
 
 ```http
 POST /scim/v1/Groups HTTP/1.1
@@ -505,7 +505,7 @@ Authorization: <Authorization credentials>
 }
 ```
 
-When it receives this request, the SCIM server responds with the group details as it would for a GET operation to the `/Groups/${groupID}/`:
+When it receives this request, the SCIM server responds with the Group details as it would for a GET operation to the `/Groups/${groupID}/`:
 
 ```http
 HTTP/1.1 201 Created
@@ -525,7 +525,7 @@ Content-Type: text/json;charset=UTF-8
 }
 ```
 
-> **Note:** If the group has a description, it is sent automatically to the SCIM server:
+> **Note:** If the Group has a description, it is sent automatically to the SCIM server:
 
 ```http
 {
@@ -537,13 +537,13 @@ Content-Type: text/json;charset=UTF-8
 }
 ```
 
-The SCIM server isn't required to save and return the group description. However, there is no option to prevent the description from being sent.
+The SCIM server isn't required to save and return the Group description. However, there is no option to prevent the description from being sent.
 
-### Retrieving groups
+### Retrieve Groups
 
 **GET** /Groups
 
-When importing groups from the SCIM server, Okta accesses the `/Groups` endpoint and processes them page by page, using the `startIndex`, `count`, and `totalResults` values for reference. Similarly, when returning large lists of resources, your SCIM implementation must support pagination. Using a limit of `count` results and an offset of `startIndex` returns smaller groupings of resources in a request.
+When importing Groups from the SCIM server, Okta accesses the `/Groups` endpoint and processes them page by page, using the `startIndex`, `count`, and `totalResults` values for reference. Similarly, when returning large lists of resources, your SCIM implementation must support pagination. Using a limit of `count` results and an offset of `startIndex` returns smaller groupings of resources in a request.
 
 > **Note:** The `itemsPerPage`, `startIndex`, and `totalResults` values need to be exchanged as integers, not as strings.
 
@@ -551,7 +551,7 @@ Okta uses `count=100` as the pagination reference to return up to 100 elements. 
 
 The SCIM server must consistently return the same ordering of results for the requests, regardless of which values are provided for the `count` and `startIndex` pagination references.
 
-A sample request from Okta to retrieve the groups from the SCIM application:
+A sample request from Okta to retrieve the Groups from the SCIM application:
 
 ```http
 GET /scim/v1/Groups?startIndex=1&count=100 HTTP/1.1
@@ -559,9 +559,9 @@ User-Agent: Okta SCIM Client 1.0.0
 Authorization: <Authorization credentials>
 ```
 
-The response to this request is a JSON listing of all the group resources found in the SCIM application.
+The response to this request is a JSON list of all the Group objects found in the SCIM application.
 
-### Retrieving specific groups
+### Retrieve specific Groups
 
 **GET** /Groups/*$groupID*
 
@@ -593,11 +593,11 @@ Content-Type: text/json;charset=UTF-8
 }
 ```
 
-### Updating a specific group name
+### Update a specific group name
 
 **PATCH** /Groups/*$groupID*
 
-Updates to existing group names for existing Okta groups are handled by a PATCH operation. The group must already be pushed out to the SCIM server.
+Updates to existing Group names for existing Okta Groups are handled by a PATCH operation. The Group must already be pushed out to the SCIM server.
 
 ```http
 PATCH /scim/v1/Groups/74094a55-c9ee-47ae-9fd4-9137deb43497 HTTP/1.1
@@ -635,15 +635,15 @@ Content-Type: text/json;charset=UTF-8
 
 > **Note:** The SCIM server response to PATCH operation requests can also be a HTTP 204 response, with no body returned.
 
-### Updating specific group membership
+### Update specific group membership
 
 **PATCH** /Groups/*$groupID*
 
 To add or remove users inside a specific pushed group on the SCIM server, Okta requires the following:
 
-* The user must be a member of the group in Okta
-* The user has been added under the **Assignments** tab of the SCIM integration inside the Okta Admin Console
-* The group is pushed under the **Push Groups** tab of the SCIM integration inside the Okta Admin Console
+* The User must be a member of the group in Okta.
+* The User has been added under the **Assignments** tab of the SCIM integration inside the Okta Admin Console.
+* The group is pushed under the **Push Groups** tab of the SCIM integration inside the Okta Admin Console.
 
 If these three requirements are met, Okta sends a request to add the specified users to the group on the SCIM server. The operation can be sent as a PUT or a PATCH operation depending on the configuration of the SCIM integration.
 
@@ -684,7 +684,7 @@ Content-Type: text/json;charset=UTF-8
 }
 ```
 
-When a user is removed from the group, Okta sends the `members` array, specifying the `${userID}` along with an `operations` element that has the value `delete`.
+When a User is removed from the group, Okta sends the `members` array, specifying the `${userID}` along with an `operations` element that has the value `delete`.
 
 ```http
 PATCH /scim/v1/Groups/74094a55-c9ee-47ae-9fd4-9137deb43497 HTTP/1.1
@@ -730,11 +730,11 @@ Content-Type: text/json;charset=UTF-8
 
 > **Note:** The SCIM server response to PATCH operation requests can also be a HTTP 204 response, with no body returned.
 
-### Deleting a specific group
+### Delete a specific group
 
 **DELETE** /Groups/*$groupID*
 
-Okta administrators can remove pushed groups from the Okta Admin Console, under the **Push Groups** tab of the SCIM integration.
+Okta administrators can remove pushed Groups from the Okta Admin Console, under the **Push Groups** tab of the SCIM integration.
 
 On the **Push Groups** tab, click **Active** then click **Unlink pushed group**. In the dialog box that appears, you can choose whether you want to **Delete the group in the target app** or **Leave the group in the target app** on the SCIM server.
 

--- a/packages/@okta/vuepress-site/docs/reference/scim/scim-11/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/scim/scim-11/index.md
@@ -469,13 +469,15 @@ Content-Type: text/json;charset=UTF-8
 
 ### Deleting users
 
-![Flowchart - delete user](/img/oin/scim_flow-user-deprovision.png "Simple flow diagram for deprovisioning a user")
+![Flowchart - deprovision user](/img/oin/scim_flow-user-deprovision.png "Simple flow diagram for deprovisioning a user")
 
 **DELETE** /Users/*$userID*
 
-Okta doesn't perform DELETE operations on users.
+Okta doesn't perform DELETE operations on users in your SCIM application.
 
-If a user is suspended, deactivated, or removed from the application in Okta, then Okta sends a PATCH request to set the `active` attribute to `false`.
+If a user is suspended, deactivated, or removed from your integration inside Okta, then Okta sends a PATCH request to your SCIM application to set the `active` attribute to `false`.
+
+For a detailed explanation on deleting user profiles, see [Delete (Deprovision)](/docs/concepts/scim/#delete-deprovision).
 
 ## SCIM Group operations
 

--- a/packages/@okta/vuepress-site/docs/reference/scim/scim-11/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/scim/scim-11/index.md
@@ -11,7 +11,7 @@ This reference focuses on how Okta API endpoints share information with System f
 
 This document specifically covers **Version 1.1** of the SCIM specification. For Version 2.0 of the SCIM specification, see our [SCIM 2.0 reference](/docs/reference/scim/scim-20/).
 
-The SCIM Protocol is an application-level REST protocol for provisioning and managing identity data on the web. The protocol supports creation, discovery, retrieval, and modification of core identity resources.
+The SCIM protocol is an application-level REST protocol for provisioning and managing identity data on the web. The protocol supports creation, discovery, retrieval, and modification of core identity resources.
 
 To better understand SCIM and the specific implementation of SCIM using Okta, see our [Understanding SCIM](/docs/concepts/scim/) guide or our blog post on [What is SCIM?](https://www.okta.com/blog/2017/01/what-is-scim/).
 
@@ -25,13 +25,13 @@ The User creation operation brings the user's application profile from Okta over
 
 To enable user provisioning, you must configure the provisioning options in the Okta Admin Console. In the Okta Admin Console:
 
-1. Select your SCIM application from your list of applications.
+1. Select your SCIM integration from the list of integrations in your Okta org.
 1. Under the **Provisioning** tab, click **To App** and **Edit**.
 1. In the **Create User** option, click **Enable** and then **Save**.
 
-For more information on enabling the provisioning features of your SCIM application, see [Provisioning and Deprovisioning](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Provisioning_Deprovisioning_Overview) under the **Accessing Provisioning Features** section.
+For more information on enabling the provisioning features of your SCIM integration, see [Provisioning and Deprovisioning](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Provisioning_Deprovisioning_Overview) under the **Accessing Provisioning Features** section.
 
-After saving the application configuration, Okta makes two requests:
+After saving the configuration, Okta makes two requests to your SCIM server:
 
 ```http
 GET /scim/v1/Users?startIndex=1&count=2 HTTP/1.1
@@ -49,7 +49,7 @@ Authorization: <Authorization credentials>
 
 > **Note:** The query parameters that Okta sends at this point are always constant.
 
-After you complete this step, whenever a user is assigned to the application in Okta, the following operation requests are made against the SCIM server:
+After you complete this step, whenever a user is assigned to the Okta integration, the following operation requests are made against the SCIM server:
 
 * Determine if the user already exists
 * Create the user if the user isn't found
@@ -58,11 +58,11 @@ After you complete this step, whenever a user is assigned to the application in 
 
 **GET** /Users
 
-Okta checks that the user exists on the SCIM server through a GET operation with the `filter=userName` parameter (or any other filter parameter that was configured with the SCIM application). This check is performed using the `eq` (equal) operator and is the only one necessary to successfully provision users with Okta.
+Okta checks that the user exists on the SCIM server through a GET operation with the `filter=userName` parameter (or any other filter parameter that was configured with the SCIM integration). This check is performed using the `eq` (equal) operator and is the only one necessary to successfully provision users with Okta.
 
 > **Note:** The filter must check an attribute that is _unique_ for all users in the Service Provider profiles.
 
-For Okta Integration Network (OIN) applications, this filter is configured during the review process done by the Okta Application Analyst assigned to evaluate the application submission. Application submissions are processed through the [OIN Manager](https://oinmanager.okta.com).
+For Okta Integration Network (OIN) integrations, this filter is configured with the help of the assigned Okta App Analyst during the submission process. Integration submissions are handled through the [OIN Manager](https://oinmanager.okta.com).
 
 The requests from Okta to the Service Provider are of the form:
 
@@ -214,7 +214,7 @@ Okta uses `count=100` as the pagination reference to return up to 100 elements. 
 
 The SCIM server must consistently return the same ordering of results for the requests, regardless of which values are provided for the `count` and `startIndex` pagination references. For more information on pagination, see [Section 3.2.2.3](http://www.simplecloud.info/specs/draft-scim-api-01.html#query-resources) of the V1.1 specification.
 
-A sample request from Okta to retrieve the users from the SCIM app:
+A sample request from Okta to retrieve the users from the SCIM application:
 
 ```http
 GET /scim/v1/Users?startIndex=1&count=100 HTTP/1.1
@@ -222,7 +222,7 @@ User-Agent: Okta SCIM Client 1.0.0
 Authorization: <Authorization credentials>
 ```
 
-The response to this request is a JSON listing of all the resources found in the SCIM app.
+The response to this request is a JSON listing of all the resources found in the SCIM application.
 
 ### Retrieving a specific user
 
@@ -273,11 +273,11 @@ Content-Type: text/json;charset=UTF-8
 
 ![Flowchart - update user (PUT)](/img/oin/scim_flow-user-update-put.png "Simple flow diagram for updating a user with a PUT operation")
 
-Updating a user refers to modifying an attribute in the Okta user profile that is mapped with an attribute in the SCIM application.
+Updating a user refers to modifying an attribute in the Okta user profile that is mapped to an attribute in the SCIM application.
 
 To update a user, you need to enable the functionality in the Okta Admin Console:
 
-1. Select the SCIM application from your list of applications.
+1. Select your SCIM integration from the list of integrations in your Okta org.
 1. Under the **Provisioning** tab, click **To App**.
 1. In the **Update User Attributes** option, click **Enable** and then **Save**.
 
@@ -414,7 +414,7 @@ Other updates to attributes in a user profile should be handled through a PUT op
 
 To deactivate users, you need to enable the functionality in the Okta Admin Console:
 
-1. Select your SCIM application from your list of applications.
+1. Select your SCIM integration from the list of integrations in your Okta org.
 1. Under the **Provisioning** tab, click **To App** and **Edit**.
 1. In the **Deactivate Users** option, click **Enable** and then **Save**.
 
@@ -485,7 +485,7 @@ If a user is suspended, deactivated, or removed from the application in Okta, th
 
 To create a group on the SCIM server, you need to push the group using the Okta Admin Console:
 
-1. Select the SCIM application from your list of applications.
+1. Select your SCIM integration from the list of integrations in your Okta org.
 1. On the **Push Groups** tab, click **Push Groups**.
 
 You can select which existing Okta group to push, either by specifying a name or a rule. For more information, see the [Using Group Push topic](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Directory_Using_Group_Push) in the Okta Help Center.
@@ -549,7 +549,7 @@ Okta uses `count=100` as the pagination reference to return up to 100 elements. 
 
 The SCIM server must consistently return the same ordering of results for the requests, regardless of which values are provided for the `count` and `startIndex` pagination references.
 
-A sample request from Okta to retrieve the groups from the SCIM app:
+A sample request from Okta to retrieve the groups from the SCIM application:
 
 ```http
 GET /scim/v1/Groups?startIndex=1&count=100 HTTP/1.1
@@ -557,7 +557,7 @@ User-Agent: Okta SCIM Client 1.0.0
 Authorization: <Authorization credentials>
 ```
 
-The response to this request is a JSON listing of all the group resources found in the SCIM app.
+The response to this request is a JSON listing of all the group resources found in the SCIM application.
 
 ### Retrieving specific groups
 
@@ -640,10 +640,10 @@ Content-Type: text/json;charset=UTF-8
 To add or remove users inside a specific pushed group on the SCIM server, Okta requires the following:
 
 * The user must be a member of the group in Okta
-* The user has been added under the **Assignments** tab of the SCIM application inside the Okta Admin Console
-* The group is pushed under the **Push Groups** tab of the SCIM application inside the Okta Admin Console
+* The user has been added under the **Assignments** tab of the SCIM integration inside the Okta Admin Console
+* The group is pushed under the **Push Groups** tab of the SCIM integration inside the Okta Admin Console
 
-If these three requirements are met, Okta sends a request to add the specified users to the group on the SCIM server. The operation can be sent as a PUT or a PATCH operation depending on the configuration of the SCIM application.
+If these three requirements are met, Okta sends a request to add the specified users to the group on the SCIM server. The operation can be sent as a PUT or a PATCH operation depending on the configuration of the SCIM integration.
 
 ```http
 PATCH /scim/v1/Groups/74094a55-c9ee-47ae-9fd4-9137deb43497 HTTP/1.1
@@ -732,7 +732,7 @@ Content-Type: text/json;charset=UTF-8
 
 **DELETE** /Groups/*$groupID*
 
-Okta administrators can remove pushed groups from the Okta Admin Console, under the **Push Groups** tab of the SCIM application.
+Okta administrators can remove pushed groups from the Okta Admin Console, under the **Push Groups** tab of the SCIM integration.
 
 On the **Push Groups** tab, click **Active** then click **Unlink pushed group**. In the dialog box that appears, you can choose whether you want to **Delete the group in the target app** or **Leave the group in the target app** on the SCIM server.
 
@@ -755,6 +755,6 @@ Date: Fri, 18 Oct 2019 07:16:10 GMT
 
 * [What is SCIM?](https://www.okta.com/blog/2017/01/what-is-scim/)
 * [SCIM Provisioning using Okta Lifecycle Management](/docs/concepts/scim/)
-* [Build a provisioning app using SCIM](/docs/guides/build-provisioning-integration/)
+* [Build a SCIM provisioning integration](/docs/guides/build-provisioning-integration/)
 * [SCIM 1.1 RFC: Core Schema](http://www.simplecloud.info/specs/draft-scim-core-schema-01.html)
 * [SCIM 1.1 RFC: Protocol](http://www.simplecloud.info/specs/draft-scim-api-01.html)

--- a/packages/@okta/vuepress-site/docs/reference/scim/scim-20/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/scim/scim-20/index.md
@@ -11,7 +11,7 @@ This reference focuses on how Okta API endpoints share information with System f
 
 This document specifically covers **Version 2.0** of the SCIM specification. For Version 1.1 of the SCIM specification, see our [SCIM 1.1 reference](/docs/reference/scim/scim-11/).
 
-The SCIM Protocol is an application-level REST protocol for provisioning and managing identity data on the web. The protocol supports creation, discovery, retrieval, and modification of core identity resources.
+The SCIM protocol is an application-level REST protocol for provisioning and managing identity data on the web. The protocol supports creation, discovery, retrieval, and modification of core identity resources.
 
 To better understand SCIM and the specific implementation of SCIM using Okta, see our [Understanding SCIM](/docs/concepts/scim/) guide or our blog post on [What is SCIM?](https://www.okta.com/blog/2017/01/what-is-scim/).
 
@@ -31,13 +31,13 @@ The User creation operation brings the user's application profile from Okta over
 
 To enable user provisioning, you must configure the provisioning options in the Okta Admin Console. In the Okta Admin Console:
 
-1. Select your SCIM application from your list of applications.
+1. Select your SCIM integration from the list of integrations in your Okta org.
 1. Under the **Provisioning** tab, click **To App** and **Edit**.
 1. In the **Create User** option, click **Enable** and then **Save**.
 
-For more information on enabling the provisioning features of your SCIM application, see [Provisioning and Deprovisioning](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Provisioning_Deprovisioning_Overview) under the **Accessing Provisioning Features** section.
+For more information on enabling the provisioning features of your SCIM integration, see [Provisioning and Deprovisioning](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Provisioning_Deprovisioning_Overview) under the **Accessing Provisioning Features** section.
 
-After you complete this step, whenever a user is assigned to the application in Okta, the following operation requests are made against the SCIM server:
+After you complete this step, whenever a user is assigned to the integration in Okta, the following operation requests are made against the SCIM server:
 
 * Determine if the user already exists
 * Create the user if the user isn't found
@@ -46,11 +46,11 @@ After you complete this step, whenever a user is assigned to the application in 
 
 **GET** /Users
 
-Okta checks that the user exists on the SCIM server through a GET operation with the `filter=userName` parameter (or any other filter parameter that was configured with the SCIM application). This check is performed using the `eq` (equal) operator and is the only one necessary to successfully provision users with Okta.
+Okta checks that the user exists on the SCIM server through a GET operation with the `filter=userName` parameter (or any other filter parameter that was configured with the SCIM integration). This check is performed using the `eq` (equal) operator and is the only one necessary to successfully provision users with Okta.
 
 > **Note:** The filter must check an attribute that is _unique_ for all users in the Service Provider profiles.
 
-For Okta Integration Network (OIN) applications, this filter is configured during the review process done by the Okta Application Analyst assigned to evaluate the application submission. Application submissions are processed through the [OIN Manager](https://oinmanager.okta.com).
+For Okta Integration Network (OIN) integrations, this filter is configured with the help of the assigned Okta App Analyst during the submission process. Integration submissions are handled through the [OIN Manager](https://oinmanager.okta.com).
 
 The requests from Okta to the Service Provider are of the form:
 
@@ -185,7 +185,7 @@ Okta uses `count=100` as the pagination reference to return up to 100 elements. 
 
 The SCIM server must consistently return the same ordering of results for the requests, regardless of which values are provided for the `count` and `startIndex` pagination references. For more information on pagination, see [Section 3.4.2.4](https://tools.ietf.org/html/rfc7644#section-3.4.2.4) of the V2.0 specification.
 
-A sample request from Okta to retrieve the users from the SCIM app:
+A sample request from Okta to retrieve the users from the SCIM application:
 
 ```http
 GET /scim/v2/Users?startIndex=1&count=100 HTTP/1.1
@@ -193,7 +193,7 @@ User-Agent: Okta SCIM Client 1.0.0
 Authorization: <Authorization credentials>
 ```
 
-The response to this request is a JSON listing of all the resources found in the SCIM app.
+The response to this request is a JSON listing of all the resources found in the SCIM application.
 
 ### Retrieving a specific user
 
@@ -241,11 +241,11 @@ Content-Type: text/json;charset=UTF-8
 
 ![Flowchart - update user (PUT)](/img/oin/scim_flow-user-update-put.png "Simple flow diagram for updating a user with a PUT operation")
 
-Updating a user refers to modifying an attribute in the Okta user profile that is mapped with an attribute in the SCIM application.
+Updating a user refers to modifying an attribute in the Okta user profile that is mapped to an attribute in the SCIM application.
 
 To update a user, you need to enable the functionality in the Okta Admin Console:
 
-1. Select the SCIM application from your list of applications.
+1. Select your SCIM integration from the list of integrations in your Okta org.
 1. Under the **Provisioning** tab, click **To App**.
 1. In the **Update User Attributes** option, click **Enable** and then **Save**.
 
@@ -373,7 +373,7 @@ Other updates to attributes in a user profile should be handled through a PUT op
 
 To deactivate users, you need to enable the functionality in the Okta Admin Console:
 
-1. Select your SCIM application from your list of applications.
+1. Select your SCIM integration from the list of integrations in your Okta org.
 1. Under the **Provisioning** tab, click **To App** and **Edit**.
 1. In the **Deactivate Users** option, click **Enable** and then **Save**.
 
@@ -445,7 +445,7 @@ If a user is suspended, deactivated, or removed from the application in Okta, th
 
 To create a group on the SCIM server, you need to push the group using the Okta Admin Console:
 
-1. Select the SCIM application from your list of applications.
+1. Select your SCIM integration from the list of integrations in your Okta org.
 1. On the **Push Groups** tab, click **Push Groups**.
 
 You can select which existing Okta group to push, either by specifying a name or a rule. For more information, see the [Using Group Push topic](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Directory_Using_Group_Push) in the Okta Help Center.
@@ -494,7 +494,7 @@ Okta uses `count=100` as the pagination reference to return up to 100 elements. 
 
 The SCIM server must consistently return the same ordering of results for the requests, regardless of which values are provided for the `count` and `startIndex` pagination references.
 
-A sample request from Okta to retrieve the groups from the SCIM app:
+A sample request from Okta to retrieve the groups from the SCIM application:
 
 ```http
 GET /scim/v2/Groups?startIndex=1&count=100 HTTP/1.1
@@ -502,7 +502,7 @@ User-Agent: Okta SCIM Client 1.0.0
 Authorization: <Authorization credentials>
 ```
 
-The response to this request is a JSON listing of all the group resources found in the SCIM app.
+The response to this request is a JSON listing of all the group resources found in the SCIM application.
 
 ### Retrieving specific groups
 
@@ -586,10 +586,10 @@ Content-Type: text/json;charset=UTF-8
 To add or remove users inside a specific pushed group on the SCIM server, Okta requires the following:
 
 * The user must be a member of the group in Okta
-* The user has been added under the **Assignments** tab of the SCIM application inside the Okta Admin Console
-* The group is pushed under the **Push Groups** tab of the SCIM application inside the Okta Admin Console
+* The user has been added under the **Assignments** tab of the SCIM integration inside the Okta Admin Console
+* The group is pushed under the **Push Groups** tab of the SCIM integration inside the Okta Admin Console
 
-If these three requirements are met, Okta sends a request to add the specified users to the group on the SCIM server. The operation can be sent as a PUT or a PATCH operation depending on the configuration of the SCIM application.
+If these three requirements are met, Okta sends a request to add the specified users to the group on the SCIM server. The operation can be sent as a PUT or a PATCH operation depending on the configuration of the SCIM integration.
 
 ```http
 PATCH /scim/v2/Groups/abf4dd94-a4c0-4f67-89c9-76b03340cb9b HTTP/1.1
@@ -669,7 +669,7 @@ Authorization: <Authorization credentials>
 
 **DELETE** /Groups/*$groupID*
 
-Okta administrators can remove pushed groups from the Okta Admin Console, under the **Push Groups** tab of the SCIM application.
+Okta administrators can remove pushed groups from the Okta Admin Console, under the **Push Groups** tab of the SCIM integration.
 
 On the **Push Groups** tab, click **Active** then click **Unlink pushed group**. In the dialog box that appears, you can choose whether you want to **Delete the group in the target app** or **Leave the group in the target app** on the SCIM server.
 
@@ -692,7 +692,7 @@ Date: Tue, 10 Sep 2019 05:29:25 GMT
 
 * [What is SCIM?](https://www.okta.com/blog/2017/01/what-is-scim/)
 * [SCIM Provisioning using Okta Lifecycle Management](/docs/concepts/scim/)
-* [Build a provisioning app using SCIM](/docs/guides/build-provisioning-integration/)
+* [Build a SCIM provisioning integration](/docs/guides/build-provisioning-integration/)
 * [SCIM 2.0 RFC: Core Schema](https://tools.ietf.org/html/rfc7643)
 * [SCIM 2.0 RFC: Protocol](https://tools.ietf.org/html/rfc7644)
 * [SCIM 2.0 RFC: Definitions and Use Cases](https://tools.ietf.org/html/rfc7642)

--- a/packages/@okta/vuepress-site/docs/reference/scim/scim-20/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/scim/scim-20/index.md
@@ -23,11 +23,11 @@ To better understand SCIM and the specific implementation of SCIM using Okta, se
 
 ## SCIM User operations
 
-### Creating users
+### Create users
 
-![Flowchart - create user](/img/oin/scim_flow-user-create.png "Simple flow diagram for create user process")
+![Flowchart - create User](/img/oin/scim_flow-user-create.png "Simple flow diagram for create User process")
 
-The User creation operation brings the user's application profile from Okta over to the Service Provider. A user's application profile represents the key-value attributes defined on the **Profile** tab when a user is added.
+The User creation operation brings the user's application profile from Okta over to the Service Provider. A user's application profile represents the key-value attributes defined on the **Profile** tab when a User object is added.
 
 To enable user provisioning, you must configure the provisioning options in the Okta Admin Console. In the Okta Admin Console:
 
@@ -39,16 +39,16 @@ For more information on enabling the provisioning features of your SCIM integrat
 
 After you complete this step, whenever a user is assigned to the integration in Okta, the following operation requests are made against the SCIM server:
 
-* Determine if the user already exists
-* Create the user if the user isn't found
+* Determine if the User object already exists
+* Create the User if the User object isn't found
 
-#### Determine if the user already exists
+#### Determine if the User already exists
 
 **GET** /Users
 
-Okta checks that the user exists on the SCIM server through a GET operation with the `filter=userName` parameter (or any other filter parameter that was configured with the SCIM integration). This check is performed using the `eq` (equal) operator and is the only one necessary to successfully provision users with Okta.
+Okta checks that the User object exists on the SCIM server through a GET operation with the `filter=userName` parameter (or any other filter parameter that was configured with the SCIM integration). This check is performed using the `eq` (equal) operator and is the only one necessary to successfully provision users with Okta.
 
-> **Note:** The filter must check an attribute that is _unique_ for all users in the Service Provider profiles.
+> **Note:** The filter must check an attribute that is _unique_ for all Users in the Service Provider profiles.
 
 For Okta Integration Network (OIN) integrations, this filter is configured with the help of the assigned Okta App Analyst during the submission process. Integration submissions are handled through the [OIN Manager](https://oinmanager.okta.com).
 
@@ -60,7 +60,7 @@ User-Agent: Okta SCIM Client 1.0.0
 Authorization: <Authorization credentials>
 ```
 
-The SCIM application checks the filter provided and returns an empty response if no users match the filter criteria. For example:
+The SCIM application checks the filter provided and returns an empty response if no Users match the filter criteria. For example:
 
 ```http
 HTTP/1.1 200 OK
@@ -76,7 +76,7 @@ Content-Type: text/json;charset=UTF-8
 }
 ```
 
-Another acceptable response from the SCIM application if no users match the filter criteria is to return the error schema response:
+Another acceptable response from the SCIM application if no User objects match the filter criteria is to return the error schema response:
 
 ```http
 HTTP/1.1 404 Not Found
@@ -92,11 +92,11 @@ Content-Type: text/html; charset=UTF-8
 
 If the SCIM server does return a user, Okta automatically matches the result with the user in Okta, sending the user application profile to the SCIM server.
 
-#### Create the user
+#### Create the User
 
 **POST** /Users
 
-If the user isn't found on the SCIM server, then Okta attempts to create it through a POST operation that contains the user application profile. The request looks like the following:
+If the User object isn't found on the SCIM server, then Okta attempts to create it through a POST operation that contains the user's application profile. The request looks like the following:
 
 ```http
 POST /scim/v2/Users HTTP/1.1
@@ -124,7 +124,7 @@ Authorization: <Authorization credentials>
 }
 ```
 
-The response from the SCIM server contains the created user profile:
+The response from the SCIM server contains the created user's profile:
 
 ```http
 HTTP/1.1 201 Created
@@ -159,7 +159,7 @@ If the SCIM server returns an empty response body to the provisioning request, t
 
 "Automatic provisioning of user `userName` to app `AppName` failed: Error while creating user `displayName`: Create new user returned empty user."
 
-If the user that Okta tries to create already exists in the Service Provider application, then the Service Provider needs to respond with an error schema to stop the provisioning job. The response looks like the following:
+If the User that Okta tries to create already exists in the Service Provider application, then the Service Provider needs to respond with an error schema to stop the provisioning job. The response looks like the following:
 
 ```http
 HTTP/1.1 409 Conflict
@@ -173,11 +173,11 @@ Content-Type: text/json;charset=UTF-8
 }
 ```
 
-### Retrieving users
+### Retrieve Users
 
 **GET** /Users
 
-When importing users from the SCIM server, Okta accesses the `/Users` endpoint and processes them page by page, using `startIndex`, `count`, and `totalResults` as pagination references. Similarly, when returning large lists of resources, your SCIM implementation must support pagination. Using a limit of `count` results and an offset of `startIndex` returns smaller groupings of resources in a request.
+When importing Users from the SCIM server, Okta accesses the `/Users` endpoint and processes them page by page, using `startIndex`, `count`, and `totalResults` as pagination references. Similarly, when returning large lists of resources, your SCIM implementation must support pagination. Using a limit of `count` results and an offset of `startIndex` returns smaller groupings of resources in a request.
 
 > **Note:** The `itemsPerPage`, `startIndex`, and `totalResults` values need to be exchanged as integers, not as strings.
 
@@ -185,7 +185,7 @@ Okta uses `count=100` as the pagination reference to return up to 100 elements. 
 
 The SCIM server must consistently return the same ordering of results for the requests, regardless of which values are provided for the `count` and `startIndex` pagination references. For more information on pagination, see [Section 3.4.2.4](https://tools.ietf.org/html/rfc7644#section-3.4.2.4) of the V2.0 specification.
 
-A sample request from Okta to retrieve the users from the SCIM application:
+A sample request from Okta to retrieve the Users from the SCIM application:
 
 ```http
 GET /scim/v2/Users?startIndex=1&count=100 HTTP/1.1
@@ -193,13 +193,13 @@ User-Agent: Okta SCIM Client 1.0.0
 Authorization: <Authorization credentials>
 ```
 
-The response to this request is a JSON listing of all the resources found in the SCIM application.
+The response to this request is a JSON list of all the resources found in the SCIM application.
 
-### Retrieving a specific user
+### Retrieve a specific User
 
 **GET** /Users/*$userID*
 
-Okta can also run a GET operation to check if a specific user still exists on the SCIM server. The request looks like the following:
+Okta can also run a GET operation to check if a specific User still exists on the SCIM server. The request looks like the following:
 
 ```http
 GET /scim/v2/Users/23a35c27-23d3-4c03-b4c5-6443c09e7173 HTTP/1.1
@@ -207,7 +207,7 @@ User-Agent: Okta SCIM Client 1.0.0
 Authorization: <Authorization credentials>
 ```
 
-The response from the server is the user profile:
+The response from the server is the user's profile:
 
 ```http
 HTTP/1.1 200 OK
@@ -237,23 +237,23 @@ Content-Type: text/json;charset=UTF-8
 }
 ```
 
-### Updating a specific user (PUT)
+### Update a specific User (PUT)
 
-![Flowchart - update user (PUT)](/img/oin/scim_flow-user-update-put.png "Simple flow diagram for updating a user with a PUT operation")
+![Flowchart - update User (PUT)](/img/oin/scim_flow-user-update-put.png "Simple flow diagram for updating a User with a PUT operation")
 
-Updating a user refers to modifying an attribute in the Okta user profile that is mapped to an attribute in the SCIM application.
+Updating a User refers to modifying an attribute in the Okta user's profile that is mapped to an attribute in the SCIM application.
 
-To update a user, you need to enable the functionality in the Okta Admin Console:
+To update a User, you need to enable the functionality in the Okta Admin Console:
 
 1. Select your SCIM integration from the list of integrations in your Okta org.
 1. Under the **Provisioning** tab, click **To App**.
 1. In the **Update User Attributes** option, click **Enable** and then **Save**.
 
-#### Retrieve the user profile
+#### Retrieve the User profile
 
 **GET** /Users/*$userID*
 
-To update a user profile, Okta first makes a GET request to `/Users/${userID}` and retrieves the body of the user's SCIM profile:
+To update a User profile, Okta first makes a GET request to `/Users/${userID}` and retrieves the body of the user's SCIM profile:
 
 ```http
 GET /scim/v2/Users/23a35c27-23d3-4c03-b4c5-6443c09e7173 HTTP/1.1
@@ -291,7 +291,7 @@ Content-Type: text/json;charset=UTF-8
 }
 ```
 
-#### Update the user profile
+#### Update the User profile
 
 **PUT** /Users/*$userID*
 
@@ -355,29 +355,29 @@ Content-Type: text/json;charset=UTF-8
 }
 ```
 
-### Updating a specific user (PATCH)
+### Update a specific User (PATCH)
 
-![Flowchart - update user (PATCH)](/img/oin/scim_flow-user-update-patch.png "Simple flow diagram for updating a user with a PATCH operation")
+![Flowchart - update User (PATCH)](/img/oin/scim_flow-user-update-patch.png "Simple flow diagram for updating a User with a PATCH operation")
 
 **PATCH** /Users/*$userID*
 
-A user resource can be updated through a PATCH operation for the following actions:
+A User object can be updated through a PATCH operation for the following actions:
 
-* Activating a user
-* Deactivating a user
-* Syncing the user password
+* Activating a User
+* Deactivating a User
+* Syncing the User password
 
 The `active` attribute in a user profile represents the user's current status.  
 
-Other updates to attributes in a user profile should be handled through a PUT operation.
+Other updates to attributes in a user's profile should be handled through a PUT operation.
 
-To deactivate users, you need to enable the functionality in the Okta Admin Console:
+To deactivate Users, you need to enable the functionality in the Okta Admin Console:
 
 1. Select your SCIM integration from the list of integrations in your Okta org.
 1. Under the **Provisioning** tab, click **To App** and **Edit**.
 1. In the **Deactivate Users** option, click **Enable** and then **Save**.
 
-When a user is deactivated, Okta sends this request:
+When a User is deactivated, Okta sends this request:
 
 ```http
 PATCH /scim/v2/Users/23a35c27-23d3-4c03-b4c5-6443c09e7173 HTTP/1.1
@@ -427,32 +427,32 @@ Content-Type: text/json;charset=UTF-8
 
 > **Note:** The SCIM server response to PATCH operation requests can also be a HTTP 204 response, with no body returned.
 
-### Deleting users
+### Delete Users
 
-![Flowchart - deprovision user](/img/oin/scim_flow-user-deprovision.png "Simple flow diagram for deprovisioning a user")
+![Flowchart - deprovision User](/img/oin/scim_flow-user-deprovision.png "Simple flow diagram for deprovisioning a User")
 
 **DELETE** /Users/*$userID*
 
-Okta doesn't perform DELETE operations on users in your SCIM application.
+Okta doesn't perform DELETE operations on User objects in your SCIM application.
 
-If a user is suspended, deactivated, or removed from your integration inside Okta, then Okta sends a PATCH request to your SCIM application to set the `active` attribute to `false`.
+If a User is suspended, deactivated, or removed from your integration inside Okta, then Okta sends a PATCH request to your SCIM application to set the `active` attribute to `false`.
 
 For a detailed explanation on deleting user profiles, see [Delete (Deprovision)](/docs/concepts/scim/#delete-deprovision).
 
 ## SCIM Group operations
 
-### Creating groups
+### Create Groups
 
 **POST** /Groups
 
-To create a group on the SCIM server, you need to push the group using the Okta Admin Console:
+To create a Group on the SCIM server, you need to push the Group using the Okta Admin Console:
 
 1. Select your SCIM integration from the list of integrations in your Okta org.
 1. On the **Push Groups** tab, click **Push Groups**.
 
-You can select which existing Okta group to push, either by specifying a name or a rule. For more information, see the [Using Group Push topic](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Directory_Using_Group_Push) in the Okta Help Center.
+You can select which existing Okta Group to push, either by specifying a name or a rule. For more information, see the [Using Group Push topic](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Directory_Using_Group_Push) in the Okta Help Center.
 
-After the group is selected, Okta makes a POST request to the Service Provider:
+After the Group is selected, Okta makes a POST request to the Service Provider:
 
 ```http
 POST /scim/v2/Groups HTTP/1.1
@@ -466,7 +466,7 @@ Authorization: <Authorization credentials>
 }
 ```
 
-When it receives this request, the SCIM server responds with the group details as it would for a GET operation to the `/Groups/${groupID}/`:
+When it receives this request, the SCIM server responds with the Group details as it would for a GET operation to the `/Groups/${groupID}/`:
 
 ```http
 HTTP/1.1 201 Created
@@ -484,11 +484,11 @@ Content-Type: text/json;charset=UTF-8
 }
 ```
 
-### Retrieving groups
+### Retrieve Groups
 
 **GET** /Groups
 
-When importing groups from the SCIM server, Okta accesses the `/Groups` endpoint and processes them page by page, using the `startIndex`, `count`, and `totalResults` values for reference. Similarly, when returning large lists of resources, your SCIM implementation must support pagination. Using a limit of `count` results and an offset of `startIndex` returns smaller groupings of resources in a request.
+When importing Groups from the SCIM server, Okta accesses the `/Groups` endpoint and processes them page by page, using the `startIndex`, `count`, and `totalResults` values for reference. Similarly, when returning large lists of resources, your SCIM implementation must support pagination. Using a limit of `count` results and an offset of `startIndex` returns smaller groupings of resources in a request.
 
 > **Note:** The `itemsPerPage`, `startIndex`, and `totalResults` values need to be exchanged as integers, not as strings.
 
@@ -496,7 +496,7 @@ Okta uses `count=100` as the pagination reference to return up to 100 elements. 
 
 The SCIM server must consistently return the same ordering of results for the requests, regardless of which values are provided for the `count` and `startIndex` pagination references.
 
-A sample request from Okta to retrieve the groups from the SCIM application:
+A sample request from Okta to retrieve the Groups from the SCIM application:
 
 ```http
 GET /scim/v2/Groups?startIndex=1&count=100 HTTP/1.1
@@ -504,9 +504,9 @@ User-Agent: Okta SCIM Client 1.0.0
 Authorization: <Authorization credentials>
 ```
 
-The response to this request is a JSON listing of all the group resources found in the SCIM application.
+The response to this request is a JSON list of all the Group objects found in the SCIM application.
 
-### Retrieving specific groups
+### Retrieve specific Groups
 
 **GET** /Groups/*$groupID*
 
@@ -536,11 +536,11 @@ Content-Type: text/json;charset=UTF-8
 }
 ```
 
-### Updating a specific group name
+### Update a specific group name
 
 **PATCH** /Groups/*$groupID*
 
-Updates to existing group names for existing Okta groups are handled by a PATCH operation. The group must already be pushed out to the SCIM server.
+Updates to existing Group names for existing Okta Groups are handled by a PATCH operation. The Group must already be pushed out to the SCIM server.
 
 ```http
 PATCH /scim/v2/Groups/abf4dd94-a4c0-4f67-89c9-76b03340cb9b HTTP/1.1
@@ -581,15 +581,15 @@ Content-Type: text/json;charset=UTF-8
 
 > **Note:** The SCIM server response to PATCH operation requests can also be a HTTP 204 response, with no body returned.
 
-### Updating specific group membership
+### Update specific group membership
 
 **PATCH** /Groups/*$groupID*
 
 To add or remove users inside a specific pushed group on the SCIM server, Okta requires the following:
 
-* The user must be a member of the group in Okta
-* The user has been added under the **Assignments** tab of the SCIM integration inside the Okta Admin Console
-* The group is pushed under the **Push Groups** tab of the SCIM integration inside the Okta Admin Console
+* The User must be a member of the group in Okta.
+* The User has been added under the **Assignments** tab of the SCIM integration inside the Okta Admin Console.
+* The group is pushed under the **Push Groups** tab of the SCIM integration inside the Okta Admin Console.
 
 If these three requirements are met, Okta sends a request to add the specified users to the group on the SCIM server. The operation can be sent as a PUT or a PATCH operation depending on the configuration of the SCIM integration.
 
@@ -633,9 +633,9 @@ Content-Type: text/json;charset=UTF-8
 }
 ```
 
-In this example, the `members` attribute is returned with a null value. Okta doesn't require the list of users to be returned, but it does require the other details about the group.
+In this example, the `members` attribute is returned with a null value. Okta doesn't require the list of users to be returned, but it does require the other details about the Group.
 
-You can also pass a full push of the group membership to the SCIM server using the `replace` operation. This operation replaces all the group members with the supplied resource values.
+You can also send a full push of the Group membership to the SCIM server using the `replace` operation. This operation replaces all the group members with the supplied object values.
 
 ```http
 PATCH /scim/v2/Groups/abf4dd94-a4c0-4f67-89c9-76b03340cb9b HTTP/1.1
@@ -667,11 +667,11 @@ Authorization: <Authorization credentials>
 
 > **Note:** The SCIM server response to PATCH operation requests can also be a HTTP 204 response, with no body returned.
 
-### Deleting a specific group
+### Delete a specific group
 
 **DELETE** /Groups/*$groupID*
 
-Okta administrators can remove pushed groups from the Okta Admin Console, under the **Push Groups** tab of the SCIM integration.
+Okta administrators can remove pushed Groups from the Okta Admin Console, under the **Push Groups** tab of the SCIM integration.
 
 On the **Push Groups** tab, click **Active** then click **Unlink pushed group**. In the dialog box that appears, you can choose whether you want to **Delete the group in the target app** or **Leave the group in the target app** on the SCIM server.
 

--- a/packages/@okta/vuepress-site/docs/reference/scim/scim-20/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/scim/scim-20/index.md
@@ -429,13 +429,15 @@ Content-Type: text/json;charset=UTF-8
 
 ### Deleting users
 
-![Flowchart - delete user](/img/oin/scim_flow-user-deprovision.png "Simple flow diagram for deprovisioning a user")
+![Flowchart - deprovision user](/img/oin/scim_flow-user-deprovision.png "Simple flow diagram for deprovisioning a user")
 
 **DELETE** /Users/*$userID*
 
-Okta doesn't perform DELETE operations on users.
+Okta doesn't perform DELETE operations on users in your SCIM application.
 
-If a user is suspended, deactivated, or removed from the application in Okta, then Okta sends a PATCH request to set the `active` attribute to `false`.
+If a user is suspended, deactivated, or removed from your integration inside Okta, then Okta sends a PATCH request to your SCIM application to set the `active` attribute to `false`.
+
+For a detailed explanation on deleting user profiles, see [Delete (Deprovision)](/docs/concepts/scim/#delete-deprovision).
 
 ## SCIM Group operations
 


### PR DESCRIPTION
## Description:
- **What's changed?**
1. Clarify the difference between "App" and "Integration" in SCIM Guide
    * This update changes most of the files in the SCIM guide, concept and reference topics to clarify when we mean an "integration" (an Okta thing) and and "application" (a customer's cloud application). There was a fair amount of ambiguity in the use of these terms throughout our SCIM documentation, so this set of changes aims to correct that.
2. Clarify the deletion action in SCIM applications
    * In several places we discuss the DELETE operation for SCIM provisioning, but there is not a clear outline of what happens when the deletion of the user resource occurs on the Okta integration side, or on the customer's SCIM application end.
    * A single set of rules has been laid out in the concepts topic, and all references to deletions in the SCIM guide and reference topics have been updated to point to that set of rules.

- **Is this PR related to a Monolith release?** 
No

### Resolves:

* [OKTA-297173](https://oktainc.atlassian.net/browse/OKTA-297173)
* [OKTA-179948](https://oktainc.atlassian.net/browse/OKTA-179948)