### PR TITLE
OKTA-299825: Improves the consistency of the `/logs` API rate limits section wrt to other pages

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
@@ -814,7 +814,8 @@ Exceeding the rate limit results in:
 ```
 
 ### Rate Limits
-Callers are limited to 60 queries max per minute.
+
+See the tables entries for `/api/v1/logs` in [Rate Limits](/docs/reference/rate-limits/) for details.
 
 ## Data Retention
 


### PR DESCRIPTION
#  Description:
- **What's changed?** Improves the consistency of the `/logs` API rate limits section wrt to other pages
- **Is this PR related to a Monolith release?** No
### Resolves:

* [OKTA-299825](https://oktainc.atlassian.net/browse/OKTA-299825)

![image](https://user-images.githubusercontent.com/25536705/82602147-a4b91900-9b7e-11ea-9756-04fec7ff020d.png)
