### PR TITLE
prevent 'cannot read property offsetTop of null' from crashing page

### DIFF
--- a/packages/@okta/vuepress-theme-prose/components/OnThisPageItem.vue
+++ b/packages/@okta/vuepress-theme-prose/components/OnThisPageItem.vue
@@ -53,7 +53,10 @@ export default {
       }
     
       if(hash) {
-        window.scrollTo(0, document.querySelector(hash).offsetTop - document.querySelector('.fixed-header').clientHeight - 45);
+        const node = document.querySelector(hash);
+        if(node) { // node is sometimes null - perhaps content hasn't loaded?
+          window.scrollTo(0, node.offsetTop - document.querySelector('.fixed-header').clientHeight - 45);
+        }
       }
     }
   }


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** 
  - prevent 'cannot read property offsetTop of null' from crashing page

- **Is this PR related to a Monolith release?** <!-- If so, which one? -->
  - No
### Resolves:  
![image](https://user-images.githubusercontent.com/492300/84086901-c9462b00-a99d-11ea-9b9a-df6ffffe2902.png)

