### PR TITLE
fix: add missing config for nodejs express-auth-code - OKTA-302260

### DIFF
--- a/packages/@okta/vuepress-site/quickstart-fragments/nodejs/express-auth-code/index.md
+++ b/packages/@okta/vuepress-site/quickstart-fragments/nodejs/express-auth-code/index.md
@@ -22,6 +22,8 @@ To use ExpressOIDC you create an instance of the middleware by passing the neede
 <DomainAdminWarning />
 
 ```javascript
+const express = require('express');
+const app = express();
 const session = require('express-session');
 const { ExpressOIDC } = require('@okta/oidc-middleware');
 
@@ -37,7 +39,8 @@ const oidc = new ExpressOIDC({
   client_id: '{clientId}',
   client_secret: '{clientSecret}',
   redirect_uri: 'http://localhost:3000/authorization-code/callback',
-  scope: 'openid profile'
+  scope: 'openid profile',
+  appBaseUrl: '{appBaseUrl}' // In this example, it should be http://localhost:3000
 });
 
 // ExpressOIDC will attach handlers for the /login and /authorization-code/callback routes


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
Adding `appBaseUrl` config for express auth code guide
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-302260](https://oktainc.atlassian.net/browse/OKTA-302260)
