### PR TITLE
Update SCIM concept topic links to h.o.c

### DIFF
--- a/packages/@okta/vuepress-site/docs/concepts/scim/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/scim/index.md
@@ -17,9 +17,9 @@ SCIM, or the [System for Cross-domain Identity Management](http://www.simpleclou
 
 The goal of SCIM is to securely automate the exchange of user identity data between your company's cloud applications and any service providers, such as enterprise SaaS applications.
 
-Managing user lifecycles in your organization is a fundamental business problem. Hiring new employees is just the first step - you also need to provision the applications that they need for their job, enforce the corporate security policies, and update their user accounts as they advance through their time with your company. At the end of their employment period, you need to make sure that all access is quickly and thoroughly revoked across all applications. Handling all of this can be a time-consuming and error-prone process if done manually.
+Managing user's lifecycle in your organization is a fundamental business problem. Hiring new employees is just the first step - you also need to provision the applications that they need for their job, enforce the corporate security policies, and update their user accounts as they advance through their time with your company. At the end of their employment period, you need to make sure that all access is quickly and thoroughly revoked across all applications. Handling all of this can be a time-consuming and error-prone process if done manually.
 
-![SCIM Lifecycle](/img/oin/scim_lifecycle.png "User lifecycle diagram: 1 - new employee 2 - provision applications 3 - enforce security 4 - update user information 5 - offboard")
+![SCIM Lifecycle](/img/oin/scim_lifecycle.png "User lifecycle diagram: 1 - new employee 2 - provision applications 3 - enforce security 4 - update user information 5 - off-board")
 
 As your company grows, the number of user accounts and provisioned software applications increases exponentially. Requests to add and remove users, reset passwords, change permissions, and add new types of accounts all take up valuable IT department time.
 
@@ -126,5 +126,5 @@ If you want to read more about how to use the Okta Admin Console to set up provi
 
 For setting up Active Directory or LDAP for profile mastering:
 
-* [Install and configure the Okta Active Directory agent](https://help.okta.com/en/prod/Content/Topics/Directory/ad-agent-install.htm)
-* [Manage LDAP provisioning, import, and integration settings](https://help.okta.com/en/prod/Content/Topics/Directory/ldap-agent-configure.htm)
+* [Manage your Active Directory integration](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_okta_active_directory_agent)
+* [Manage your LDAP provisioning integration](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_LDAP_Provisioning)

--- a/packages/@okta/vuepress-site/docs/concepts/scim/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/scim/index.md
@@ -17,7 +17,7 @@ SCIM, or the [System for Cross-domain Identity Management](http://www.simpleclou
 
 The goal of SCIM is to securely automate the exchange of user identity data between your company's cloud applications and any service providers, such as enterprise SaaS applications.
 
-Managing user's lifecycle in your organization is a fundamental business problem. Hiring new employees is just the first step - you also need to provision the applications that they need for their job, enforce the corporate security policies, and update their user accounts as they advance through their time with your company. At the end of their employment period, you need to make sure that all access is quickly and thoroughly revoked across all applications. Handling all of this can be a time-consuming and error-prone process if done manually.
+Managing user lifecycles in your organization is a fundamental business problem. Hiring new employees is just the first step - you also need to provision the applications that they need for their job, enforce the corporate security policies, and update their user accounts as they advance through their time with your company. At the end of their employment period, you need to make sure that all access is quickly and thoroughly revoked across all applications. Handling all of this can be a time-consuming and error-prone process if done manually.
 
 ![SCIM Lifecycle](/img/oin/scim_lifecycle.png "User lifecycle diagram: 1 - new employee 2 - provision applications 3 - enforce security 4 - update user information 5 - off-board")
 


### PR DESCRIPTION
## Description:
- **What's changed?**
Updates the links from the SCIM concept topic to the AD and LDAP guides in h.o.c - they were not using the aliases, so when those topics were relocated, the links broke.

- **Is this PR related to a Monolith release?** 
Nope
### Resolves:

* [OKTA-309457](https://oktainc.atlassian.net/browse/OKTA-309457)
