### PR TITLE
Update index to have link to /docs

### DIFF
--- a/packages/@okta/vuepress-site/index.md
+++ b/packages/@okta/vuepress-site/index.md
@@ -1,0 +1,1 @@
+This page is not part of the standard okta-developer-docs repository. This page is maintained by the Web team.  Please [go to the docs page](/docs) to begin your adventure with the okta-developer-docs repository.


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** If you go to the root of the domain `localhost:8080` when you are developing, this PR adds a note about going to `/docs` instead with a link.
- **Is this PR related to a Monolith release?** No

<img width="1392" alt="Screen Shot 2020-07-08 at 12 28 54 PM" src="https://user-images.githubusercontent.com/1906920/86945292-e3973400-c116-11ea-8fea-05ac85423c99.png">

This will only show up during development.  `developer.okta.com/` is handled by AWS

### Resolves:

* [OKTA-305658](https://oktainc.atlassian.net/browse/OKTA-305658)
