### PR TITLE
Standardizes support instructions for guides

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/add-an-external-idp/before-you-begin/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/add-an-external-idp/before-you-begin/index.md
@@ -10,7 +10,7 @@ We also support additional services such as directories and credential providers
 
 This guide assumes that you:
 
-* Have an Okta Developer Edition organization. [Create one for free](https://developer.okta.com/signup).
+* Have an Okta Developer Edition organization. Don't have one? [Create one for free](https://developer.okta.com/signup).
 * Have an application that you want to add authentication to.
 
 > **Note:** This guide doesn't explain the differences between SAML and OpenID Connect and doesn't help you choose between them. See [External Identity Providers](/docs/concepts/identity-providers/#the-big-picture) for more information.

--- a/packages/@okta/vuepress-site/docs/guides/add-an-external-idp/before-you-begin/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/add-an-external-idp/before-you-begin/index.md
@@ -10,7 +10,7 @@ We also support additional services such as directories and credential providers
 
 This guide assumes that you:
 
-* Have an Okta Developer Edition organization. (Don't have one? [Create one for free](https://developer.okta.com/signup).)
+* Have an Okta Developer Edition organization. [Create one for free](https://developer.okta.com/signup).
 * Have an application that you want to add authentication to.
 
 > **Note:** This guide doesn't explain the differences between SAML and OpenID Connect and doesn't help you choose between them. See [External Identity Providers](/docs/concepts/identity-providers/#the-big-picture) for more information.
@@ -27,5 +27,9 @@ We support a lot of Identity Providers. This guide provides instructions for the
 * [Okta to Okta](/docs/guides/add-an-external-idp/oktatookta/create-an-app-at-idp/)
 * [OpenID Connect](/docs/guides/add-an-external-idp/openidconnect/create-an-app-at-idp/)
 * [SAML 2.0](/docs/guides/add-an-external-idp/saml2/create-an-app-at-idp/)
+
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/add-an-external-idp/next-steps/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/add-an-external-idp/next-steps/index.md
@@ -1,7 +1,7 @@
 ---
 title: Next steps
 ---
-You should now understand how to add an external Identity Provider and have successfully <GuideLink link="../create-an-app-at-idp">added</GuideLink> and <GuideLink link="../use-idp-to-sign-in">tested the authorization URL</GuideLink> with the external Identity Provider. If you got stuck, post a question in our [Developer Forums](https://devforum.okta.com).
+You should now understand how to add an external Identity Provider and have successfully <GuideLink link="../create-an-app-at-idp">added</GuideLink> and <GuideLink link="../use-idp-to-sign-in">tested the authorization URL</GuideLink> with the external Identity Provider.
 
 To add another Identity Provider:
 * If you have already created an app at the Identity Provider, start by <GuideLink link="../configure-idp-in-okta">configuring the Identity Provider in Okta</GuideLink>.
@@ -14,5 +14,3 @@ For more information about topics mentioned in this guide:
 * [Concepts: External Identity Providers](/docs/concepts/identity-providers/)
 * [Implement the Implicit Flow](/docs/guides/implement-implicit/overview/)
 * [Implement the Authorization Code Flow](/docs/guides/implement-auth-code/overview/)
-
-

--- a/packages/@okta/vuepress-site/docs/guides/build-custom-ui-mobile/before-you-begin/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-custom-ui-mobile/before-you-begin/index.md
@@ -4,12 +4,17 @@ title: Before you begin
 You can connect your mobile app to Okta and sign users in by [opening a browser](/docs/guides/sign-into-mobile-app/before-you-begin/). But, if you prefer that your users not leave your app, you need to build a custom sign-in UI with native controls and screens instead. Use this guide to build a customized sign-in experience inside your mobile application.
 
 This guide assumes that:
-* You have an Okta Developer organization. Don't have one? [Create one for free](https://developer.okta.com/signup).
+
+* You have an Okta Developer organization. [Create one for free](https://developer.okta.com/signup).
 * You have an app that you want to add a custom UI to
 * You have already walked through the [Sign users in to your mobile app](/docs/guides/sign-into-mobile-app/) guide.
 
 > **Note:** If the browser sign-in works for your application, we recommend using that since building a custom sign-in UI takes more effort and development time.
 
 <StackSelector snippet="sample" />
+
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/build-custom-ui-mobile/before-you-begin/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-custom-ui-mobile/before-you-begin/index.md
@@ -5,7 +5,7 @@ You can connect your mobile app to Okta and sign users in by [opening a browser]
 
 This guide assumes that:
 
-* You have an Okta Developer organization. [Create one for free](https://developer.okta.com/signup).
+* You have an Okta Developer organization. Don't have one? [Create one for free](https://developer.okta.com/signup).
 * You have an app that you want to add a custom UI to
 * You have already walked through the [Sign users in to your mobile app](/docs/guides/sign-into-mobile-app/) guide.
 

--- a/packages/@okta/vuepress-site/docs/guides/build-custom-ui-mobile/next-steps/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-custom-ui-mobile/next-steps/index.md
@@ -1,7 +1,7 @@
 ---
 title: Next steps
 ---
-You should now understand how to build a custom UI in your mobile application. If you got stuck, post a question in our [Developer Forums](https://devforum.okta.com).
+You should now understand how to build a custom UI in your mobile application.
 
 ## What's next
 When a user signs in, their profile information (stored in Okta) is made available to your application. It's common to use this information to update your app's UI.

--- a/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/next-steps/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/next-steps/index.md
@@ -3,8 +3,6 @@ title: Next Steps
 ---
 You should now have a SCIM integration that has been successfully built and tested.
 
-If you have any problems with your integration, contact <developers@okta.com>, or post a question in our [Developer Forum](https://devforum.okta.com).
-
 After you have completed your testing and your integration is working as expected, you can start the submission process to have your integration included in the [Okta Integration Network](https://www.okta.com/okta-integration-network/) (OIN).
 
 Our [Submit an app integration](/docs/guides/submit-app) guide takes you through the steps required to submit your SCIM integration through the OIN Manager site.

--- a/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-provisioning-integration/overview/index.md
@@ -10,10 +10,12 @@ While many ISVs have custom APIs for managing user accounts, this guide assumes 
 
 Your Okta integration should use Single Sign-On (SSO) to initiate end-user authentication. Learn how to set up your integration with SSO in our [Build a Single Sign-On (SSO) integration](/docs/guides/build-sso-integration/) guide.
 
-If you need additional assistance, read through our [SCIM FAQ](/docs/concepts/scim/faqs/) page, post your question on the [Okta Developer Forums](https://devforum.okta.com/), or email us at <developers@okta.com>.
-
 ## Submit your integration
 
 After you have prepared and tested your SCIM integration, and you want to make it public, you can follow the steps in our [Submit an app integration](/docs/guides/submit-app) guide to have it published in the [Okta Integration Network (OIN) catalog](https://www.okta.com/integrations/).
+
+# Support
+
+If you need additional assistance, read through our [SCIM FAQ](/docs/concepts/scim/faqs/) page, post your question on the [Okta Developer Forums](https://devforum.okta.com/), or email us at <developers@okta.com>.
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/build-self-signed-jwt/next-steps/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-self-signed-jwt/next-steps/index.md
@@ -2,4 +2,4 @@
 title: Next Steps
 ---
 
-You should now understand how to build a JWT. If you got stuck, post a question in our [Developer Forum](https://devforum.okta.com).
+You should now understand how to build a JWT.

--- a/packages/@okta/vuepress-site/docs/guides/build-self-signed-jwt/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-self-signed-jwt/overview/index.md
@@ -25,4 +25,8 @@ Which JWT type that you use depends on the client authentication method configur
 
 > **Tip:** Don't know which method is configured for your client app? You can quickly check the settings by doing a GET to `https://${yourOktaDomain}/api/v1/apps/${appId}`.
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/build-sso-integration/before-you-begin/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-sso-integration/before-you-begin/index.md
@@ -6,6 +6,8 @@ After you have decided which protocol is right for your needs, you need to gathe
 
 <StackSelector snippet="prep" />
 
+## Support
+
 If you have questions at any point during the creation of your integration, send an email to <developers@okta.com> or research your questions on a relevant developer site:
 
 OIDC

--- a/packages/@okta/vuepress-site/docs/guides/create-an-api-token/create-the-token/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/create-an-api-token/create-the-token/index.md
@@ -3,22 +3,22 @@ title: Create the token
 ---
 To create an API token, follow these steps:
 
-1.  Sign in to your Okta organization as a user with [administrator privileges](https://help.okta.com/en/prod/Content/Topics/Security/Administrators.htm?cshid=Security_Administrators#Security_Administrators).
+1. Sign in to your Okta organization as a user with [administrator privileges](https://help.okta.com/en/prod/Content/Topics/Security/Administrators.htm?cshid=Security_Administrators#Security_Administrators).
 
      API tokens have the same permissions as the user who creates them, and if the user permissions change, the API token permissions also change.
 
     See the note above on <GuideLink link="../overview/#privilege-level">Privilege level</GuideLink>, regarding the use of a service account when creating an API token, to specifically control the privilege level associated with the token.
-    
+
     If you don't have an Okta organization, you can [create one for free](https://developer.okta.com/signup).
 
-2.  Access the API page:
+2. Access the API page:
     - If you use the Developer Console, select **Tokens** from the **API** menu.
     - If you use the Administrator Console (Classic UI), select **API** from the **Security** menu, and then select **Tokens**.
 
-3.  Click **Create Token**.
+3. Click **Create Token**.
 
-4.  Name your token and click **Create Token**.
+4. Name your token and click **Create Token**.
 
-5.  Record the token value. This is the only opportunity to see it and record it.
+5. Record the token value. This is the only opportunity to see it and record it.
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/create-an-api-token/next-steps/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/create-an-api-token/next-steps/index.md
@@ -9,4 +9,3 @@ With the token created, you can begin using it, supplying it in the `Authorizati
 * For information on the general principles the Okta API follows, see [API Overview](/docs/reference/api-overview/).
 
 * For reference documentation for each API, see [API Reference](/docs/reference/).
-

--- a/packages/@okta/vuepress-site/docs/guides/create-an-api-token/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/create-an-api-token/overview/index.md
@@ -17,4 +17,8 @@ Different Okta API operations require different admin privilege levels. API toke
 
 As an alternative to Okta API tokens, you can now interact with Okta APIs using scoped OAuth 2.0 access tokens for a number of Okta endpoints. Each access token enables the bearer to perform specific actions on specific Okta endpoints, with that ability controlled by which scopes the access token contains. For more information, see the [OAuth for Okta](/docs/guides/implement-oauth-for-okta/) guide.
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/custom-error-pages/next-steps/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-error-pages/next-steps/index.md
@@ -3,8 +3,6 @@ title: Next steps
 ---
 You should now understand how to customize the error page.
 
-If you have any issues or problems, post your question in our [Developer Forums](https://devforum.okta.com).
-
 Read more about other customization options:
 
 * [Customize the Okta URL domain](/docs/guides/custom-url-domain/)

--- a/packages/@okta/vuepress-site/docs/guides/custom-error-pages/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-error-pages/overview/index.md
@@ -22,4 +22,8 @@ Before you can get started customizing error pages, you must have already [custo
 
 A custom error page appears only when an application connects to Okta using your custom domain. Otherwise, the default Okta error page appears.
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/custom-hosted-signin/next-steps/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-hosted-signin/next-steps/index.md
@@ -1,7 +1,7 @@
 ---
 title: Next steps
 ---
-You should now understand how to customize the hosted sign-in page. If you got stuck, post a question in our [Developer Forums](https://devforum.okta.com).
+You should now understand how to customize the hosted sign-in page.
 
 Read more about other customization options:
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-hosted-signin/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-hosted-signin/overview/index.md
@@ -17,4 +17,8 @@ Yes. See the <GuideLink link="../customization-examples/#per-application-customi
 ## Before you begin
 Before you can get started customizing your hosted sign-in page, you must have already customized your [Okta URL domain](/docs/guides/custom-url-domain/).
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/next-steps/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/next-steps/index.md
@@ -1,7 +1,7 @@
 ---
 title: Next steps
 ---
-You should now understand how to customize the Okta URL domain. If you got stuck, post a question in our [Developer Forums](https://devforum.okta.com).
+You should now understand how to customize the Okta URL domain.
 
 Read more about other customization options:
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/overview/index.md
@@ -29,4 +29,8 @@ No. You can only have one custom domain set up per Okta organization.
 **Will the existing Okta domain work?**
 Yes. When you turn the custom domain on, the Okta domain (for example, `example.okta.com`) still works.
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/customize-authz-server/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-authz-server/overview/index.md
@@ -16,4 +16,8 @@ If you only need one authorization server, but you'd like to know more about cus
 
 > **Note:** For a high-level explanation of OAuth 2.0 and OpenID Connect see our [OAuth 2.0 Overview](/docs/concepts/auth-overview/). See [Authorization Servers](/docs/concepts/auth-servers) for more information on the types of authorization servers available to you and what you can use them for.
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/customize-tokens-returned-from-okta/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-tokens-returned-from-okta/overview/index.md
@@ -5,8 +5,12 @@ Tokens contain claims that are statements about the subject, such as name, role,
 
 This guide assumes that you:
 
-* Have an Okta Developer Edition organization. Don't have one? [Create an org for free](https://developer.okta.com/signup).
+* Have an Okta Developer Edition organization. [Create an org for free](https://developer.okta.com/signup).
 * Have an [OpenID Connect client application](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Apps_App_Integration_Wizard-oidc) in Okta with at least [one user assigned to it](https://help.okta.com/en/prod/okta_help_CSH.htm#ext-assign-apps).
 * Have a [group in Okta](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Directory_Groups) with at least one person assigned to it.
+
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/enable-cors/next-steps/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/enable-cors/next-steps/index.md
@@ -1,7 +1,7 @@
 ---
 title: Next steps
 ---
-You should now understand how to configure Cross-Origin Resource Sharing for your org. If you got stuck, post a question in our [Developer Forum](https://devforum.okta.com).
+You should now understand how to configure Cross-Origin Resource Sharing for your org.
 
 ## Read more
 

--- a/packages/@okta/vuepress-site/docs/guides/enable-cors/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/enable-cors/overview/index.md
@@ -20,4 +20,8 @@ Not all browsers supports CORS. The following table describes which browsers sup
 
 > **Note:** IE8 and IE9 don't support authenticated requests and can't use the Okta session cookie with CORS.
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/find-your-app-credentials/findcreds/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/find-your-app-credentials/findcreds/index.md
@@ -11,5 +11,3 @@ To find your Application's credentials:
 5. Copy the client ID and/or client secret using the **Copy to Clipboard** buttons to the right of each text field.
 
 ![Application Client Credentials section with Client ID and Client Secret fields](/img/app-client-credentials-section.png "Application Client Credentials section with Client ID and Client Secret fields")
-
-If you're stuck and need help, post a question on our [Developer Forum](https://devforum.okta.com).

--- a/packages/@okta/vuepress-site/docs/guides/find-your-app-credentials/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/find-your-app-credentials/overview/index.md
@@ -12,4 +12,8 @@ Or this one:
 
 The first step in building an Application with Okta is creating an Okta Application resource that represents your project. Okta generates credentials for you (called a client ID and client secret) that you copy into your code to associate your project with the Okta Application.
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/find-your-domain/findorg/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/find-your-domain/findorg/index.md
@@ -19,5 +19,3 @@ Your Okta domain looks like:
 * `example.okta-emea.com`
 
 See [Okta Organizations](/docs/concepts/okta-organizations/) for more information on the types of Okta orgs.
-
-If you're stuck and need help, post a question on our [Developer Forum](https://devforum.okta.com).

--- a/packages/@okta/vuepress-site/docs/guides/find-your-domain/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/find-your-domain/overview/index.md
@@ -8,4 +8,8 @@ If you're building an application using one of our SDKs or client libraries, you
 
 Okta orgs host pages on subdomains and each org is assigned a URL. The typical org URL is the tenant name (the subdomain), and then the domain name.
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/implement-auth-code-pkce/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-auth-code-pkce/overview/index.md
@@ -14,4 +14,8 @@ The Authorization Code Flow with PKCE is the standard Code flow with an extra st
 
 For more information on the authorization code with PKCE flow, including why to use it, see our [OAuth 2.0 Overview](/docs/concepts/auth-overview/#authorization-code-with-pkce-flow).
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/implement-auth-code/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-auth-code/overview/index.md
@@ -14,4 +14,8 @@ At a high-level, this flow has the following steps:
 
 For more information on the authorization code flow, including why to use it, see [our OAuth 2.0 overview](/docs/concepts/auth-overview/#authorization-code-flow).
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/implement-client-creds/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-client-creds/overview/index.md
@@ -7,4 +7,8 @@ The Client Credentials flow is recommended for use in machine-to-machine authent
 - Your application passes its client credentials to your Okta authorization server.
 - If the credentials are accurate, Okta responds with an access token.
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/implement-implicit/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-implicit/overview/index.md
@@ -15,4 +15,8 @@ At a high level, the Implicit flow has the following steps:
 
 For more information on the Implicit flow, see our [OAuth 2.0 overview](/docs/concepts/auth-overview/#implicit-flow).
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta-serviceapp/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta-serviceapp/overview/index.md
@@ -8,7 +8,7 @@ Most Okta API endpoints require that you include an API token with your request.
 
 To use this guide, you need the following:
 
-* An Okta developer org. (Don't have one? [Create an org for free](https://developer.okta.com/signup).)
+* An Okta developer org. [Create an org for free](https://developer.okta.com/signup).
 * [Postman client](https://www.getpostman.com/downloads/) to test requests with the access token. See [Get Started with the Okta APIs](https://developer.okta.com/code/rest/) for information on setting up Postman.
 
 ## Use the Client Credentials grant flow
@@ -23,5 +23,9 @@ The following are the high-level steps required to perform the Client Credential
 1. Create a JSON Web Token (JWT) token and sign it using the private key for use as the client assertion when making the `/token` endpoint API call.
 
 > **Note:** At this time, OAuth for Okta works only with the APIs listed on the [Scopes and supported endpoints](/docs/guides/implement-oauth-for-okta/scopes/) page. We are actively working towards supporting additional APIs. Our goal is to cover all public Okta API endpoints.
+
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta/create-oauth-app/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta/create-oauth-app/index.md
@@ -3,7 +3,7 @@ title: Create an OAuth 2.0 app in Okta
 ---
 Create the client application that you want to use with the Okta APIs.
 
-1. Sign in to your Okta organization as a user with administrative privileges. Don't have one? [Create an org for free](https://developer.okta.com/signup).
+1. Sign in to your Okta organization as a user with administrative privileges. [Create an org for free](https://developer.okta.com/signup).
 
     > **Note:** Make sure that you are using the Developer Console. If you see Admin Console in the top left of the page, click it and select **Developer Console** to switch.
 

--- a/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta/overview/index.md
@@ -16,9 +16,13 @@ Scoped access tokens have a number of advantages, including:
 
 To use this guide, you need the following:
 
-* An Okta developer org. (Don't have one? [Create an org for free](https://developer.okta.com/signup).)
+* An Okta developer org. [Create an org for free](https://developer.okta.com/signup).
 * [Postman client](https://www.getpostman.com/downloads/) to test requests with the access token. See [Get Started with the Okta APIs](https://developer.okta.com/code/rest/) for information on setting up Postman.
 
 > **Note:** At this time, OAuth for Okta works only with the APIs listed in the <GuideLink link="../scopes">Scopes and supported endpoints</GuideLink> section. We are actively working towards supporting additional APIs. Our goal is to cover all public Okta API endpoints.
+
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/implement-password/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-password/overview/index.md
@@ -12,4 +12,8 @@ At a high-level, this flow has the following steps:
 
 For more information on the resource owner password flow, including why to use it, see [our OAuth 2.0 overview](/docs/concepts/auth-overview/#resource-owner-password-flow).
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/mfa/next-steps/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/mfa/next-steps/index.md
@@ -2,8 +2,7 @@
 title: Next steps
 ---
 
-At this point, you should understand how to use the Okta API to add MFA to an existing application. You can learn more about using the
-Okta MFA API using the following resources:
+At this point, you should understand how to use the Okta API to add MFA to an existing application. You can learn more about using the Okta MFA API using the following resources:
 
 * The [design principles for the Okta API](/docs/reference/api-overview/)
 * The API documentation for the [Okta Factors API](/docs/reference/api/factors/)

--- a/packages/@okta/vuepress-site/docs/guides/mfa/prerequisites/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/mfa/prerequisites/index.md
@@ -12,7 +12,7 @@ in an idiomatic way.
 
 This guide assumes that you have:
 
-* An Okta Developer Edition organization. [Create one for free](https://developer.okta.com/signup)
+* An Okta Developer Edition organization. Don't have one? [Create one for free](https://developer.okta.com/signup)
 * [Postman configured](/code/rest/) to make API requests to your Developer Edition org
 * The Users API and Factors API [Postman collections](/docs/reference/postman-collections/)
 * [Created an API token](/docs/guides/create-an-api-token/) for your Okta org

--- a/packages/@okta/vuepress-site/docs/guides/mfa/prerequisites/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/mfa/prerequisites/index.md
@@ -12,9 +12,13 @@ in an idiomatic way.
 
 This guide assumes that you have:
 
-* An Okta Developer Edition organization. (Don't have one? [Create one for free](https://developer.okta.com/signup))
+* An Okta Developer Edition organization. [Create one for free](https://developer.okta.com/signup)
 * [Postman configured](/code/rest/) to make API requests to your Developer Edition org
 * The Users API and Factors API [Postman collections](/docs/reference/postman-collections/)
 * [Created an API token](/docs/guides/create-an-api-token/) for your Okta org
+
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/password-import-hook/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/password-import-hook/overview/index.md
@@ -6,10 +6,12 @@ This guide is about coding an external service to respond to calls from the Pass
 
 * See [Password Import Inline Hook](/docs/reference/password-hook/) for a complete description of this Inline Hook type.
 
-* See [Inline Hooks](/docs/concepts/inline-hooks/) for a general conceptual overview of how Okta Inline Hooks work. 
+* See [Inline Hooks](/docs/concepts/inline-hooks/) for a general conceptual overview of how Okta Inline Hooks work.
 
 The sample code presented in this guide is meant as a demonstration of the steps any external service for the Password Import Inline Hook needs to implement: parsing requests from Okta, looking up received end user credentials in an existing user store, and responding to Okta with commands that indicate whether the end user credentials are valid.
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
 <NextSectionLink/>
-
-

--- a/packages/@okta/vuepress-site/docs/guides/protect-your-api/before-you-begin/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/protect-your-api/before-you-begin/index.md
@@ -7,11 +7,15 @@ These steps apply to back-end APIs that are serving [single-page apps](/docs/gui
 
 This guide assumes that you:
 
-* Have an Okta Developer Edition organization. (Don't have one? [Create one for free](https://developer.okta.com/signup).)
+* Have an Okta Developer Edition organization. [Create one for free](https://developer.okta.com/signup).
 * Have a project or application that you want to add authentication to.
 
 If you don't have an existing app, or are new to building apps, start with this documentation:
 
 <StackSelector snippet="create-app"/>
+
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/protect-your-api/before-you-begin/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/protect-your-api/before-you-begin/index.md
@@ -7,7 +7,7 @@ These steps apply to back-end APIs that are serving [single-page apps](/docs/gui
 
 This guide assumes that you:
 
-* Have an Okta Developer Edition organization. [Create one for free](https://developer.okta.com/signup).
+* Have an Okta Developer Edition organization. Don't have one? [Create one for free](https://developer.okta.com/signup).
 * Have a project or application that you want to add authentication to.
 
 If you don't have an existing app, or are new to building apps, start with this documentation:

--- a/packages/@okta/vuepress-site/docs/guides/protect-your-api/next-steps/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/protect-your-api/next-steps/index.md
@@ -1,7 +1,7 @@
 ---
 title: Next steps
 ---
-You should now understand how to protect your API. If you got stuck, post a question in our [Developer Forums](https://devforum.okta.com).
+You should now understand how to protect your API.
 
 Read about customization options:
 

--- a/packages/@okta/vuepress-site/docs/guides/refresh-tokens/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/refresh-tokens/overview/index.md
@@ -12,4 +12,8 @@ Refresh tokens are available for a subset of Okta OAuth 2.0 client applications,
 
 Be sure to specify `refresh_token` as a `data_type` value for the `grant_type` parameter when adding an [OAuth client app](/docs/reference/api/apps/#add-oauth-2-0-client-application) using the `/apps` API. Alternatively, after you set up an application, you can select the **Refresh Token** option for **Allowed grant types** on the **General Settings** tab in the Admin Console.
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/request-user-consent/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/request-user-consent/overview/index.md
@@ -8,7 +8,7 @@ If you want users to acknowledge and accept that they are giving an app access t
 
 This guide assumes that you:
 
-* Have an Okta Developer Edition org. Don't have one? [Create an org for free](https://developer.okta.com/signup).
+* Have an Okta Developer Edition org. [Create an org for free](https://developer.okta.com/signup).
 * Have an [OpenID Connect client application](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Apps_App_Integration_Wizard-oidc) in Okta with at least [one user assigned to it](https://help.okta.com/en/prod/okta_help_CSH.htm#ext-assign-apps).
 
 ## User consent and tokens
@@ -18,5 +18,9 @@ User consent represents a user's explicit permission to allow an application to 
 When an application needs to get a new access token from an authorization server, the user isn't prompted for consent if they have already consented to the specified scopes. Consent grants remain valid until the user or admin manually revokes them, or until the user, application, authorization server, or scope is deactivated or deleted.
 
 > **Note:** The user only has to grant consent once for an attribute per authorization server.
+
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/revoke-tokens/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/revoke-tokens/overview/index.md
@@ -20,4 +20,8 @@ http --form POST https://${yourOktaDomain}/oauth2/v1/revoke \
 
 See [Revoke a token](/docs/reference/api/oidc/#revoke) in the Okta OpenID Connect & OAuth 2.0 API reference.
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/saml-tracer/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/saml-tracer/overview/index.md
@@ -232,3 +232,7 @@ RKvwyyTfqfq9pgSmB9xNVJIeVZbbZGTlNGqJti24E0AiIPggtxg5NJ+HHnEQ5RxdSsR4fbMz9i0K
 ```
 
 SAML responses are signed, and contain the profile attributes of the person who requested access to the app, as set in the General tab of the administrator UI.
+
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).

--- a/packages/@okta/vuepress-site/docs/guides/session-cookie/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/session-cookie/overview/index.md
@@ -170,3 +170,7 @@ GET /app/template_wsfed/k9x69oiKYSUWMIYZBKTY/sso/wsfed/passive?wa=wsignin1.0&wtr
 Host: your-domain.okta.com
 Accept: */*
 ```
+
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).

--- a/packages/@okta/vuepress-site/docs/guides/set-up-event-hook/ongoing-delivery-of-events/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/set-up-event-hook/ongoing-delivery-of-events/index.md
@@ -9,4 +9,3 @@ Every time an event of a type that the Event Hook is subscribed to occurs in you
 ## Next Steps
 
 See the Event Hooks [Overview](/docs/concepts/event-hooks/) for more information on Event Hooks.
-

--- a/packages/@okta/vuepress-site/docs/guides/set-up-event-hook/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/set-up-event-hook/overview/index.md
@@ -9,5 +9,8 @@ Event Hooks are outbound calls from Okta that can be used to notify your own sof
 1. Verify to Okta that you control the endpoint.
 1. Begin receiving ongoing delivery of event notifications.
 
-<NextSectionLink/>
+## Support
 
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
+<NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/shared-sso-android-ios/next-steps/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/shared-sso-android-ios/next-steps/index.md
@@ -1,7 +1,7 @@
 ---
 title: Next steps
 ---
-You should now have a better understanding of how a sign-in session is shared between two mobile apps on a device and can then use the steps in the guide to help you configure your own apps. If you got stuck, post a question in our [Developer Forums](https://devforum.okta.com).
+You should now have a better understanding of how a sign-in session is shared between two mobile apps on a device and can then use the steps in the guide to help you configure your own apps.
 
 To learn more about our Mobile OpenID Connect (OIDC) SDKs and sample apps:
 

--- a/packages/@okta/vuepress-site/docs/guides/shared-sso-android-ios/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/shared-sso-android-ios/overview/index.md
@@ -7,11 +7,15 @@ This guide uses sample apps to demonstrate the concept of sharing a Single Sign-
 
 This guide assumes that you:
 
-* Have an Okta Developer Edition organization. (Don't have one? [Create one for free](https://developer.okta.com/signup).)
+* Have an Okta Developer Edition organization. [Create one for free](https://developer.okta.com/signup).
 * Are using Android Studio with an emulator for Android testing
 * Are using Xcode with a simulator for iOS testing
-* Downloaded the appropriate apps to use for testing purposes: 
+* Downloaded the appropriate apps to use for testing purposes:
 
     <StackSelector snippet="sampleapp" />
+
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/shared-sso-android-ios/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/shared-sso-android-ios/overview/index.md
@@ -7,7 +7,7 @@ This guide uses sample apps to demonstrate the concept of sharing a Single Sign-
 
 This guide assumes that you:
 
-* Have an Okta Developer Edition organization. [Create one for free](https://developer.okta.com/signup).
+* Have an Okta Developer Edition organization. Don't have one? [Create one for free](https://developer.okta.com/signup).
 * Are using Android Studio with an emulator for Android testing
 * Are using Xcode with a simulator for iOS testing
 * Downloaded the appropriate apps to use for testing purposes:

--- a/packages/@okta/vuepress-site/docs/guides/sharing-cert/next-steps/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sharing-cert/next-steps/index.md
@@ -1,7 +1,7 @@
 ---
 title: Next steps
 ---
-You should now understand how to share application key credentials between apps. If you got stuck, post a question in our [Developer Forum](https://devforum.okta.com).
+You should now understand how to share application key credentials between apps.
 
 Read more in our API Reference docs:
 

--- a/packages/@okta/vuepress-site/docs/guides/sharing-cert/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sharing-cert/overview/index.md
@@ -21,4 +21,8 @@ For this example, we assume that you want to share a certificate between two ins
 
 This example also works if the apps are two instances of the same app or two different apps.
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app/before-you-begin/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app/before-you-begin/index.md
@@ -7,10 +7,14 @@ If you are building a web application, see [Sign users in to your web applicatio
 
 This guide assumes that you:
 
-* Have an Okta Developer Edition organization. (Don't have one? [Create one for free](https://developer.okta.com/signup).)
+* Have an Okta Developer Edition organization. [Create one for free](https://developer.okta.com/signup).
 * Know the basics of building mobile apps.
 * Have a project or app that you want to add authentication to.
 
 <StackSelector snippet="sample"/>
+
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app/before-you-begin/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app/before-you-begin/index.md
@@ -7,7 +7,7 @@ If you are building a web application, see [Sign users in to your web applicatio
 
 This guide assumes that you:
 
-* Have an Okta Developer Edition organization. [Create one for free](https://developer.okta.com/signup).
+* Have an Okta Developer Edition organization. Don't have one? [Create one for free](https://developer.okta.com/signup).
 * Know the basics of building mobile apps.
 * Have a project or app that you want to add authentication to.
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app/next-steps/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app/next-steps/index.md
@@ -1,7 +1,7 @@
 ---
 title: Next steps
 ---
-You should now understand how to sign users in to your mobile applications using Okta. If you got stuck, post a question in our [Developer Forums](https://devforum.okta.com).
+You should now understand how to sign users in to your mobile applications using Okta.
 
 In this guide you signed users in to your app by opening a browser. To learn how to customize the sign-in page displayed in the browser, see [Customize the Okta-hosted sign-in page](/docs/guides/custom-hosted-signin/).
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/before-you-begin/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/before-you-begin/index.md
@@ -7,7 +7,7 @@ If you are building a web application rendered by a server, see [Sign users in t
 
 This guide assumes that you:
 
-* Have an Okta Developer Edition organization. [Create one for free](https://developer.okta.com/signup).
+* Have an Okta Developer Edition organization. Don't have one? [Create one for free](https://developer.okta.com/signup).
 * Know the basics of building JavaScript applications.
 * Have a project or application that you want to add authentication to.
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/before-you-begin/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/before-you-begin/index.md
@@ -7,12 +7,16 @@ If you are building a web application rendered by a server, see [Sign users in t
 
 This guide assumes that you:
 
-* Have an Okta Developer Edition organization. (Don't have one? [Create one for free](https://developer.okta.com/signup).)
+* Have an Okta Developer Edition organization. [Create one for free](https://developer.okta.com/signup).
 * Know the basics of building JavaScript applications.
 * Have a project or application that you want to add authentication to.
 
 If you don't have an existing app, or are new to building apps, start with this documentation:
 
 <StackSelector snippet="create-app"/>
+
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/next-steps/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/next-steps/index.md
@@ -1,7 +1,7 @@
 ---
 title: Next steps
 ---
-You should now understand how to sign users in to your single-page applications using Okta. If you got stuck, post a question in our [Developer Forum](https://devforum.okta.com).
+You should now understand how to sign users in to your single-page applications using Okta.
 
 Read more:
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/before-you-begin/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/before-you-begin/index.md
@@ -7,7 +7,7 @@ If you are building a single-page (browser) app, see [Sign users in to your sing
 
 This guide assumes that you:
 
-* Have an Okta Developer Edition organization. [Create one for free](https://developer.okta.com/signup).
+* Have an Okta Developer Edition organization. Don't have one? [Create one for free](https://developer.okta.com/signup).
 * Know the basics of building Web applications.
 * Have a project or application that you want to add authentication to.
 * Are building a web app that's rendered by a server.

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/before-you-begin/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/before-you-begin/index.md
@@ -7,7 +7,7 @@ If you are building a single-page (browser) app, see [Sign users in to your sing
 
 This guide assumes that you:
 
-* Have an Okta Developer Edition organization. (Don't have one? [Create one for free](https://developer.okta.com/signup).)
+* Have an Okta Developer Edition organization. [Create one for free](https://developer.okta.com/signup).
 * Know the basics of building Web applications.
 * Have a project or application that you want to add authentication to.
 * Are building a web app that's rendered by a server.
@@ -15,5 +15,9 @@ This guide assumes that you:
 If you don't have an existing app, or are new to building apps, start with this documentation:
 
 <StackSelector snippet="create-app"/>
+
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/next-steps/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/next-steps/index.md
@@ -1,7 +1,7 @@
 ---
 title: Next steps
 ---
-You should now understand how to sign users in to your web applications using Okta. If you got stuck, post a question in our [Developer Forum](https://devforum.okta.com).
+You should now understand how to sign users in to your web applications using Okta.
 
 Read more:
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-users-out/before-you-begin/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-users-out/before-you-begin/index.md
@@ -7,10 +7,14 @@ If you are building a web app that is served by a server framework, see [Sign us
 
 This guide assumes that you:
 
-* Have an Okta Developer Edition organization. (Don't have one? [Create one for free](https://developer.okta.com/signup).)
-* Already followed one of our sign-in guides: 
-    * [Sign users in to your web app](/docs/guides/sign-into-web-app/) 
-    * [Sign users in to your single-page app](/docs/guides/sign-into-spa/)
-    * [Sign users in to your mobile app](/docs/guides/sign-into-mobile-app/)
+* Have an Okta Developer Edition organization. [Create one for free](https://developer.okta.com/signup).
+* Already followed one of our sign-in guides:
+  * [Sign users in to your web app](/docs/guides/sign-into-web-app/)
+  * [Sign users in to your single-page app](/docs/guides/sign-into-spa/)
+  * [Sign users in to your mobile app](/docs/guides/sign-into-mobile-app/)
+
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/sign-users-out/before-you-begin/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-users-out/before-you-begin/index.md
@@ -7,7 +7,7 @@ If you are building a web app that is served by a server framework, see [Sign us
 
 This guide assumes that you:
 
-* Have an Okta Developer Edition organization. [Create one for free](https://developer.okta.com/signup).
+* Have an Okta Developer Edition organization. Don't have one? [Create one for free](https://developer.okta.com/signup).
 * Already followed one of our sign-in guides:
   * [Sign users in to your web app](/docs/guides/sign-into-web-app/)
   * [Sign users in to your single-page app](/docs/guides/sign-into-spa/)

--- a/packages/@okta/vuepress-site/docs/guides/sign-users-out/next-steps/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-users-out/next-steps/index.md
@@ -1,7 +1,7 @@
 ---
 title: Next steps
 ---
-You should now understand how to sign users out of your app and out of Okta. If you got stuck, post a question in our [Developer Forum](https://devforum.okta.com).
+You should now understand how to sign users out of your app and out of Okta.
 
 Read more:
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-your-own-saml-csr/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-your-own-saml-csr/overview/index.md
@@ -26,4 +26,8 @@ The general procedure is the same for both the Outbound and Inbound SAML applica
 
 For information on using the Postman REST API test client for these steps, see [Get Started with the Okta REST APIs](/code/rest/).
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/sign-your-own-saml-csr/upload-the-certificate/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-your-own-saml-csr/upload-the-certificate/index.md
@@ -14,4 +14,3 @@ For Outbound SAML, complete the following four steps.
 4. Perform the setup for your app again, using the instructions provided. During this setup, you upload the certificate in a specified format, the metadata, or the certificate fingerprint.
 
 For Inbound SAML, follow the existing procedures for your setup.
-

--- a/packages/@okta/vuepress-site/docs/guides/unlock-mobile-app-with-biometrics/next-steps/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/unlock-mobile-app-with-biometrics/next-steps/index.md
@@ -1,7 +1,7 @@
 ---
 title: Next steps
 ---
-You should now understand how to unlock a mobile app with biometrics. If you got stuck, post a question in our [Developer Forums](https://devforum.okta.com).
+You should now understand how to unlock a mobile app with biometrics.
 
 ## Sample applications
 

--- a/packages/@okta/vuepress-site/docs/guides/unlock-mobile-app-with-biometrics/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/unlock-mobile-app-with-biometrics/overview/index.md
@@ -12,4 +12,8 @@ The refresh token is used to get new access tokens. Access tokens allow your mob
 
 By storing the refresh token on the device and encrypting it with a biometric challenge, you can safely keep the user signed in, but require the user to pass a biometric challenge to keep using the app. This means that the user must sign in with their password the first time, but can then use their fingerprint or face to unlock the app after that.
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/updating-saml-cert/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/updating-saml-cert/overview/index.md
@@ -17,7 +17,6 @@ As instructed, upload the SHA256 certificate to the ISV.
 
 ### Existing SAML 2.0 App Integrations
 
-
 To update existing app integrations, there are four steps to follow.
 
   1. List your apps and get the app id, name, and label for each app to update.<br />For each app to update, perform the following steps.<br />
@@ -78,5 +77,9 @@ Where:
 `<application id>` is the application ID you used in Step 1.
 
 > **Note:** Certificates downloaded with this method contain the Begin Certificate and End Certificate lines.
+
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/validate-access-tokens/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/validate-access-tokens/overview/index.md
@@ -45,7 +45,7 @@ You will have to decode the access token, which is in JWT format.  This involves
 - Verify the Token Signature
 - Verify the Claims
 
-Okta provides libraries to perform these steps for you: 
+Okta provides libraries to perform these steps for you:
 <StackSelector snippet="accesstoken"/>
 
 Don't see the language you're working in? Get in touch: <developers@okta.com>
@@ -56,3 +56,6 @@ Alternatively, you can also validate an access or refresh Token using the Token 
 
 This incurs a network request which is slower to do verification, but can be used when you want to guarantee that the access token hasn't been revoked.
 
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).

--- a/packages/@okta/vuepress-site/docs/guides/validate-id-tokens/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/validate-id-tokens/overview/index.md
@@ -72,4 +72,6 @@ The Okta JWT Verifier is available for the following languages:
 - [Node.js](https://github.com/okta/okta-oidc-js/tree/master/packages/jwt-verifier)
 - [PHP](https://github.com/okta/okta-jwt-verifier-php)
 
-Don't see the language you're working in? Get in touch: <developers@okta.com>
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).


### PR DESCRIPTION
## Description:
- **What's changed?** 

For all guides in the library:
* Moved (or added) instructions on how to get support through the developer forum from the last page of the guide to the first page
* Shortened the text pointing developers to get a free developer org, as it was wrapping weirdly in all the guides.
* Cleaned up a few places where there were extra spaces or new lines at the ends of files.


- **Is this PR related to a Monolith release?**
No

### Resolves:

* [OKTA-311865](https://oktainc.atlassian.net/browse/OKTA-311865)
