### PR TITLE
Update verify push factor polling doc

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/factors/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/factors/index.md
@@ -3087,9 +3087,13 @@ Polls a push verification transaction for completion. The transaction result is 
 {
   "expiresAt": "2015-04-01T15:57:32.000Z",
   "factorResult": "WAITING",
+  "profile":{
+     "credentialId":"jane.doe@example.com",
+     ...
+  },
   "_links": {
     "poll": {
-      "href": "https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/opfh52xcuft3J4uZc0g3/transactions/mst1eiHghhPxf0yhp0g",
+      "href": "https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/opfh52xcuft3J4uZc0g3/transactions/v2mst.GldKV5VxTrifyeZmWSQguA",
       "hints": {
         "allow": [
           "GET"
@@ -3097,7 +3101,7 @@ Polls a push verification transaction for completion. The transaction result is 
       }
     },
     "cancel": {
-      "href": "https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/opfh52xcuft3J4uZc0g3/transactions/mst1eiHghhPxf0yhp0g",
+      "href": "https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/opfh52xcuft3J4uZc0g3/transactions/v2mst.GldKV5VxTrifyeZmWSQguA",
       "hints": {
         "allow": [
           "DELETE"
@@ -3121,6 +3125,10 @@ Polls a push verification transaction for completion. The transaction result is 
 ```json
 {
   "factorResult": "REJECTED",
+  "profile":{
+     "credentialId":"jane.doe@example.com",
+     ...
+  },
   "_links": {
     "verify": {
       "href": "https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/opfh52xcuft3J4uZc0g3/verify",
@@ -3148,6 +3156,10 @@ Polls a push verification transaction for completion. The transaction result is 
 ```json
 {
   "factorResult": "TIMEOUT",
+  "profile":{
+     "credentialId":"jane.doe@example.com",
+     ...
+  },
   "_links": {
     "verify": {
       "href": "https://${yourOktaDomain}/api/v1/users/00u15s1KDETTQMQYABRL/factors/opfh52xcuft3J4uZc0g3/verify",


### PR DESCRIPTION
Update verify push factor polling doc to include profile information

The example responses provided in the push factor polling api doc do not display the additional `profile` metadata that is returned. `profile` contains a lot of information like `username`, `deviceType`, `name`, `platform`, `version` and `keys` [[examples here](https://oktainc.atlassian.net/browse/OKTA-210969?focusedCommentId=1341314)] But since we dont want to go into too much detail in example doc, I have added only username in `profile` metadata and replaced additional details with `...`


Resolves: OKTA-210969

<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
The example responses for verify push factor polling doc [[linked here](https://developer.okta.com/docs/reference/api/factors/#verify-a-push-factor-challenge)] do not contain the profile information . Updating the examples to reflect the correct response.

- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-210969](https://oktainc.atlassian.net/browse/OKTA-210969)
