### PR TITLE
Add missing "next" button when creating an OIDC app

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/create-okta-application/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/create-okta-application/index.md
@@ -7,12 +7,14 @@ Start by signing in to the Okta Developer Console:
 
 <a href="https://login.okta.com/" target="_blank" class="Button--blue">Go to Console</a>
 
-1. Select **Applications**, then **Add Application**. Pick **Web** as the platform. Enter a name for your application (or leave the default value).
+1. Select **Applications**, then **Add Application**. Pick **Web** as the platform. Click **Next**.
 
-2. Add the **Base URI** of your application during local development, such as `http://localhost:3000`. Also, add any base URIs where your application runs in production, such as `https://app.example.com`.
+2. Enter a name for your application (or leave the default value).
 
-3. Next, enter values for the **Login redirect URI**. This is the callback described in <GuideLink link="../define-callback">Understand the callback route</GuideLink>. Add values for local development (such as `http://localhost:8080/authorization-code/callback`) and production (such as `https://app.example.com/authorization-code/callback`).
+3. Add the **Base URI** of your application during local development, such as `http://localhost:3000`. Also, add any base URIs where your application runs in production, such as `https://app.example.com`.
 
-4. Click **Done** to finish creating the Okta application. You need to copy some values into your code later, so leave the Developer Console open.
+4. Next, enter values for the **Login redirect URI**. This is the callback described in <GuideLink link="../define-callback">Understand the callback route</GuideLink>. Add values for local development (such as `http://localhost:8080/authorization-code/callback`) and production (such as `https://app.example.com/authorization-code/callback`).
+
+5. Click **Done** to finish creating the Okta application. You need to copy some values into your code later, so leave the Developer Console open.
 
 <NextSectionLink/>


### PR DESCRIPTION
There is a page change in the middle of step one
Maybe just splitting it into another step would help?

The diff looks worse than it is, the actual change is probably 50 characters