### PR TITLE
Correct invalid config in spring-boot example

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/configure-packages/springboot/configmid.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/configure-packages/springboot/configmid.md
@@ -6,7 +6,7 @@ okta.oauth2.clientId={clientId}
 okta.oauth2.clientSecret={clientSecret}
 
 # Customize the callback route path
-security.oauth2.sso.loginPath=/authorization-code/callback
+okta.oauth2.redirect-uri=/authorization-code/callback
 ```
 
 Take a look at the [Spring Boot Externalized Configuration](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html) for details on other ways to configure properties.

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/configure-packages/springboot/configmid.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/configure-packages/springboot/configmid.md
@@ -2,7 +2,7 @@ Edit `src/main/resources/application.properties` and update these values to incl
 
 ```properties
 okta.oauth2.issuer=https://${yourOktaDomain}/oauth2/default
-okta.oauth2.clientId={clientId}
+okta.oauth2.client-id={clientId}
 okta.oauth2.client-secret={clientSecret}
 
 # Customize the callback route path

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/configure-packages/springboot/configmid.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/configure-packages/springboot/configmid.md
@@ -3,7 +3,7 @@ Edit `src/main/resources/application.properties` and update these values to incl
 ```properties
 okta.oauth2.issuer=https://${yourOktaDomain}/oauth2/default
 okta.oauth2.clientId={clientId}
-okta.oauth2.clientSecret={clientSecret}
+okta.oauth2.client-secret={clientSecret}
 
 # Customize the callback route path
 okta.oauth2.redirect-uri=/authorization-code/callback


### PR DESCRIPTION
The first step in this example was previously updated, but this step which contains the full config was never updated
