### PR TITLE
204 response for user deletion operation

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/users/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/users/index.md
@@ -2418,7 +2418,7 @@ is required to delete the user.
 ##### Response Parameters
 
 
-Returns an empty object.
+`204 No Content`
 
 Passing an invalid `id` returns a `404 Not Found` status code with error code `E0000007`.
 
@@ -2437,10 +2437,7 @@ curl -v -X DELETE \
 
 
 ```http
-HTTP/1.1 202 ACCEPTED
-Content-Type: application/json
-
-{}
+`204 No Content`
 ```
 
 ### Unlock User


### PR DESCRIPTION
## Description:
- **What's changed?** Modified the response parameters and response example for Delete User operation in order to reflect the correct response 204 No Content instead of 202 Accepted.
- **Is this PR related to a Monolith release?** No