### PR TITLE
Redirect for add-okta-redirect-uri-to-idp

### DIFF
--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -1953,3 +1953,7 @@ redirects:
     to: /docs/guides/build-sso-integration/saml2/overview/
   - from: /docs/guides/saml-application-setup/index.html
     to: /docs/guides/build-sso-integration/saml2/overview/
+  - from: /docs/guides/add-an-external-idp/facebook/add-okta-redirect-uri-to-idp/
+    to: /docs/guides/add-an-external-idp/facebook/create-an-app-at-idp/
+  - from: /docs/guides/add-an-external-idp/facebook/add-okta-redirect-uri-to-idp/index.html
+    to: /docs/guides/add-an-external-idp/facebook/create-an-app-at-idp/


### PR DESCRIPTION
## Description:
- **What's changed?** Adding redirect from /docs/guides/add-an-external-idp/facebook/add-okta-redirect-uri-to-idp/ to /docs/guides/add-an-external-idp/facebook/create-an-app-at-idp/
- No
