### PR TITLE
OKTA-304036: Reader Feedback: Group Rules API Missing Required Property

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
@@ -1043,14 +1043,15 @@ Creates a Group rule to dynamically add users to the specified Group if they mat
 ##### Request parameters
 
 
-| Parameter                           | Description                                    | ParamType | DataType                          | Required | Default |
-| ----------------------------------- | ---------------------------------------------- | --------- | --------------------------------- | -------- | ------- |
-| name                                | name of the Group                              | Body      | String                            | TRUE     |         |
-| conditions.expression.value          | Okta expression that would result in a boolean value | Body      | String                     | TRUE     |         |
-| conditions.expression.type           | `urn:okta:expression:1.0`             | Body      | String                     | TRUE     |         |
-| conditions.people.users.exclude      | userIds that would be excluded when rules are processed | Body      | String                  | FALSE    |         |
-| conditions.people.groups.exclude     | currently not supported                     | Body      | String                            | FALSE    |         |
-| actions.assignUserToGroups.groupIds | Array of groupIds to which users would be added.| Body      | String                           | TRUE     |         |
+| Parameter                           | Description                                             | ParamType | DataType                          | Required | Default |
+| ----------------------------------- | ------------------------------------------------------- | --------- | --------------------------------- | -------- | ------- |
+| name                                | name of the Group                                       | Body      | String                            | TRUE     |         |
+| type                                | `group_rule`                                            | Body      | String                            | TRUE     |         |
+| conditions.expression.value         | Okta expression that would result in a boolean value    | Body      | String                            | TRUE     |         |
+| conditions.expression.type          | `urn:okta:expression:1.0`                               | Body      | String                            | TRUE     |         |
+| conditions.people.users.exclude     | userIds that would be excluded when rules are processed | Body      | String                            | FALSE    |         |
+| conditions.people.groups.exclude    | currently not supported                                 | Body      | String                            | FALSE    |         |
+| actions.assignUserToGroups.groupIds | Array of groupIds to which users would be added.        | Body      | String                            | TRUE     |         |
 
 ##### Response parameters
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
Group Rule has a required type `property` that is undocumented, and this PR adds that into the developer doc.

- **Is this PR related to a Monolith release?** <!-- If so, which one? -->
No

### Resolves:

* [OKTA-304036](https://oktainc.atlassian.net/browse/OKTA-304036)

### Reviewers:
@jakubvul-okta @okta/eng-extensibility 