### PR TITLE
Adds github edit to link checking exceptions

### DIFF
--- a/scripts/broken-link-checker.js
+++ b/scripts/broken-link-checker.js
@@ -29,6 +29,7 @@ var options = {
     "/product/",
     "/product/*",
     "/okta-integration-network/",
+    "github.com/okta/okta-developer-docs/edit",
   ]
 };
 


### PR DESCRIPTION
## Description:
- **What's changed?** 

  - Adds github edit links to the list of link checking exceptions (these links currently exist but are not visible)

- **Is this PR related to a Monolith release?** 
  - No

### Resolves:

The noise when validating external links
