### PR TITLE
Updates auth-js versions

### DIFF
--- a/packages/@okta/vuepress-site/code/library-versions/index.md
+++ b/packages/@okta/vuepress-site/code/library-versions/index.md
@@ -53,7 +53,7 @@ This table lists the current (and historical) major versions of our open-source 
 | Library                                                         | Version                              | Status                               |
 | --------------------------------------------------------------- | ------------------------------------ | ------------------------------------ |
 | [Sign-In Widget][signin-widget]                                 | 1.13.0<br>2.21.0<br>3.9.2<br>**4.x** | Retired<br>Retired<br>Retiring on 2021-02-01<br>**Stable** |
-| [Auth.js][authjs]                                               | 1.x<br>2.x<br>**3.x**                | Retired<br>Retiring on 2020-12-04<br>**Stable** |
+| [Auth.js][authjs]                                               | 1.x<br>2.x<br>3.x<br>**4.x**         | Retired<br>Retiring on 2020-09-30<br>Retiring on 2021-05-30<br>**Stable** |
 | [Android AppAuth SDK][appauth-android]                          | 0.2.4                                | Retired                              |
 | [Android OIDC][oidc-android]                                    | 1.0.1                                | **Stable**                           |
 | [Angular SDK][sdk-angular]                                      | 0.1.0<br>1.x<br>**2.x**              | Retired<br>Retiring on 2020-12-10<br>**Stable**                |


### PR DESCRIPTION
## Description:
- **What's changed?** 
  - okta-auth-js was listed with wrong retirement for 2.x and didn't list 4.x on the /code/library-versions/ page.

- **Is this PR related to a Monolith release?** 
  - No
### Resolves:

* [OKTA-327605](https://oktainc.atlassian.net/browse/OKTA-327605)
