### PR TITLE
Fix Referrer-Policy header explanation for OIDC response-mode

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/oidc/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oidc/index.md
@@ -140,7 +140,7 @@ This is a starting point for browser-based OpenID Connect flows such as the impl
     `okta_post_message` is an adaptation of the [Web Message Response Mode](https://tools.ietf.org/html/draft-sakimura-oauth-wmrm-00#section-4.1).
     This value provides a secure way for a single-page application to perform a sign-in flow in a pop-up window or an iFrame and receive the ID token, access token, and/or authorization code back in the parent page without leaving the context of that page. The data object for the `postMessage` call is in the next section.
   
-  The `Referrer-Policy` header is automatically included in the response when `fragment` or `query` and is set to `Referrer-Policy: no-referrer`.
+  The `Referrer-Policy` header is automatically included in the response when either the `fragment` or `query` parameter values are used. The header is set to `Referrer-Policy: no-referrer`.
 
 * `state`:
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oidc/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oidc/index.md
@@ -139,7 +139,8 @@ This is a starting point for browser-based OpenID Connect flows such as the impl
 
     `okta_post_message` is an adaptation of the [Web Message Response Mode](https://tools.ietf.org/html/draft-sakimura-oauth-wmrm-00#section-4.1).
     This value provides a secure way for a single-page application to perform a sign-in flow in a pop-up window or an iFrame and receive the ID token, access token, and/or authorization code back in the parent page without leaving the context of that page. The data object for the `postMessage` call is in the next section.
-  * The `Referrer-Policy` header is automatically included in the request for `fragment` or `query` and is set to `Referrer-Policy: no-referrer`.
+  
+  The `Referrer-Policy` header is automatically included in the response when `fragment` or `query` and is set to `Referrer-Policy: no-referrer`.
 
 * `state`:
 


### PR DESCRIPTION
## Description:
**What's changed?** 
- Clarified that the `Referrer-Policy` is a  response header that is included.
- Removed the bullet point (kept indent under `response_mode`) to clarify the list of potential values does not include this item.

**Is this PR related to a Monolith release?** No