### PR TITLE
remove console.log from many places in link checker

### DIFF
--- a/scripts/broken-link-checker.js
+++ b/scripts/broken-link-checker.js
@@ -102,11 +102,9 @@ var siteChecker = new blc.SiteChecker(options, {
   junk: function(result, customData){},
   link: function(result, customData){
     if (customData.firstLink) {
-      console.log("Getting links from: " + result.base.resolved);
       customData.firstLink = false;
     }
     if (result.broken) {
-      console.log(chalk.bold.red("─BROKEN─ ") + chalk.cyan(result.url.resolved));
       customData.brokenLinks.push(result);
       customData.pageBrokenCount++;
     } else if (result.excluded) {
@@ -114,15 +112,12 @@ var siteChecker = new blc.SiteChecker(options, {
     } else {
       //good link
       if (customData.outputGoodLinks) {
-        console.log(chalk.bold.green("───OK─── ") + chalk.gray(result.url.resolved));
       }
     }
     customData.pageLinkCount++;
   },
   page: function(error, pageUrl, customData){
     if (customData.pageLinkCount > 0) {
-      console.log("Finished! " + customData.pageLinkCount + " link(s) found. " + customData.pageBrokenCount + " broken.");
-      console.log();
       customData.totalLinkCount += customData.pageLinkCount;
       customData.totalExcludedCount += customData.pageExcludedCount;
       customData.totalBrokenCount += customData.pageBrokenCount;


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** removes a lot of console.logs from the link checker to clean up logs in travis

Changes:
<img width="1311" alt="Screen Shot 2020-09-15 at 3 57 24 PM" src="https://user-images.githubusercontent.com/1906920/93260837-eb570280-f76f-11ea-9b42-476bd57940cb.png">

To:
<img width="571" alt="Screen Shot 2020-09-15 at 4 24 04 PM" src="https://user-images.githubusercontent.com/1906920/93260863-f5790100-f76f-11ea-9433-c0e632ae6e69.png">



### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
