### PR TITLE
Fixed content nav display

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_content.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_content.scss
@@ -67,7 +67,7 @@
     }
 
     .mobile-on-this-page {
-      @include media('>=tablet') {
+      @include media('>=desktop') {
         display: none;
       }
     }
@@ -120,10 +120,7 @@
 
   .on-this-page {
     width: 18%;
-    @include media('>=tablet') {
-      width: 18rem;
-    }
-    @include media('<tablet') {
+    @include media('<desktop') {
       display: none;
     }
   }


### PR DESCRIPTION

## Description:
- Fixed problem with content nav displaying incorrectly - wrong width and horizontal scroll.  Now mobile widget "On this page" is displayed when screen width <= 1024px, not only for mobile. 

State before: 
![image](https://user-images.githubusercontent.com/68992536/94792209-4da33a80-03e1-11eb-9ea5-71513a24d967.png)

State after:
![image](https://user-images.githubusercontent.com/68992536/94792359-88a56e00-03e1-11eb-81c7-d4c645cb8d2f.png)
 

### Resolves:

* OKTA-331496](https://oktainc.atlassian.net/browse/OKTA-331496)
