### PR TITLE
Fixed active states for nav bar

### DIFF
--- a/packages/@okta/vuepress-theme-prose/components/Sidebar.vue
+++ b/packages/@okta/vuepress-theme-prose/components/Sidebar.vue
@@ -1,14 +1,14 @@
 <template>
   <aside class="landing-navigation" :class="{active: sidebarActive}">
     <ul class="landing">
-      <SidebarItem v-for="(link, key) in navigation" :key="key" :link="link" />
+      <SidebarItem v-for="link in navigation" :key="link.title" :link="link" />
     </ul>
   </aside>
 </template>
 
 <script>
 import _ from "lodash";
-import { getGuidesInfo, guideFromPath } from "../util/guides";
+import { getGuidesInfo, guideFromPath } from "../util/guides";  
 
 export default {
   name: "Sidebar",

--- a/packages/@okta/vuepress-theme-prose/components/SidebarItem.vue
+++ b/packages/@okta/vuepress-theme-prose/components/SidebarItem.vue
@@ -10,10 +10,10 @@
             </svg>
 
             <div v-if="link.path">
-                <router-link :to="link.path" @click="setData" :class="{'router-link-active': link.imActive, 'router-link-exact-active': link.imActive}">{{link.title}}</router-link>
+                <router-link :to="link.path" @click="setData" :class="{'router-link-active': link.imActive, 'router-link-exact-active': iHaveChildrenActive}">{{link.title}}</router-link>
             </div>
             <div v-else>
-                <div class="is-link" @click="toggle">{{link.title}}</div>
+                <div :class="{'is-link':true, 'router-link-active': iHaveChildrenActive}" @click="toggle">{{link.title}}</div>
             </div>
         </div>
 

--- a/packages/@okta/vuepress-theme-prose/components/SidebarItem.vue
+++ b/packages/@okta/vuepress-theme-prose/components/SidebarItem.vue
@@ -9,16 +9,17 @@
                 <path d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"/>
             </svg>
 
-            <div v-if="link.path">
-                <router-link :to="link.path" @click="setData" :class="{'tree-nav-link': true, 'router-link-active': link.imActive, 'router-link-exact-active': link.imActive}">{{link.title}}</router-link>
+             <div v-if="link.path">
+                <router-link :to="link.path" exact @click="setData" class="tree-nav-link">{{link.title}}</router-link>
             </div>
+
             <div v-else>
                 <div :class="{'is-link':true, 'router-link-active': iHaveChildrenActive}" @click="toggle">{{link.title}}</div>
             </div>
         </div>
 
         <ul v-if="link.subLinks" class="sections" v-show="iHaveChildrenActive">
-            <SidebarItem v-for="(sublink, key) in link.subLinks" :key="key" :link="sublink" />
+            <SidebarItem v-for="sublink in link.subLinks" :key="sublink.title" :link="sublink" />
         </ul>
       </li>
 </template>

--- a/packages/@okta/vuepress-theme-prose/components/SidebarItem.vue
+++ b/packages/@okta/vuepress-theme-prose/components/SidebarItem.vue
@@ -10,7 +10,7 @@
             </svg>
 
             <div v-if="link.path">
-                <router-link :to="link.path" @click="setData" :class="{'router-link-active': link.imActive, 'router-link-exact-active': iHaveChildrenActive}">{{link.title}}</router-link>
+                <router-link :to="link.path" @click="setData" :class="{'tree-nav-link': true, 'router-link-active': link.imActive, 'router-link-exact-active': link.imActive}">{{link.title}}</router-link>
             </div>
             <div v-else>
                 <div :class="{'is-link':true, 'router-link-active': iHaveChildrenActive}" @click="toggle">{{link.title}}</div>


### PR DESCRIPTION
## Description:
- Active states for navbar were fixed. After discussing with @alexdahl-okta  there was decided that each parent of active link will have bold text and active item will remain bold to: 
![image](https://user-images.githubusercontent.com/68992536/94921149-5fa7da80-04c0-11eb-84d6-8376dbba4d0e.png)

- Fixed issue with relative links and exact links (active link style was applied to parent part of a link, even if link was not currently active - this why first item of sidebar was always bold, see "Languages & SDKs" and "Add user auth to your angular app"). Screenshot on before state, current state on previous screenshot: 
![image](https://user-images.githubusercontent.com/68992536/94921261-9c73d180-04c0-11eb-8854-37477eb1d007.png)

- Fixed "keys" properties for Vue for render directive - now link names are used for "keys" instead of array indexes (when we have non-flat arrays we can not use indexes - several elements will have same "key" properties, this can cause side effects when components are updated) 

- Fixed issue with double active links in Concepts section. 

Before: 

![bugged-gif](https://user-images.githubusercontent.com/68992536/94922266-94b52c80-04c2-11eb-8c85-e49a9a05b806.gif)

After:

![fixed-gif](https://user-images.githubusercontent.com/68992536/94922279-9d0d6780-04c2-11eb-819a-dc360b94563c.gif)

- Fixed issue with implementing same set of styles twice. 
Before: 
![image](https://user-images.githubusercontent.com/68992536/94922401-ce863300-04c2-11eb-8a57-58779f3c62e6.png)
After:
![image](https://user-images.githubusercontent.com/68992536/94922434-e067d600-04c2-11eb-9fd5-198293e7c5b9.png)


- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-320822](https://oktainc.atlassian.net/browse/OKTA-320822)
