### PR TITLE
Okta 323353 add missed libs and samples

### DIFF
--- a/packages/@okta/vuepress-site/code/android/index.md
+++ b/packages/@okta/vuepress-site/code/android/index.md
@@ -47,6 +47,12 @@ The Okta OpenID Connect (OIDC) Android SDK is for communicating with OAuth 2.0 a
 			<span>Okta JWT Verifier for Java</span>
 		</a>
 	</li>
+	<li>
+		<i class='fa fa-github'></i>
+		<a href="https://github.com/okta/okta-oidc-js/tree/master/packages/okta-react-native/android">
+			<span>React Native app with Okta's OpenID Connect API</span>
+		</a>
+	</li>
 </ul>
 
 ## Recommended Guides

--- a/packages/@okta/vuepress-site/code/ios/index.md
+++ b/packages/@okta/vuepress-site/code/ios/index.md
@@ -62,6 +62,19 @@ Okta provides an OpenID Connect (OIDC) client library on Cocoa Pods. We recommen
                     <p>Use this library for building custom authentication flows with Okta.</p>
             </a>
         </li>
+	<li>
+		<i class='fa fa-github'></i>
+		<a href="https://github.com/okta/okta-oidc-js/tree/master/packages/okta-react-native/ios">
+			<span>React Native app with Okta's OpenID Connect API</span>
+		</a>
+	</li>
+	<li>
+		<i class='fa fa-github'></i>
+		<a href="https://github.com/okta/okta-storage-swift">
+			<span>Okta Secure Storage Library</span>
+		</a>
+	</li>
+
 </ul>
 
 ## Recommended Guides

--- a/packages/@okta/vuepress-site/code/java/index.md
+++ b/packages/@okta/vuepress-site/code/java/index.md
@@ -89,6 +89,12 @@ The Okta Authentication SDK can be used in scenarios where using OAuth 2.0 is no
 	</a>
 </p>
 
+## Java Servlet Sample
+
+<a href='https://github.com/okta/samples-java-servlet'>
+	<span class='fa fa-github'></span> <span>Java Servlet Sample</span>
+</a>
+
 ## Recommended Guides
 
 

--- a/packages/@okta/vuepress-site/code/java/spring/index.md
+++ b/packages/@okta/vuepress-site/code/java/spring/index.md
@@ -57,6 +57,17 @@ The Okta Spring Boot Starter can be used to add OAuth 2.0 authorization to Sprin
 	</li>
 </ul>
 
+## Spring Samples
+
+<ul class="language-libraries">
+	<li>
+		<i class='fa fa-github'></i>
+		<a href="https://github.com/okta/samples-java-spring">
+			<span>Okta Spring Boot Samples</span>
+		</a>
+	</li>
+</ul>
+
 ## Recommended Guides
 
 

--- a/packages/@okta/vuepress-site/code/java/spring/index.md
+++ b/packages/@okta/vuepress-site/code/java/spring/index.md
@@ -63,7 +63,7 @@ The Okta Spring Boot Starter can be used to add OAuth 2.0 authorization to Sprin
 	<li>
 		<i class='fa fa-github'></i>
 		<a href="https://github.com/okta/samples-java-spring">
-			<span>Okta Spring Boot Samples</span>
+			<span>Spring Security OAuth Sample Applications for Okta</span>
 		</a>
 	</li>
 </ul>

--- a/packages/@okta/vuepress-site/code/javascript/index.md
+++ b/packages/@okta/vuepress-site/code/javascript/index.md
@@ -48,6 +48,12 @@ Auth.js is a library wrapper for the Okta Authentication API. Use it when you ne
 			<span>Okta Sign-In Widget</span>
 		</a>
 	</li>
+	<li>
+		<i class='fa fa-github'></i>
+		<a href="https://github.com/okta/okta-oidc-js">
+			<span>Okta's OpenID Connect</span>
+		</a>
+	</li>
 </ul>
 
 ## Recommended Guides


### PR DESCRIPTION

## Description:
- **What's changed?** Added to the dev docs missed library/samples links.
- **Is this PR related to a Monolith release?** No

**1. Added link to React native lib for Android doc:**

**Before:**

<img width="554" alt="Screen Shot 2020-10-02 at 4 52 40 PM" src="https://user-images.githubusercontent.com/70781392/94930889-bb2d9480-04cf-11eb-9490-a597ab35cdb7.png">

**After:**

<img width="484" alt="Screen Shot 2020-10-02 at 4 52 07 PM" src="https://user-images.githubusercontent.com/70781392/94931130-0c3d8880-04d0-11eb-9b7c-a1aaf38f2f79.png">

**2. Added links to React native and Secure storage libs for IOS doc:**

**Before:**

<img width="619" alt="Screen Shot 2020-10-02 at 4 00 35 PM" src="https://user-images.githubusercontent.com/70781392/94927418-e5308800-04ca-11eb-8740-0ec6477c5ef1.png">

**After:**

<img width="583" alt="Screen Shot 2020-10-02 at 4 00 46 PM" src="https://user-images.githubusercontent.com/70781392/94931233-3000ce80-04d0-11eb-858a-92cb57add40b.png">

**3. Added link to OpenID Connect library for Javascript doc:**

**Before:**

<img width="481" alt="Screen Shot 2020-10-02 at 4 22 46 PM" src="https://user-images.githubusercontent.com/70781392/94928706-c59a5f00-04cc-11eb-8ee2-ec5603eb362a.png">

**After:**
<img width="528" alt="Screen Shot 2020-10-02 at 4 04 01 PM" src="https://user-images.githubusercontent.com/70781392/94931484-7b1ae180-04d0-11eb-9eae-ef6d9f2c3643.png">


**4. Added links to the sample sources for Java doc:**

**- Java Servlet Sample:**
**Before:**

<img width="683" alt="Screen Shot 2020-10-02 at 4 07 33 PM" src="https://user-images.githubusercontent.com/70781392/94929578-f202ab00-04cd-11eb-80d0-e6aeca644fea.png">

**After:**

<img width="591" alt="Screen Shot 2020-10-02 at 4 07 08 PM" src="https://user-images.githubusercontent.com/70781392/94931988-2330aa80-04d1-11eb-91c3-00420e4b563c.png">

**- Spring Security OAuth Sample Applications for Okta:**

**Before:**

<img width="675" alt="Screen Shot 2020-10-02 at 4 08 52 PM" src="https://user-images.githubusercontent.com/70781392/94929803-3e4deb00-04ce-11eb-9d2d-92f9f547cd83.png">

**After:**

<img width="614" alt="Screen Shot 2020-10-02 at 4 08 31 PM" src="https://user-images.githubusercontent.com/70781392/94931878-f7152980-04d0-11eb-8d5b-d9902813c52f.png">


### Resolves:

* [OKTA-323353](https://oktainc.atlassian.net/browse/OKTA-323353)
