### PR TITLE
OKTA-327765: Tree nav width and arrows

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_content.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_content.scss
@@ -27,6 +27,8 @@
     width: 18%;
     @include media('>=tablet') {
       width: 18rem;
+      flex-grow: 0;
+      flex-shrink: 0;
     }
 
     @include media('<tablet') {

--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_sidebar.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_sidebar.scss
@@ -14,7 +14,6 @@
   }
 
   &.active {
-    
     @include media('<tablet') {
       position: sticky;
       z-index: 100;
@@ -24,7 +23,6 @@
       width: 300px;
       margin-right:5rem;
     }
-
   }
 
   .router-link-active {
@@ -35,6 +33,7 @@
     border-left: 0.2rem solid cv('gray', '900');
     margin-left: -1.2rem;
     padding-left: 1.0rem;
+    padding-right: 0.65rem;
     color: cv('gray', '900');
   }
 
@@ -96,7 +95,9 @@
     font-size: 1em;
     text-decoration: none;
     display: block;
+    padding-right: 1rem;
   }
+
 
   .sections {
     margin-left: 1.5rem;

--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_sidebar.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_sidebar.scss
@@ -68,19 +68,20 @@
 
     .link-wrap {
       display: flex;
-      align-items: center;
 
-      
+      .item-collapsable {
+        display: flex;
+        align-items: center;
 
-      svg {
-        flex-shrink: 0;
-        margin-right: 0.5em;
-        fill: currentColor;
-        height: 1em;
-        margin-left: -1.2rem;
-
-        &.open {
-          margin-top: -0.5rem;
+        svg {
+          flex-shrink: 0;
+          margin-right: 0.5em;
+          fill: currentColor;
+          height: 1em;
+          margin-left: -1.2rem;
+          &.open {
+            margin-top: -0.5rem;
+          }
         }
       }
     }
@@ -95,7 +96,7 @@
     font-size: 1em;
     text-decoration: none;
     display: block;
-    padding-right: 1rem;
+    padding-right: 1.3rem;
   }
 
 

--- a/packages/@okta/vuepress-theme-prose/components/SidebarItem.vue
+++ b/packages/@okta/vuepress-theme-prose/components/SidebarItem.vue
@@ -1,19 +1,20 @@
 <template>
     <li :class="{'subnav': link.subLinks}">
         <div class="link-wrap">
-            <svg viewBox="0 0 320 512" v-if="link.subLinks && !iHaveChildrenActive">
-                <path d="M0 384.662V127.338c0-17.818 21.543-26.741 34.142-14.142l128.662 128.662c7.81 7.81 7.81 20.474 0 28.284L34.142 398.804C21.543 411.404 0 402.48 0 384.662z"/>
-            </svg>
-
-            <svg viewBox="0 0 320 512" v-if="link.subLinks && iHaveChildrenActive">
-                <path d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"/>
-            </svg>
-
             <div v-if="link.path">
                 <router-link :to="link.path" @click="setData" :class="{'router-link-active': link.imActive, 'router-link-exact-active': link.imActive}">{{link.title}}</router-link>
             </div>
             <div v-else>
-                <div class="is-link" @click="toggle">{{link.title}}</div>
+                <div class="is-link item-collapsable" @click="toggle">
+                    <svg viewBox="0 0 320 512" v-if="link.subLinks && !iHaveChildrenActive">
+                        <path d="M0 384.662V127.338c0-17.818 21.543-26.741 34.142-14.142l128.662 128.662c7.81 7.81 7.81 20.474 0 28.284L34.142 398.804C21.543 411.404 0 402.48 0 384.662z"/>
+                    </svg>
+
+                    <svg viewBox="0 0 320 512" v-if="link.subLinks && iHaveChildrenActive">
+                        <path d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"/>
+                    </svg>
+                    {{link.title}}
+                </div>
             </div>
         </div>
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
  * tree nav gets fixed width
  * clicking triangle icon expands/collapses item
  * line breaks are consistent between collapsed and expanded states
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->
No

Before:
![tree-nav-before-fix](https://user-images.githubusercontent.com/71440851/95104429-7ce9dc80-073e-11eb-9d94-d3fbf743cd08.gif)

After:
![tree-nav-after-fix](https://user-images.githubusercontent.com/71440851/95104689-cafee000-073e-11eb-91f6-2c6c0207c454.gif)

### Resolves:

* [OKTA-327765](https://oktainc.atlassian.net/browse/OKTA-327765)
