### PR TITLE
Fix navigation for Vue Guides 

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/nav/codePages.js
+++ b/packages/@okta/vuepress-site/.vuepress/nav/codePages.js
@@ -12,9 +12,9 @@ module.exports = [
   {
     title: "Front End",
     subLinks: [
-      { 
+      {
         title: 'Angular',
-        subLinks: 
+        subLinks:
         [
           {
             title: 'Add User Authentication to Your Angular App',
@@ -28,45 +28,61 @@ module.exports = [
             title: 'Okta Auth JS and Angular',
             path: '/code/angular/okta_angular_auth_js/',
           }
-        ]  
+        ]
       },
-      { 
+      {
         title: 'JavaScript',
-        subLinks: 
+        subLinks:
         [
           {
             title: 'Add User Authentication to Your JavaScript App',
             path: '/code/javascript/',
           },
           {
+            title: 'Okta Sign-In Widget Guide',
+            path: '/code/javascript/okta_sign-in_widget/',
+          },
+          {
             title: 'Okta Auth SDK Guide',
             path: '/code/javascript/okta_auth_sdk/',
           },
-          {
-            title: 'Okta Sign-In Widget Guide',
-            path: '/code/javascript/okta_sign-in_widget/',
-          }
         ]
        },
        {
         title: 'React',
-        subLinks: 
+        subLinks:
         [
           {
             title: 'Add User Authentication to Your React App',
             path: '/code/react/',
           },
           {
-            title: 'Okta React Overview',
-            path: '/code/react/okta_react/',
-          },
-          {
             title: 'Okta Sign-In Widget and React',
             path: '/code/react/okta_react_sign-in_widget/',
+          },
+          {
+            title: 'Okta Auth JS and React',
+            path: '/code/react/okta_react/',
           }
           ]
         },
-      { title: 'Vue', path: '/code/vue/' }
+      {
+        title: 'Vue',
+        subLinks: [
+          {
+            title: 'Add User Authentication to Your Vue App',
+            path: '/code/vue/',
+          },
+          {
+            title: 'Okta Sign-In Widget and Vue',
+            path: '/code/vue/okta_vue_sign-in_widget/',
+          },
+          {
+            title: 'Okta Auth JS and Vue',
+            path: '/code/vue/okta_vue/',
+          }
+        ]
+      }
     ]
   },
   {

--- a/packages/@okta/vuepress-site/code/angular/index.md
+++ b/packages/@okta/vuepress-site/code/angular/index.md
@@ -34,7 +34,7 @@ New to Okta? Our how to guide will walk you through adding user authentication t
 The Okta Angular SDK builds on top of the Okta OpenID Connect API to help you create a fully-branded sign-experience.
 
 <a href='https://www.npmjs.com/package/@okta/okta-angular' class="language-reference">
-	<span class='icon download-16'></span> <span>Okta-angular on npm</span>
+	<span class='icon download-16'></span> <span>okta-angular on npm</span>
 </a>
 
 <a href='https://github.com/okta/okta-oidc-js/tree/master/packages/okta-angular'>

--- a/packages/@okta/vuepress-site/code/angular/index.md
+++ b/packages/@okta/vuepress-site/code/angular/index.md
@@ -44,7 +44,7 @@ The Okta Angular SDK builds on top of the Okta OpenID Connect API to help you cr
 ## Recommended Guides
 
 
-- [Angular Sign in widget](/code/angular/okta_angular_sign-in_widget/)
+- [Okta Sign-In Widget and Angular](/code/angular/okta_angular_sign-in_widget/)
 - [Okta Auth JS and Angular](/code/angular/okta_angular_auth_js/)
 - [Implementing the PKCE Flow](/docs/guides/implement-auth-code-pkce/)
 - [Social Login](/docs/concepts/social-login/)

--- a/packages/@okta/vuepress-site/code/react/index.md
+++ b/packages/@okta/vuepress-site/code/react/index.md
@@ -41,8 +41,8 @@ The Okta React SDK makes it easy to integrate react-router with Okta's OpenID Co
 
 ## Recommended Guides
 
-- [Okta React Overview](/code/react/okta_react/)
 - [Okta Sign-In Widget and React](/code/react/okta_react_sign-in_widget/)
+- [Okta Auth JS and React](/code/react/okta_react/)
 - [Implementing the PKCE Flow](/docs/guides/implement-auth-code-pkce/)
 - [Social Login](/docs/concepts/social-login/)
 - [Validate access tokens](/docs/guides/validate-access-tokens)

--- a/packages/@okta/vuepress-site/code/vue/index.md
+++ b/packages/@okta/vuepress-site/code/vue/index.md
@@ -42,8 +42,8 @@ The Okta Vue SDK makes it easy to integrate Vue Router with Okta's OpenID Connec
 
 ## Recommended Guides
 
-- [Okta Vue Overview](/code/vue/okta_vue/)
 - [Okta Sign-In Widget and Vue](/code/vue/okta_vue_sign-in_widget/)
+- [Okta Auth JS and Vue](/code/vue/okta_vue/)
 - [Implementing the PKCE Flow](/docs/guides/implement-auth-code-pkce/)
 - [Social Login](/docs/concepts/social-login/)
 - [Validate access tokens](/docs/guides/validate-access-tokens)


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** This PR fixes the left nav so it expands for Vue Guides. I also changed the order of menu items so Sign-In Widget comes before the Auth JS SDK, which seems reasonable.
- **Is this PR related to a Monolith release?** Nope.

Vue Guides Before:

<img width="1120" alt="vue-siw-before" src="https://user-images.githubusercontent.com/17892/95274151-4a091c80-0802-11eb-9740-bddbde7dd634.png">

Vue Guides After:

<img width="1167" alt="vue-siw-after" src="https://user-images.githubusercontent.com/17892/95274244-8177c900-0802-11eb-9815-eaa2bd93e747.png">

Left nav with Auth JS first and "Overview" instead of "Auth JS":

![image](https://user-images.githubusercontent.com/17892/95274275-96545c80-0802-11eb-8507-8f9d69090d74.png)

Left nav after:

![image](https://user-images.githubusercontent.com/17892/95274287-9ce2d400-0802-11eb-836f-9ee3681a7a73.png)

