### PR TITLE
Change mastered -> backed with respect to Okta and AD in AuthN API docs

### DIFF
--- a/packages/@okta/vuepress-site/data/error-codes.json
+++ b/packages/@okta/vuepress-site/data/error-codes.json
@@ -183,7 +183,7 @@
     "statusCode" : 403,
     "statusReasonPhrase" : "Forbidden",
     "errorCode" : "E0000023",
-    "errorSummary" : "Operation failed because user profile is mastered under another system",
+    "errorSummary" : "Operation failed because user profile is backed by another system",
     "errorDescription" : null
   }, {
     "title" : "Unsupported app metadata operation exception",
@@ -607,7 +607,7 @@
     "statusCode" : 405,
     "statusReasonPhrase" : "Method Not Allowed",
     "errorCode" : "E0000076",
-    "errorSummary" : "Cannot modify the app user because it is mastered by an external app.",
+    "errorSummary" : "Cannot modify the app user because it is backed by an external app.",
     "errorDescription" : null
   }, {
     "title" : "Read only attribute exception",

--- a/packages/@okta/vuepress-site/data/event-types.json
+++ b/packages/@okta/vuepress-site/data/event-types.json
@@ -12961,7 +12961,7 @@
     }, {
       "id" : "group.privilege.grant",
       "category" : "dda",
-      "description" : "Fired when a group within Okta has been granted admin privileges. The group granted privileges can be an Okta mastered group, and AD mastered group, or an LDAP mastered group. This can be used to audit the provisioning of admin privileges for groups. When fired, this event contains information about the type of admin privileges that have been granted, and what entity masters the group. Related events include: GROUP_PRIVILEGE_REVOKE.",
+      "description" : "Fired when a group within Okta has been granted admin privileges. The group granted privileges can be an Okta-backed group, and AD-backed group, or an LDAP-backed group. This can be used to audit the provisioning of admin privileges for groups. When fired, this event contains information about the type of admin privileges that have been granted, and what entity backs the group. Related events include: GROUP_PRIVILEGE_REVOKE.",
       "info" : {
         "created" : "2019-02-25",
         "release" : "2019.03.0"
@@ -12977,7 +12977,7 @@
     }, {
       "id" : "group.privilege.revoke",
       "category" : "dda",
-      "description" : "Fired when a group within Okta has had admin privileges revoked. The group with revoked privileges can be an Okta mastered group, and AD mastered group, or an LDAP mastered group. This can be used to audit the provisioning of admin privileges for groups. When fired, this event contains information about the type of admin privileges that have been revoked, and what entity masters the group. Related events include: GROUP_PRIVILEGE_REVOKE.",
+      "description" : "Fired when a group within Okta has had admin privileges revoked. The group with revoked privileges can be an Okta-backed group, and AD-backed group, or an LDAP-backed group. This can be used to audit the provisioning of admin privileges for groups. When fired, this event contains information about the type of admin privileges that have been revoked, and what entity masters the group. Related events include: GROUP_PRIVILEGE_REVOKE.",
       "info" : {
         "created" : "2019-02-25",
         "release" : "2019.03.0"

--- a/packages/@okta/vuepress-site/docs/concepts/scim/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/scim/index.md
@@ -67,14 +67,14 @@ The deletion or deprovisioning of end-user profiles in SCIM operations depends o
 
    Deactivated end-user accounts lose access to their provisioned Okta integrations. Your application can run different actions after deprovisioning a user, such as changing user access permissions, removing a license, or completely disabling the user account.
 * If an admin deletes a deactivated end-user profile inside Okta, the user resource inside your SCIM application isn't changed. The initial deactivation step already set `active=false`. Okta doesn't send a request to delete the user resource inside the customer's SCIM application.
-* Conversely, if an end-user profile is marked with `active=false` inside your SCIM application, and the Okta integration is mastered by that SCIM application, then when an import from your SCIM application is run, the user's profile is marked as deactivated inside Okta.
-* Similarly, if an end-user profile is deleted from inside your SCIM application, and the end user is mastered by that SCIM application, then when an import from your SCIM application is run, the user's profile is deleted inside Okta.
+* Conversely, if an end-user profile is marked with `active=false` inside your SCIM application, and the Okta integration is backed by that SCIM application, then when an import from your SCIM application is run, the user's profile is marked as deactivated inside Okta.
+* Similarly, if an end-user profile is deleted from inside your SCIM application, and the end user is backed by that SCIM application, then when an import from your SCIM application is run, the user's profile is deleted inside Okta.
 
 ### Sync passwords
 
 Outside of the base CRUD operations, Okta supports additional provisioning features like syncing passwords.
 
-Password synchronization helps you coordinate Okta-mastered users to ensure that a user’s Active Directory (AD) password and their Okta password always match. With password synchronization, your users have a single password to access applications and devices.
+Password synchronization helps you coordinate Okta-backed users to ensure that a user’s Active Directory (AD) password and their Okta password always match. With password synchronization, your users have a single password to access applications and devices.
 
 This option sets the user's password for your integration to match the Okta password or to be assigned a randomly generated password. For more information about this functionality and how to configure it in the Okta product, see [Synchronize passwords from Okta to Active Directory](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Security_Using_Sync_Password).
 
@@ -88,7 +88,7 @@ Okta uses a Profile Editor to map specific user attributes from the source appli
 
 ## Lifecycle management using profile mastering
 
-Profile mastering defines the flow and maintenance of user attributes. When a profile is mastered using a source outside of Okta (for example, an HR application, Active Directory, or LDAP), then the Okta user's attributes and lifecycle state are derived exclusively from that resource. The SCIM protocol is used to handle the secure exchange of user identity data between the profile master and Okta. In this scenario, the profile isn't editable in Okta by the user or an Okta admin.
+Profile mastering defines the flow and maintenance of user attributes. When a profile is backed using a source outside of Okta (for example, an HR application, Active Directory, or LDAP), then the Okta user's attributes and lifecycle state are derived exclusively from that resource. The SCIM protocol is used to handle the secure exchange of user identity data between the profile master and Okta. In this scenario, the profile isn't editable in Okta by the user or an Okta admin.
 
 For example, if the lifecycle state of the user is changed to "Disabled" in Active Directory, then on the next SCIM read operation, the linked Okta user profile is switched and given the corresponding lifecycle state of `active=false`.
 

--- a/packages/@okta/vuepress-site/docs/guides/customize-tokens-groups-claim/add-groups-claim-org-as/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-tokens-groups-claim/add-groups-claim-org-as/index.md
@@ -2,7 +2,7 @@
 title: Add a Groups claim for the Org Authorization Server
 ---
 
-Use these steps to create a Groups claim for an OpenID Connect client application. This approach is recommended if you are using only Okta-mastered Groups. For an Okta Org Authorization Server, you can only create an ID token with a Groups claim, not an access token. See [Authorization Servers](/docs/guides/customize-authz-server/overview/) for more information on the types of authorization servers available to you and what you can use them for.
+Use these steps to create a Groups claim for an OpenID Connect client application. This approach is recommended if you are using only Okta-backed Groups. For an Okta Org Authorization Server, you can only create an ID token with a Groups claim, not an access token. See [Authorization Servers](/docs/guides/customize-authz-server/overview/) for more information on the types of authorization servers available to you and what you can use them for.
 
 <RequireClassicUI/>
 

--- a/packages/@okta/vuepress-site/docs/guides/customize-tokens-groups-claim/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-tokens-groups-claim/overview/index.md
@@ -4,7 +4,7 @@ title: Overview
 
 You can add a Groups claim to ID tokens for any combination of App Groups and User Groups to perform single sign-on (SSO) using the Okta Org Authorization Server. You can also add a Groups claim to ID tokens and access tokens to perform authentication and authorization using a Custom Authorization Server.
 
-This guide walks you through creating a Groups claim for an OpenID Connect client application. This approach is recommended if you are using only Okta-mastered Groups. For an Okta Org Authorization Server, you can only create an ID token with a Groups claim, not an access token.
+This guide walks you through creating a Groups claim for an OpenID Connect client application. This approach is recommended if you are using only Okta-backed Groups. For an Okta Org Authorization Server, you can only create an ID token with a Groups claim, not an access token.
 
 Additionally, you can create a dynamic or static whitelist when you need to set group whitelists on a per-application basis using both the Org Authorization Server and a Custom Authorization Server. See [Add a Groups claim with a dynamic whitelist](/docs/guides/customize-tokens-dynamic/) and [Add a Groups claim with a static whitelist](/docs/guides/customize-tokens-static).
 

--- a/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
@@ -7472,7 +7472,7 @@ Specifies the password complexity requirements of the assigned password policy
 | minNumber       | Minimum number of numeric characters for the password          | Number   | FALSE    | FALSE  | TRUE     |
 | minSymbol       | Minimum number of symbol characters for the password           | Number   | FALSE    | FALSE  | TRUE     |
 | minUpperCase    | Minimum number of uppercase characters for the password       | Number   | FALSE    | FALSE  | TRUE     |
-> **Note:** Duplicate the minimum Active Directory (AD) requirements in these settings for AD-mastered users. No enforcement is triggered by Okta settings for AD-mastered users.
+> **Note:** Duplicate the minimum Active Directory (AD) requirements in these settings for AD-backed users. No enforcement is triggered by Okta settings for AD-backed users.
 
 #### Password age object
 

--- a/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
@@ -1311,7 +1311,7 @@ curl -v -X POST \
         ]
       }
     }
-  } 
+  }
 }
 ```
 
@@ -2067,7 +2067,7 @@ curl -v -X GET \
         ]
       }
     }
-  } 
+  }
 }
 ]
 ```
@@ -5472,7 +5472,7 @@ Certificate chain description for verifying assertions from the Smart Card.
 | `SAML2`      | `AUTO` or `DISABLED`          | `NONE`, `ASSIGN`, `APPEND`, or `SYNC` | `AUTO`                        |                       |
 | `X509`       | `DISABLED`                    | No support for JIT provisioning       |                               |                       |
 
-> **Note:** `CALLOUT` is a <ApiLifecycle access="deprecated" /> User provisioning action and Account Link action. 
+> **Note:** `CALLOUT` is a <ApiLifecycle access="deprecated" /> User provisioning action and Account Link action.
 
 #### Provisioning Policy object
 
@@ -5583,7 +5583,7 @@ The Group provisioning action for an IdP User:
 | `APPEND`    | Adds a User to any Group defined by the IdP as a value of the `sourceAttributeName` array that matches the name of the whitelisted Group defined in the `filter` | Unchanged                                                                                     | Unchanged                                          | Unchanged                                    |
 | `ASSIGN`    | Assigns a User to Groups defined in the `assignments` array                                                                                                          | Unchanged                                                                                     | Unchanged                                          | Unchanged                                    |
 | `NONE`      | Skips processing of Group memberships                                                                                                                              | Unchanged                                                                                     | Unchanged                                          | Unchanged                                    |
-| `SYNC`      | Group memberships are mastered by the IdP as a value of the `sourceAttributeName` array that matches the name of the whitelisted Group defined in the `filter` | Removed if not defined by the IdP in `sourceAttributeName` and matching name of the Group in `filter` | Unchanged                                          | Unchanged                                    |
+| `SYNC`      | Group memberships are backed by the IdP as a value of the `sourceAttributeName` array that matches the name of the whitelisted Group defined in the `filter` | Removed if not defined by the IdP in `sourceAttributeName` and matching name of the Group in `filter` | Unchanged                                          | Unchanged                                    |
 
 > **Note:** Group provisioning action is processed independently from profile mastering. You can sync Group memberships through SAML with profile mastering disabled.
 

--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -1232,7 +1232,7 @@ The following conditions may be applied to the rules associated with MFA Enrollm
 
 The Password policy determines the requirements for a user's password length and complexity, as well as the frequency with which a password must be changed. This policy also governs the recovery operations that may be performed by the user, including change password, reset (forgot) password and self-service password unlock.
 
-> **NOTE:** Password policies are enforced only for Okta and AD-mastered users. For AD-mastered users, ensure that your Active Directory policies don't conflict with the Okta policies.
+> **NOTE:** Password policies are enforced only for Okta and AD-backed users. For AD-backed users, ensure that your Active Directory policies don't conflict with the Okta policies.
 
 #### Policy Settings Example
 
@@ -1440,7 +1440,7 @@ Common Password Lookup object
 
 | Property   | Description                                                                                                                                                                            | Data Type | Required | Default |
 | ---        | ---                                                                                                                                                                                    | ---       | ---      | ---     |
-| skipUnlock | Indicates if, when performing an unlock operation on an Active Directory mastered user who is locked out of Okta, the system should also attempt to unlock the user's Windows account. | Boolean   | No       | false   |
+| skipUnlock | Indicates if, when performing an unlock operation on an Active Directory backed user who is locked out of Okta, the system should also attempt to unlock the user's Windows account. | Boolean   | No       | false   |
 
 ### Policy Conditions
 The following conditions may be applied to Password Policy

--- a/packages/@okta/vuepress-site/docs/reference/api/users/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/users/index.md
@@ -2508,7 +2508,7 @@ curl -v -X DELETE \
 
 Unlocks a user with a `LOCKED_OUT` status and returns them to `ACTIVE` status.  Users will be able to login with their current password.
 
-> **Note:** This operation works with Okta-mastered users. It doesn't support directory-mastered accounts such as Active Directory.
+> **Note:** This operation works with Okta-backed users. It doesn't support directory-backed accounts such as Active Directory.
 
 ##### Request Parameters
 


### PR DESCRIPTION
## Description:
- Fix developer docs to use "backed" instead of "mastered" w.r.t. Okta and AD users
- Only outstanding instance fo "*-mastered" is on a weekly release notes, which I didn't change as it's a record
- **Is this PR related to a Monolith release?** No.

## Notes
- Per my notes on the internal Okta Jira [here](https://oktainc.atlassian.net/browse/OKTA-335460?focusedCommentId=1553725&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1553725) and [here](https://oktainc.atlassian.net/browse/OKTA-335460?focusedCommentId=1553734&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1553734), there are also references to "whitelist", and "master" appears as the branch name in some JS snippets whose GitHub links are commented
- However, as discussed with @jakubvul, the developer docs team will take care of the global changes regarding the IP whitelisting wording
- When it comes to the JS snippets, these are google GitHub repos, so they would have to update their mainline branch name

### Resolves:

* [OKTA-335460](https://oktainc.atlassian.net/browse/OKTA-335460)
