### PR TITLE
OKTA-328009: Extra space on mobile viewports

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_content.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_content.scss
@@ -25,13 +25,18 @@
 
   .tree-nav {
     width: 18%;
-    @include media('>=tablet') {
-      width: 18rem;
+
+    @include media('>=desktop') {
       flex-grow: 0;
       flex-shrink: 0;
     }
 
+    @include media('>=tablet') {
+      width: 18rem;
+    }
+
     @include media('<tablet') {
+      flex-basis: 0;
       width: 40rem;
 
       .landing-navigation {


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
  * shrink empty tree-nav for mobile viewports
  * set fixed tree-nav width for desktops only
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->
No

### Resolves:

* [OKTA-328009](https://oktainc.atlassian.net/browse/OKTA-328009)
