### PR TITLE
Add GitHub edit link to bottom of content pages

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/config.js
+++ b/packages/@okta/vuepress-site/.vuepress/config.js
@@ -191,7 +191,7 @@ module.exports = {
       repo: 'okta/okta-developer-docs',
       repoLabel: 'Edit',
       editLinks: true,
-      editLinkText: "Edit",
+      editLinkText: "Edit This Page On GitHub",
       docsDir: "packages/@okta/vuepress-site"
     }
 

--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_editLink.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_editLink.scss
@@ -1,6 +1,8 @@
 .edit-on-github {
 
   text-align: right;
+  margin: 4rem 0 2rem 0;
+  font-size: 120%;
 
   @include media('<tablet') {
     display: none;

--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_editLink.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_editLink.scss
@@ -1,0 +1,8 @@
+.edit-on-github {
+
+  text-align: right;
+
+  @include media('<tablet') {
+    display: none;
+  }
+}

--- a/packages/@okta/vuepress-theme-prose/assets/css/prose.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/prose.scss
@@ -26,6 +26,7 @@
 @import 'components/button';
 @import 'components/code';
 @import 'components/content';
+@import 'components/editLink';
 @import 'components/footer';
 @import 'components/pageTitle';
 @import 'components/top-bar';

--- a/packages/@okta/vuepress-theme-prose/components/PageTitle.vue
+++ b/packages/@okta/vuepress-theme-prose/components/PageTitle.vue
@@ -4,24 +4,10 @@
       <i class='icon-48' v-if="$page.frontmatter.icon" :class="$page.frontmatter.icon" ></i>
       {{$page.title}}
     </h1>
-    <div class="page-title--updated" v-show="false">
-      <span class="updated-at">
-        Last updated <span v-text=$page.lastUpdated></span> &mdash; 
-        <a
-          v-if=editLink
-          id="edit-link"
-          :href="editLink"
-          target="_blank"
-          rel="noopener noreferrer"
-          data-proofer-ignore
-        >{{ editLinkText }}</a>
-      </span>
-    </div>
   </div>
 </template>
 
 <script>
-  export const endingSlashRE = /\/$/
   export default {
     name: 'PageTitle',
     computed: {
@@ -30,41 +16,6 @@
           return true;
         }
         return this.$page.frontmatter.icon ? true : false;
-      },
-      editLink () {
-        if (this.$page.frontmatter.editLink === false) {
-          return
-        }
-        const {
-          repo,
-          editLinks,
-          docsDir = '',
-          docsBranch = 'master',
-          docsRepo = repo
-        } = this.$site.themeConfig.editLink
-        if (docsRepo && editLinks && this.$page.regularPath) {
-          return this.createEditLink(repo, docsRepo, docsDir, docsBranch, this.$page.regularPath)
-        }
-      },
-      editLinkText () {
-        return (
-          this.$site.themeConfig.editLink.editLinkText
-          || `Edit this page`
-        )
-      }
-    },
-
-    methods: {
-      createEditLink (repo, docsRepo, docsDir, docsBranch, path) {
-
-        return (
-          `https://github.com/${docsRepo}`
-          + `/edit`
-          + `/${docsBranch}/`
-          + (docsDir ? docsDir.replace(endingSlashRE, '') : '')
-          + path
-          + `/index.md`
-        )
       }
     }
   }

--- a/packages/@okta/vuepress-theme-prose/layouts/Layout.vue
+++ b/packages/@okta/vuepress-theme-prose/layouts/Layout.vue
@@ -18,6 +18,18 @@
             <PageTitle />
             <MobileOnThisPage />
             <ContentPage />
+            <div class="edit-on-github">
+              <span class='fa fa-github'></span>
+              <span>
+                <a v-if=editLink
+                   id="edit-link"
+                   :href="editLink"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   data-proofer-ignore
+                >{{ editLinkText }}</a>
+              </span>
+            </div>
           </div>
           <div class="on-this-page">
             <OnThisPage />
@@ -36,7 +48,7 @@
 export const LAYOUT_CONSTANTS = {
   HEADER_TO_CONTENT_GAP: 45, //px
 };
-
+export const endingSlashRE = /\/$/
 export default {
   components: {
     TopBar: () => import('../components/TopBar.vue'),
@@ -69,6 +81,29 @@ export default {
       this.redirIfRequired();
     }
   },
+  computed: {
+    editLink () {
+      if (this.$page.frontmatter.editLink === false) {
+        return
+      }
+      const {
+        repo,
+        editLinks,
+        docsDir = '',
+        docsBranch = 'master',
+        docsRepo = repo
+      } = this.$site.themeConfig.editLink
+      if (docsRepo && editLinks && this.$page.regularPath) {
+        return this.createEditLink(repo, docsRepo, docsDir, docsBranch, this.$page.regularPath)
+      }
+    },
+    editLinkText () {
+      return (
+        this.$site.themeConfig.editLink.editLinkText
+        || `Edit this page`
+      )
+    }
+  },
   methods: {
     redirIfRequired() {
       if(this.$page && this.$page.redir) {
@@ -79,6 +114,16 @@ export default {
           this.$router.replace({ path: `${this.$page.redir}` });
         }
       }
+    },
+    createEditLink (repo, docsRepo, docsDir, docsBranch, path) {
+      return (
+        `https://github.com/${docsRepo}`
+        + `/edit`
+        + `/${docsBranch}/`
+        + (docsDir ? docsDir.replace(endingSlashRE, '') : '')
+        + path
+        + `/index.md`
+      )
     }
   }
 }

--- a/packages/@okta/vuepress-theme-prose/layouts/Layout.vue
+++ b/packages/@okta/vuepress-theme-prose/layouts/Layout.vue
@@ -93,8 +93,9 @@ export default {
         docsBranch = 'master',
         docsRepo = repo
       } = this.$site.themeConfig.editLink
-      if (docsRepo && editLinks && this.$page.regularPath) {
-        return this.createEditLink(repo, docsRepo, docsDir, docsBranch, this.$page.regularPath)
+      if (docsRepo && editLinks && this.$page.relativePath) {
+        console.log('page: ', this.$page)
+        return this.createEditLink(repo, docsRepo, docsDir, docsBranch, this.$page.relativePath)
       }
     },
     editLinkText () {
@@ -121,8 +122,8 @@ export default {
         + `/edit`
         + `/${docsBranch}/`
         + (docsDir ? docsDir.replace(endingSlashRE, '') : '')
+        + '/'
         + path
-        + `/index.md`
       )
     }
   }


### PR DESCRIPTION
This change moves the 'edit link' from the PageTitle component to the Layout, as PageTitle is NOT use for every page

**NOTE:**
* Edit link is at the bottom of page
* It is only shown when screen size is bigger than a tablet 
* css is minimal, someone may want to improve it before merging

Example:
The browser URL: 
```
/docs/guides/sign-users-out/android/before-you-begin/
```

shows a link to 
```
https://github.com/okta/okta-developer-docs/edit/master/packages/@okta/vuepress-site/docs/guides/sign-users-out/android/before-you-begin//index.md
```

NFDEPLOY