### PR TITLE
OKTA-320836: In-page link target headings do not take user to the right content nav section

### DIFF
--- a/packages/@okta/vuepress-theme-prose/components/ContentPage.vue
+++ b/packages/@okta/vuepress-theme-prose/components/ContentPage.vue
@@ -25,11 +25,13 @@ export default {
     });
   },
   watch: {
-    $page() {
-      this.$nextTick(function () {
-        this.scrollToActiveAnchor();
-        this.captureAnchors();
-      });
+    $page(to, from) {
+      if(from.title !== to.title) {
+        this.$nextTick(function () {
+          this.scrollToActiveAnchor();
+          this.captureAnchors();
+        });
+      }
     },
   },
   methods: {
@@ -55,9 +57,8 @@ export default {
       }
     },
     captureAnchors() {
-      this.anchors.forEach((link) =>
-        link.removeEventListener("click", this.onAnchorClick)
-      );
+      this.anchors.forEach(link =>
+        link.removeEventListener("click", this.onAnchorClick), this);
 
       this.headingAnchorsMap = Array.from(
         document.querySelectorAll(".header-anchor.header-link")

--- a/packages/@okta/vuepress-theme-prose/components/ContentPage.vue
+++ b/packages/@okta/vuepress-theme-prose/components/ContentPage.vue
@@ -14,14 +14,12 @@ export default {
     };
   },
   mounted() {
-    window.addEventListener("load", () => {
-      window.setTimeout(() => {
-        this.paddedHeaderHeight =
-          document.querySelector(".fixed-header").clientHeight +
-          LAYOUT_CONSTANTS.HEADER_TO_CONTENT_GAP;
-        this.scrollToActiveAnchor();
-        this.captureAnchors();
-      }, 500);
+    this.$nextTick(function() {
+      this.paddedHeaderHeight =
+        document.querySelector(".fixed-header").clientHeight +
+        LAYOUT_CONSTANTS.HEADER_TO_CONTENT_GAP;
+      this.scrollToActiveAnchor();
+      this.captureAnchors();
     });
   },
   watch: {

--- a/packages/@okta/vuepress-theme-prose/components/ContentPage.vue
+++ b/packages/@okta/vuepress-theme-prose/components/ContentPage.vue
@@ -6,7 +6,6 @@
 import { LAYOUT_CONSTANTS } from "../layouts/Layout";
 export default {
   name: "ContentPage",
-  props: ["pageTitle"],
   data() {
     return {
       anchors: [],
@@ -26,7 +25,7 @@ export default {
     });
   },
   watch: {
-    pageTitle() {
+    $page() {
       this.$nextTick(function () {
         this.scrollToActiveAnchor();
         this.captureAnchors();

--- a/packages/@okta/vuepress-theme-prose/components/ContentPage.vue
+++ b/packages/@okta/vuepress-theme-prose/components/ContentPage.vue
@@ -83,8 +83,6 @@ export default {
         if (target) {
           window.scrollTo(0, target.offsetTop - this.paddedHeaderHeight);
         }
-      } else {
-        window.scrollBy(0, -this.paddedHeaderHeight);
       }
     },
   },

--- a/packages/@okta/vuepress-theme-prose/components/ContentPage.vue
+++ b/packages/@okta/vuepress-theme-prose/components/ContentPage.vue
@@ -10,27 +10,32 @@ export default {
     return {
       anchors: [],
       headingAnchorsMap: {},
-      paddedHeaderHeight: 0,
+      paddedHeaderHeight: 0
     };
   },
   mounted() {
-    this.$nextTick(function() {
-      this.paddedHeaderHeight =
-        document.querySelector(".fixed-header").clientHeight +
-        LAYOUT_CONSTANTS.HEADER_TO_CONTENT_GAP;
-      this.scrollToActiveAnchor();
-      this.captureAnchors();
-    });
+    this.paddedHeaderHeight =
+      document.querySelector(".fixed-header").clientHeight +
+      LAYOUT_CONSTANTS.HEADER_TO_CONTENT_GAP;
+    if (document.readyState === "complete") {
+        this.scrollToActiveAnchor();
+        this.captureAnchors();
+    } else {
+      window.addEventListener("load", () => {
+        this.scrollToActiveAnchor();
+        this.captureAnchors();
+      });
+    }
   },
   watch: {
     $page(to, from) {
-      if(from.title !== to.title) {
-        this.$nextTick(function () {
+      if (from.title !== to.title) {
+        this.$nextTick(function() {
           this.scrollToActiveAnchor();
           this.captureAnchors();
         });
       }
-    },
+    }
   },
   methods: {
     onAnchorClick(event) {
@@ -55,12 +60,14 @@ export default {
       }
     },
     captureAnchors() {
-      this.anchors.forEach(link =>
-        link.removeEventListener("click", this.onAnchorClick), this);
+      this.anchors.forEach(
+        link => link.removeEventListener("click", this.onAnchorClick),
+        this
+      );
 
       this.headingAnchorsMap = Array.from(
         document.querySelectorAll(".header-anchor.header-link")
-      ).reduce(function (anchorsByHash, anchor) {
+      ).reduce(function(anchorsByHash, anchor) {
         anchorsByHash[anchor.hash] = anchor;
         return anchorsByHash;
       }, {});
@@ -70,9 +77,10 @@ export default {
         )
       );
 
-      this.anchors.forEach((link) => {
-        link.addEventListener("click", this.onAnchorClick);
-      }, this);
+      this.anchors.forEach(
+        link => link.addEventListener("click", this.onAnchorClick),
+        this
+      );
     },
     scrollToActiveAnchor() {
       let anchor = window.location.href.split("#")[1];
@@ -82,7 +90,7 @@ export default {
           window.scrollTo(0, target.offsetTop - this.paddedHeaderHeight);
         }
       }
-    },
-  },
+    }
+  }
 };
 </script>

--- a/packages/@okta/vuepress-theme-prose/components/ContentPage.vue
+++ b/packages/@okta/vuepress-theme-prose/components/ContentPage.vue
@@ -1,0 +1,92 @@
+<template>
+  <Content />
+</template>
+
+<script>
+import { LAYOUT_CONSTANTS } from "../layouts/Layout";
+export default {
+  name: "ContentPage",
+  props: ["pageTitle"],
+  data() {
+    return {
+      anchors: [],
+      headingAnchorsMap: {},
+      paddedHeaderHeight: 0,
+    };
+  },
+  mounted() {
+    window.addEventListener("load", () => {
+      window.setTimeout(() => {
+        this.paddedHeaderHeight =
+          document.querySelector(".fixed-header").clientHeight +
+          LAYOUT_CONSTANTS.HEADER_TO_CONTENT_GAP;
+        this.scrollToActiveAnchor();
+        this.captureAnchors();
+      }, 500);
+    });
+  },
+  watch: {
+    pageTitle() {
+      this.$nextTick(function () {
+        this.scrollToActiveAnchor();
+        this.captureAnchors();
+      });
+    },
+  },
+  methods: {
+    onAnchorClick(event) {
+      const element = event.target.hash
+        ? event.target
+        : event.target.closest("a");
+      if (
+        location.pathname.replace(/^\//, "") ==
+          element.pathname.replace(/^\//, "") &&
+        location.hostname == element.hostname
+      ) {
+        let scrollToAnchor = this.headingAnchorsMap[element.hash];
+        if (scrollToAnchor) {
+          event.preventDefault();
+          window.scrollTo(
+            0,
+            scrollToAnchor.offsetTop - this.paddedHeaderHeight
+          );
+          location.hash = element.hash;
+          return false;
+        }
+      }
+    },
+    captureAnchors() {
+      this.anchors.forEach((link) =>
+        link.removeEventListener("click", this.onAnchorClick)
+      );
+
+      this.headingAnchorsMap = Array.from(
+        document.querySelectorAll(".header-anchor.header-link")
+      ).reduce(function (anchorsByHash, anchor) {
+        anchorsByHash[anchor.hash] = anchor;
+        return anchorsByHash;
+      }, {});
+      this.anchors = Array.from(
+        document.querySelectorAll(
+          'a[href^="#"]:not(.on-this-page-link):not(.tree-nav-link)'
+        )
+      );
+
+      this.anchors.forEach((link) => {
+        link.addEventListener("click", this.onAnchorClick);
+      }, this);
+    },
+    scrollToActiveAnchor() {
+      let anchor = window.location.href.split("#")[1];
+      if (anchor) {
+        let target = document.getElementById(anchor);
+        if (target) {
+          window.scrollTo(0, target.offsetTop - this.paddedHeaderHeight);
+        }
+      } else {
+        window.scrollBy(0, -this.paddedHeaderHeight);
+      }
+    },
+  },
+};
+</script>

--- a/packages/@okta/vuepress-theme-prose/components/OnThisPage.vue
+++ b/packages/@okta/vuepress-theme-prose/components/OnThisPage.vue
@@ -66,21 +66,17 @@
           document.documentElement.scrollTop,
           document.body.scrollTop
         )
-        for (let i = 0; i < anchors.length; i++) {
-          const anchor = anchors[i]
-          const nextAnchor = anchors[i + 1]
 
-          const isActive = i === 0 && scrollTop === 0
-            || (scrollTop >= anchor.parentElement.offsetTop - document.querySelector('.fixed-header').clientHeight - 45
-              && (!nextAnchor || scrollTop < nextAnchor.parentElement.offsetTop - document.querySelector('.fixed-header').clientHeight - 45))
-          
-          
-          
-          if (isActive && decodeURIComponent(this.$route.hash) !== decodeURIComponent(anchor.hash)) {
-            this.activeAnchor = anchor.hash;
-            
-            return
-          }
+        const paddedHeaderHeight = document.querySelector('.fixed-header').clientHeight + 45;
+        const anchorOffsets = anchors.map(anchor => anchor.parentElement.offsetTop);
+        const anchorOffsetPairs = anchorOffsets.map((anchorOffset, index, anchorOffsets) => [anchorOffset, anchorOffsets[index + 1]]);
+
+        const matchingPair = anchorOffsetPairs.find(pair =>
+          (scrollTop >= pair[0] - paddedHeaderHeight) && (!pair[1] || scrollTop < pair[1] - paddedHeaderHeight));
+
+        const activeAnchor = matchingPair ? anchors[anchorOffsetPairs.indexOf(matchingPair)] : anchors[0];
+        if (activeAnchor && decodeURIComponent(this.$route.hash) !== decodeURIComponent(activeAnchor.hash)) {
+          this.activeAnchor = activeAnchor.hash;
         }
       }
     }

--- a/packages/@okta/vuepress-theme-prose/components/OnThisPage.vue
+++ b/packages/@okta/vuepress-theme-prose/components/OnThisPage.vue
@@ -15,6 +15,7 @@
 </template>
 
 <script>
+  import { LAYOUT_CONSTANTS } from '../layouts/Layout.vue';
   export default {
     name: 'OnThisPage',
     components: {
@@ -67,7 +68,7 @@
           document.body.scrollTop
         )
 
-        const paddedHeaderHeight = document.querySelector('.fixed-header').clientHeight + 45;
+        const paddedHeaderHeight = document.querySelector('.fixed-header').clientHeight + LAYOUT_CONSTANTS.HEADER_TO_CONTENT_GAP;
         const anchorOffsets = anchors.map(anchor => anchor.parentElement.offsetTop);
         const anchorOffsetPairs = anchorOffsets.map((anchorOffset, index, anchorOffsets) => [anchorOffset, anchorOffsets[index + 1]]);
 

--- a/packages/@okta/vuepress-theme-prose/components/OnThisPageItem.vue
+++ b/packages/@okta/vuepress-theme-prose/components/OnThisPageItem.vue
@@ -10,6 +10,7 @@
 </template>
 
 <script>
+import { LAYOUT_CONSTANTS } from '../layouts/Layout.vue';
 export default {
   name: 'OnThisPageItem',
   props: ['link', 'activeAnchor'],
@@ -55,7 +56,7 @@ export default {
       if(hash) {
         const node = document.querySelector(hash);
         if(node) { // node is sometimes null - perhaps content hasn't loaded?
-          const scrollToPosition = node.offsetTop - document.querySelector('.fixed-header').clientHeight - 45;
+          const scrollToPosition = node.offsetTop - document.querySelector('.fixed-header').clientHeight - LAYOUT_CONSTANTS.HEADER_TO_CONTENT_GAP;
           window.scrollTo(0, scrollToPosition);
           // Chrome & Safari: when zoomed in/out, window.scrollTo does not always perform scroll strictly equal to passed parameter
           // https://bugs.chromium.org/p/chromium/issues/detail?id=890345

--- a/packages/@okta/vuepress-theme-prose/components/OnThisPageItem.vue
+++ b/packages/@okta/vuepress-theme-prose/components/OnThisPageItem.vue
@@ -51,11 +51,18 @@ export default {
       if(e.target.tagName.toLowerCase() === 'a') {
         hash = e.target.hash
       }
-    
+
       if(hash) {
         const node = document.querySelector(hash);
         if(node) { // node is sometimes null - perhaps content hasn't loaded?
-          window.scrollTo(0, node.offsetTop - document.querySelector('.fixed-header').clientHeight - 45);
+          const scrollToPosition = node.offsetTop - document.querySelector('.fixed-header').clientHeight - 45;
+          window.scrollTo(0, scrollToPosition);
+          // Chrome & Safari: when zoomed in/out, window.scrollTo does not always perform scroll strictly equal to passed parameter
+          // https://bugs.chromium.org/p/chromium/issues/detail?id=890345
+          if(window.scrollY < scrollToPosition) {
+            const scrollAlignment = 2;
+            window.scrollBy(0, scrollAlignment);
+          }
         }
       }
     }

--- a/packages/@okta/vuepress-theme-prose/components/SidebarItem.vue
+++ b/packages/@okta/vuepress-theme-prose/components/SidebarItem.vue
@@ -45,14 +45,8 @@ export default {
             this.setData();
         },
         'iHaveChildrenActive' (isActivated, _) {
-            if (isActivated && this.link.path) {
-                this.$el.scrollIntoView({
-                    block: 'center'
-                });
-            } else if (isActivated) {
-                this.$el.scrollIntoView({
-                    block: 'nearest'
-                });
+            if (isActivated) {
+                this.$el.scrollIntoViewIfNeeded();
             }
         }
     },

--- a/packages/@okta/vuepress-theme-prose/layouts/Layout.vue
+++ b/packages/@okta/vuepress-theme-prose/layouts/Layout.vue
@@ -77,7 +77,6 @@ export default {
 
           Array.from(allContentAnchors).forEach((link) => {
             link.addEventListener('click', function(event) {
-              debugger;
               if (location.pathname.replace(/^\//,'') == this.pathname.replace(/^\//,'') && location.hostname == this.hostname) {
                 let target = headingAnchorsMap[this.hash];
                 if (target) {

--- a/packages/@okta/vuepress-theme-prose/layouts/Layout.vue
+++ b/packages/@okta/vuepress-theme-prose/layouts/Layout.vue
@@ -17,7 +17,7 @@
           <div class="content-area">
             <PageTitle />
             <MobileOnThisPage />
-            <ContentPage :pageTitle="$page.title"/>
+            <ContentPage />
           </div>
           <div class="on-this-page">
             <OnThisPage />

--- a/packages/@okta/vuepress-theme-prose/layouts/Layout.vue
+++ b/packages/@okta/vuepress-theme-prose/layouts/Layout.vue
@@ -53,13 +53,16 @@ export default {
   },
   mounted() {
     window.addEventListener('load', () => {
+        const paddedHeaderHeight = document.querySelector('.fixed-header').clientHeight + 45;
         window.setTimeout(() => {
           let anchor = window.location.href.split('#')[1];
           if (anchor) {
             let target = document.getElementById(anchor);
             if (target) {
-              window.scrollTo(0, target.offsetTop - document.querySelector('.fixed-header').clientHeight - 45);
+              window.scrollTo(0, target.offsetTop - paddedHeaderHeight);
             }
+          } else {
+            window.scrollBy(0, -paddedHeaderHeight)
           }
 
           // let links = document.querySelectorAll('a[href*="#"]:not([href="#"]):not([href*="/quickstart/#"])');
@@ -73,7 +76,7 @@ export default {
                 let target = document.querySelector(this.hash);
                 if (target) {
                   event.preventDefault();
-                  window.scrollTo(0, target.offsetTop - document.querySelector('.fixed-header').clientHeight - 45);
+                  window.scrollTo(0, target.offsetTop - paddedHeaderHeight);
                   location.hash = this.hash;
                   return false;
                 }

--- a/packages/@okta/vuepress-theme-prose/layouts/Layout.vue
+++ b/packages/@okta/vuepress-theme-prose/layouts/Layout.vue
@@ -33,6 +33,10 @@
 
 <script>
 
+export const LAYOUT_CONSTANTS = {
+  HEADER_TO_CONTENT_GAP: 45, //px
+};
+
 export default {
   components: {
     TopBar: () => import('../components/TopBar.vue'),
@@ -53,7 +57,7 @@ export default {
   },
   mounted() {
     window.addEventListener('load', () => {
-        const paddedHeaderHeight = document.querySelector('.fixed-header').clientHeight + 45;
+        const paddedHeaderHeight = document.querySelector('.fixed-header').clientHeight + LAYOUT_CONSTANTS.HEADER_TO_CONTENT_GAP;
         window.setTimeout(() => {
           let anchor = window.location.href.split('#')[1];
           if (anchor) {
@@ -65,15 +69,17 @@ export default {
             window.scrollBy(0, -paddedHeaderHeight)
           }
 
-          // let links = document.querySelectorAll('a[href*="#"]:not([href="#"]):not([href*="/quickstart/#"])');
-          let links = document.querySelectorAll('.header-anchor.header-link');
+          const headingAnchorsMap = Array.from(document.querySelectorAll('.header-anchor.header-link')).reduce(function (anchorsByHash, anchor) {
+            anchorsByHash[anchor.hash] = anchor;
+            return anchorsByHash;
+          }, {});
+          const allContentAnchors = document.querySelectorAll('a[href^="#"]:not(.on-this-page-link):not(.tree-nav-link)');
 
-          Array.from(links).forEach((link) => {
+          Array.from(allContentAnchors).forEach((link) => {
             link.addEventListener('click', function(event) {
-
+              debugger;
               if (location.pathname.replace(/^\//,'') == this.pathname.replace(/^\//,'') && location.hostname == this.hostname) {
-
-                let target = document.querySelector(this.hash);
+                let target = headingAnchorsMap[this.hash];
                 if (target) {
                   event.preventDefault();
                   window.scrollTo(0, target.offsetTop - paddedHeaderHeight);

--- a/packages/@okta/vuepress-theme-prose/layouts/Layout.vue
+++ b/packages/@okta/vuepress-theme-prose/layouts/Layout.vue
@@ -17,7 +17,7 @@
           <div class="content-area">
             <PageTitle />
             <MobileOnThisPage />
-            <Content />
+            <ContentPage :pageTitle="$page.title"/>
           </div>
           <div class="on-this-page">
             <OnThisPage />
@@ -45,6 +45,7 @@ export default {
     MobileOnThisPage: () => import('../components/MobileOnThisPage.vue'),
     PageTitle: () => import('../components/PageTitle.vue'),
     Breadcrumb: () => import('../components/Breadcrumb.vue'),
+    ContentPage: () => import('../components/ContentPage.vue'),
     Footer: () => import('../components/Footer.vue'),
     Documentation: () => import('../components/Documentation.vue'),
     Reference: () => import('../components/Reference.vue'),
@@ -56,41 +57,6 @@ export default {
     }
   },
   mounted() {
-    window.addEventListener('load', () => {
-        const paddedHeaderHeight = document.querySelector('.fixed-header').clientHeight + LAYOUT_CONSTANTS.HEADER_TO_CONTENT_GAP;
-        window.setTimeout(() => {
-          let anchor = window.location.href.split('#')[1];
-          if (anchor) {
-            let target = document.getElementById(anchor);
-            if (target) {
-              window.scrollTo(0, target.offsetTop - paddedHeaderHeight);
-            }
-          } else {
-            window.scrollBy(0, -paddedHeaderHeight)
-          }
-
-          const headingAnchorsMap = Array.from(document.querySelectorAll('.header-anchor.header-link')).reduce(function (anchorsByHash, anchor) {
-            anchorsByHash[anchor.hash] = anchor;
-            return anchorsByHash;
-          }, {});
-          const allContentAnchors = document.querySelectorAll('a[href^="#"]:not(.on-this-page-link):not(.tree-nav-link)');
-
-          Array.from(allContentAnchors).forEach((link) => {
-            link.addEventListener('click', function(event) {
-              if (location.pathname.replace(/^\//,'') == this.pathname.replace(/^\//,'') && location.hostname == this.hostname) {
-                let target = headingAnchorsMap[this.hash];
-                if (target) {
-                  event.preventDefault();
-                  window.scrollTo(0, target.offsetTop - paddedHeaderHeight);
-                  location.hash = this.hash;
-                  return false;
-                }
-              }
-            })
-          })
-        }, 500);
-    });
-
     let that = this;
     this.$on('toggle-tree-nav', event => {
       that.treeNavOpen = event.treeNavOpen;

--- a/tests/selenium/framework/page-objects/BasePage.js
+++ b/tests/selenium/framework/page-objects/BasePage.js
@@ -146,5 +146,14 @@ class BasePage {
     }
   }
 
+  getInPageLink(hash) {
+    return element(by.css(`a[href='${hash}']:not(.header-anchor)`));
+  }
+
+  getHeading(selector) {
+    return element(by.css(selector));
+  }
+
+
 }
 module.exports = BasePage;

--- a/tests/selenium/framework/shared/util.js
+++ b/tests/selenium/framework/shared/util.js
@@ -86,7 +86,12 @@ util.isInViewport = async function (elem) {
     + "    found = true;"
     + "    break;"
     + "  }"
-    + "  foundElement = foundElement.parentElement;"
+    + "  try { "
+    + "    foundElement = foundElement.parentElement;"
+    + "  } catch (e) {"
+    + "    console.log('Unable to locate element in viewport ', e.message);"
+    + "    return false;"
+    + "  } "
     + "} while (foundElement);"
     + "return found;"
     , elem).then(isInViewport => {

--- a/tests/selenium/spec/page-content-spec.js
+++ b/tests/selenium/spec/page-content-spec.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const TextPage = require('../framework/page-objects/TextPage');
+const DocsPage = require('../framework/page-objects/DocsPage');
+const util = require('../framework/shared/util');
+
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+const { browser } = require('protractor');
+
+chai.use(chaiAsPromised);
+var expect = chai.expect;
+
+describe('content section', () => {
+  const page = new TextPage('/test_page/');
+  const docsPage = new DocsPage('/docs');
+
+  it('displays heading corresponding to URL hash', util.itHelper(async () => {
+    page.navigate('/test_page/#last-section');
+    page.refresh();
+    const id = '#first-section';
+    try {
+      const inPageLink = await page.getInPageLink(id).getWebElement();
+      let heading = page.getHeading(`h2${id}`).getWebElement();
+      expect(await util.isInViewport(heading), 'heading is not expected to be visible before in-page link click').to.equal(false);
+      inPageLink.click();
+      heading = page.getHeading(id).getWebElement();
+      expect(await util.isInViewport(heading), 'heading is not visible').to.equal(true);
+    } catch(err) {
+      throw err;
+    }
+  }));
+
+  it('preserves correct scroll-to-heading behavior on page change', util.itHelper(async () => {
+    docsPage.navigate('/docs/reference/api/groups');
+    const id = "#factor-lifecycle-operations";
+    try {
+      const treeNavLink = await (await docsPage.getTreeNavLink('Factors')).getWebElement();
+      treeNavLink.click();
+      await docsPage.waitForPresence(await docsPage.getHeading(`h2${id}`), 2000)
+      let heading = await docsPage.getHeading(`h2${id}`).getWebElement();
+      expect(await util.isInViewport(heading), 'heading is not expected to be visible before in-page link click').to.equal(false);
+      const inPageLink = await docsPage.getInPageLink(id).getWebElement();
+      inPageLink.click();
+      heading = await docsPage.getHeading(`h2${id}`).getWebElement();
+      expect(await util.isInViewport(heading), 'heading is not visible').to.equal(true);
+    } catch(err) {
+      throw err;
+    }
+  }));
+  });


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
  * add scroll correction for non-100% screen scale
  * scroll page title into view on direct URL navigation w/o anchor set
  * move static values out of the loop
  * attach click handlers to non-heading anchors
  * selenium test for scroll-to-heading
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->
No

### Resolves:

* [OKTA-320836](https://oktainc.atlassian.net/browse/OKTA-320836)
