### PR TITLE
Updated "Find your Okta domain" page in the Basics guide

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/find-your-domain/findorg/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/find-your-domain/findorg/index.md
@@ -20,5 +20,4 @@ Your Okta domain looks like:
 
 See [Okta Organizations](/docs/concepts/okta-organizations/) for more information on the types of Okta orgs.
 
-   > **Note:** Alternatively, find the welcome email in your inbox that you received when you signed up. The email contains your Okta URL.
-
+> **Note:** Alternatively, find the welcome email in your inbox that you received when you signed up. The email contains your Okta URL.

--- a/packages/@okta/vuepress-site/docs/guides/find-your-domain/findorg/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/find-your-domain/findorg/index.md
@@ -19,3 +19,6 @@ Your Okta domain looks like:
 * `example.okta-emea.com`
 
 See [Okta Organizations](/docs/concepts/okta-organizations/) for more information on the types of Okta orgs.
+
+   > **Note:** Alternatively, find the welcome email in your inbox that you received when you signed up. The email contains your Okta URL.
+


### PR DESCRIPTION
## Description:
- **What's changed?** In the Basics guide, "Find your Okta domain" topic is updated with a note to provide an alternative way to find the Okta URL.

- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-338985](https://oktainc.atlassian.net/browse/OKTA-338985)
