### PR TITLE
Typo: getUser() method returns claims object, not array

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/user-info/angular/getuserinfo.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/user-info/angular/getuserinfo.md
@@ -15,7 +15,7 @@ export class ProfileComponent implements OnInit {
   }
 
   async ngOnInit() {
-    // returns an array of claims
+    // returns an object with user's claims
     const userClaims = await this.oktaAuth.getUser();
 
     // user name is exposed directly as property


### PR DESCRIPTION
## Description:
-  Change text on [Get info about the user](https://developer.okta.com/docs/guides/sign-into-spa/angular/user-info/) page:`getUser()` method returns claims object, not array (example of returned claims: [here](https://developer.okta.com/docs/reference/api/oidc/#response-example-success-5))

### Resolves:

* [OKTA-327081](https://oktainc.atlassian.net/browse/OKTA-327081)
