### PR TITLE
Require authentication for everything > Angular - callback route should be unprotected

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/require-authentication/angular/reqautheverything.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/require-authentication/angular/reqautheverything.md
@@ -1,16 +1,22 @@
-To require authentication for all routes, use a loop to add `OktaAuthGuard` to every item in the `Routes` collection.
+To require authentication for all routes, use a loop to add `OktaAuthGuard` to every item in the `Routes` collection except login callback route.
 
 ```javascript
 
 import { Routes, RouterModule } from '@angular/router';
 import { OktaAuthGuard } from '@okta/okta-angular';
 
+const CALLBACK_PATH = 'login/callback';
+const pathExceptions = [
+  CALLBACK_PATH
+];
+
 const appRoutes: Routes = [
   // Your routes...
 ];
 
-// Require authentication on every route
-appRoutes.forEach(route => {
+// Require authentication on every route except login callback route
+const protectedRoutes = appRoutes.filter(route => !pathExceptions.includes(route.path));
+protectedRoutes.forEach(route => {
   router.canActivate = router.canActivate || [];
   route.canActivate.push(OktaAuthGuard);
 });


### PR DESCRIPTION


<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** 
https://developer.okta.com/docs/guides/sign-into-spa/angular/require-authentication/
For Angular user should protect all routes except login callback one (with path like `login/callback` and component `OktaCallbackComponent`)

- **Is this PR related to a Monolith release?** 
No

### Resolves:

* [OKTA-336830](https://oktainc.atlassian.net/browse/OKTA-336830)
