### PR TITLE
OKTA-343973: Add LDAP_INTERFACE AuthType to policy api documentation

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -757,7 +757,7 @@ Specifies an authentication entry point
 
 | Parameter | Description                              | Data Type                             | Required | Default |
 | --------- | ---------------------------------------- | ------------------------------------- | -------- | ------- |
-| authType  | This tells how the user is authenticated | `ANY` or `RADIUS` or `LDAP_INTERFACE` | No       |  `ANY`  |
+| `authType`  | Specifies how the user is authenticated | `ANY` or `RADIUS` or `LDAP_INTERFACE` | No       |  `ANY`  |
 
 > **Note:** The `LDAP_INTERFACE` data type option is an <ApiLifecycle access="ea" /> feature.
 

--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -759,7 +759,7 @@ Specifies an authentication entry point
 | --------- | ---------------------------------------- | ------------------------------------- | -------- | ------- |
 | authType  | This tells how the user is authenticated | `ANY` or `RADIUS` or `LDAP_INTERFACE` | No       |  `ANY`  |
 
-`LDAP_INTERFACE` is an <ApiLifecycle access="ea" /> release.
+> **Note:** The `LDAP_INTERFACE` data type option is an <ApiLifecycle access="ea" /> feature.
 
 #### Network Condition object
 

--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -755,9 +755,9 @@ Specifies a set of Groups whose Users are to be included or excluded
 
 Specifies an authentication entry point
 
-| Parameter | Description | Data Type                             | Required | Default |
-| --------- | ----------- | ------------------------------------- | -------- | ------- |
-| authType  |             | `ANY` or `RADIUS` or `LDAP_INTERFACE` | No       |         |
+| Parameter | Description | Data Type                                                         | Required | Default |
+| --------- | ----------- | ----------------------------------------------------------------- | -------- | ------- |
+| authType  |             | `ANY` or `RADIUS` or `LDAP_INTERFACE`<ApiLifecycle access="ea" /> | No       |         |
 
 #### Network Condition object
 

--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -753,11 +753,13 @@ Specifies a set of Groups whose Users are to be included or excluded
 
 #### AuthContext Condition object
 
-Specifies an authentication entry point. This tells how the user is authenticated.
+Specifies an authentication entry point
 
-| Parameter | Description | Data Type                                                         | Required | Default |
-| --------- | ----------- | ----------------------------------------------------------------- | -------- | ------- |
-| authType  |             | `ANY` or `RADIUS` or `LDAP_INTERFACE`<ApiLifecycle access="ea" /> | No       |         |
+| Parameter | Description                              | Data Type                             | Required | Default |
+| --------- | ---------------------------------------- | ------------------------------------- | -------- | ------- |
+| authType  | This tells how the user is authenticated | `ANY` or `RADIUS` or `LDAP_INTERFACE` | No       |  `ANY`  |
+
+`LDAP_INTERFACE` is an <ApiLifecycle access="ea" /> release.
 
 #### Network Condition object
 

--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -753,7 +753,7 @@ Specifies a set of Groups whose Users are to be included or excluded
 
 #### AuthContext Condition object
 
-Specifies an authentication entry point
+Specifies an authentication entry point. This tells how the user is authenticated.
 
 | Parameter | Description | Data Type                                                         | Required | Default |
 | --------- | ----------- | ----------------------------------------------------------------- | -------- | ------- |

--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -755,9 +755,9 @@ Specifies a set of Groups whose Users are to be included or excluded
 
 Specifies an authentication entry point
 
-| Parameter | Description | Data Type         | Required | Default |
-| --------- | ----------- | ----------------- | -------- | ------- |
-| authType  |             | `ANY` or `RADIUS` | No       |         |
+| Parameter | Description | Data Type                             | Required | Default |
+| --------- | ----------- | ------------------------------------- | -------- | ------- |
+| authType  |             | `ANY` or `RADIUS` or `LDAP_INTERFACE` | No       |         |
 
 #### Network Condition object
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
  * Add a new AuthType: LDAP_INTERFACE to policy api documentation
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->
2021.03.0. (confirm with John Huang)

### Resolves:

* OKTA-343973
