### PR TITLE
removed PROFILE_MASTERING feature example from docs

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/roles/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/roles/index.md
@@ -760,7 +760,6 @@ The example shows two applications and two instances. Note the response for inst
       "IMPORT_NEW_USERS",
       "IMPORT_PROFILE_UPDATES",
       "IMPORT_USER_SCHEMA",
-      "PROFILE_MASTERING",
       "PUSH_NEW_USERS",
       "PUSH_PASSWORD_UPDATES",
       "PUSH_PROFILE_UPDATES",


### PR DESCRIPTION
## Description:
removed PROFILE_MASTERING feature example from “App administrator role App targets” API Doc 
 https://developer.okta.com/docs/reference/api/roles/#response-example-13
### Resolves:

* [OKTA-338565](https://oktainc.atlassian.net/browse/OKTA-338565)
