### PR TITLE
add apps api ea docs

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/public/docs/api/postman/apps.json
+++ b/packages/@okta/vuepress-site/.vuepress/public/docs/api/postman/apps.json
@@ -1239,7 +1239,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"profile\": {\n        \"authScheme\": \"TOKEN\",\n        \"token\": \"TESTTOKEN\"\n    }\n}s"
+							"raw": "{\n    \"profile\": {\n        \"authScheme\": \"TOKEN\",\n        \"token\": \"TESTTOKEN\"\n    }\n}"
 						},
 						"url": {
 							"raw": "{{url}}/api/v1/apps/{{appId}}/connections/default?activate=true",

--- a/packages/@okta/vuepress-site/.vuepress/public/docs/api/postman/apps.json
+++ b/packages/@okta/vuepress-site/.vuepress/public/docs/api/postman/apps.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "c4506b10-2933-4f8b-a191-eb4dc646509f",
+		"_postman_id": "67983c32-de20-4b47-86f4-d8a60c20f2c0",
 		"name": "Apps (Okta API)",
 		"description": "The [Okta Application API](/docs/api/rest/apps.html) provides operations to manage applications and/or assignments to users or groups for your organization.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -1129,6 +1129,382 @@
 						}
 					},
 					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "Logo Operations",
+			"item": [
+				{
+					"name": "Update logo",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Authorization",
+								"value": "SSWS {{apikey}}"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "file",
+									"type": "file",
+									"src": []
+								}
+							]
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/apps/{{appId}}/logo",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"apps",
+								"{{appId}}",
+								"logo"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "Provisioning Connection Operations",
+			"item": [
+				{
+					"name": "Get Default Provisioning Connection",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "SSWS {{apikey}}"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/api/v1/apps/{{appId}}/connections/default",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"apps",
+								"{{appId}}",
+								"connections",
+								"default"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create Default Provisioning Connection",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "SSWS {{apikey}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"profile\": {\n        \"authScheme\": \"TOKEN\",\n        \"token\": \"TESTTOKEN\"\n    }\n}s"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/apps/{{appId}}/connections/default?activate=true",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"apps",
+								"{{appId}}",
+								"connections",
+								"default"
+							],
+							"query": [
+								{
+									"key": "activate",
+									"value": "true"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Activate Default Provisioning Connection",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "SSWS {{apikey}}"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": []
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/apps/{{appId}}/connections/default/lifecycle/activate",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"apps",
+								"{{appId}}",
+								"connections",
+								"default",
+								"lifecycle",
+								"activate"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Deactivate Default Provisioning Connection",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "SSWS {{apikey}}"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": []
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/apps/{{appId}}/connections/default/lifecycle/deactivate",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"apps",
+								"{{appId}}",
+								"connections",
+								"default",
+								"lifecycle",
+								"deactivate"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "a77fb141-38be-4bc2-b481-2314b001e0b4",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "24585604-a33f-4337-a2f4-5e423cc80c3e",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "Feature Operations",
+			"item": [
+				{
+					"name": "Get Features",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "SSWS {{apikey}}"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/api/v1/apps/{{appId}}/features",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"apps",
+								"{{appId}}",
+								"features"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get USER_PROVISIONING Feature",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "SSWS {{apikey}}"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/api/v1/apps/{{appId}}/features/USER_PROVISIONING",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"apps",
+								"{{appId}}",
+								"features",
+								"USER_PROVISIONING"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update USER_PROVISIONING Feature",
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "SSWS {{apikey}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": " {\n    \"create\": {\n        \"lifecycleCreate\": {\n            \"status\": \"ENABLED\"\n        }\n    },\n    \"update\": {\n        \"lifecycleDeactivate\": {\n            \"status\": \"ENABLED\"\n        },\n        \"profile\":{\n            \"status\": \"ENABLED\"\n        },\n        \"password\":{\n            \"status\": \"ENABLED\",\n            \"seed\": \"RANDOM\",\n            \"change\": \"CYCLE\"\n        }\n    }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/apps/{{appId}}/features/USER_PROVISIONING",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"apps",
+								"{{appId}}",
+								"features",
+								"USER_PROVISIONING"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "99a59eae-2f2a-47e2-b010-fd530bc6df5e",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "ab0ed878-67d2-4ed9-9a3b-654d3eb2d646",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
 				}
 			],
 			"protocolProfileBehavior": {}

--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -6973,7 +6973,7 @@ The Feature object is used to configure settings of the application. For example
 | ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- |
 | capabilities            | Defines the configuration of specific settings related to an application feature    | [Capabilities Object](#capabilties-object)                                                                  | FALSE    | FALSE   | TRUE    |           |
 | description            | Description of the feature      | String  | FALSE    | FALSE   | TRUE    |           |
-| _links           | Discoverable resources related to the app user     | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)     | TRUE    | FALSE   | TRUE    |           |
+| _links           | Discoverable resources related to the application feature     | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)     | TRUE    | FALSE   | TRUE    |           |
 | name              | Identifiying name     | `USER_PROVISIONING`  | FALSE    | FALSE  | TRUE    |           |       |      |
 | status            | Status of the feature   | `ENABLED`, `DISABLED`    | FALSE    | FALSE   | TRUE    |      `DISABLED`  |
 

--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -5466,11 +5466,11 @@ curl -v -X DELETE \
 HTTP/1.1 204 No Content
 ```
 
-## Application Logo operations
+## Application logo operations
 
 <ApiLifecycle access="ea" />
 
-### Update Logo for application
+### Update logo for application
 
 <ApiLifecycle access="ea" />
 
@@ -5478,18 +5478,18 @@ HTTP/1.1 204 No Content
 
 Update the logo for an application.
 
-> Note: It is only possible to update the logo for applications with a "login" `appLink`.
+> **Note:** You must have a valid login appLinks object to update the logo of an application.
 
-#### Request parameters
+##### Request parameters
 
 | Parameter       | Description                                | Parameter Type   | DataType   | Required |
 | :-------------- | :----------------------------------------- | :--------------- | :--------- | :------- |
 | applicationId   | `id` of an [app](#application-object)      | URL              | String     | TRUE     |
-| file            | file containing logo                       | Body             | File       | TRUE     |
+| file            | File containing logo                       | Body             | File       | TRUE     |
 
-The file must be must be a `PNG`, `JPG`, or `GIF` and less than `1Mb`. For best results use landscape orientation, a transparent background, and a minimum of 420px by 120px to prevent upscaling.
+**The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.** For best results use landscape orientation, a transparent background, and a minimum **size** of 420px by 120px to prevent upscaling.
 
-#### Request example
+##### Request example
 
 ```bash
 curl -v -X POST \
@@ -5499,7 +5499,7 @@ curl -v -X POST \
 "https://${yourOktaDomain}/api/v1/apps/${applicationId}/logo"
 ```
 
-#### Response example
+##### Response example
 
 ``` http
 HTTP/1.1 201 Content Created
@@ -5510,7 +5510,7 @@ Location: https://${yourOktaDomain}/bc/image/fileStoreRecord?id=fs01hfslJH2m3qUO
 
 <ApiLifecycle access="ea" />
 
->Note: Only Okta Org2Org application is supported
+> **Note:** The only currently supported application is Okta Org2Org.
 
 ### Get default Provisioning Connection for application
 
@@ -5520,17 +5520,17 @@ Location: https://${yourOktaDomain}/bc/image/fileStoreRecord?id=fs01hfslJH2m3qUO
 
 Fetches the default Provisioning Connection for an application.
 
-#### Request parameters
+##### Request parameters
 
 | Parameter       | Description                                | Parameter Type   | DataType   | Required |
 | :-------------- | :----------------------------------------- | :--------------- | :--------- | :------- |
 | applicationId   | `id` of an [app](#application-object)      | URL              | String     | TRUE     |
 
-#### Response parameters
+##### Response parameters
 
 The fetched [Provisioning Connection](#provisioning-connection-object).
 
-#### Request example
+##### Request example
 
 ```bash
 curl -v -X GET \
@@ -5576,7 +5576,7 @@ curl -v -X GET \
 
 Sets the default Provisioning Connection for an application.
 
-#### Request parameters
+##### Request parameters
 
 | Parameter       | Description                                | Parameter Type   | DataType   | Required | Default |
 | :-------------- | :----------------------------------------- | :--------------- | :--------- | :------- | :-------|
@@ -5584,11 +5584,11 @@ Sets the default Provisioning Connection for an application.
 | applicationId   | `id` of an [app](#application-object)      | URL              | String     | TRUE     |         |
 | profile   | Provisioning profile     | Body              | [Provisioning Connection Profile](#provisioning-connection-profile-object)   | TRUE     |         |
 
-#### Response parameters
+##### Response parameters
 
 The new default [Provisioning Connection](#provisioning-connection-object).
 
-#### Request example
+##### Request example
 
 ```bash
 curl -v -X POST \
@@ -5603,7 +5603,7 @@ curl -v -X POST \
 }' "https://${yourOktaDomain}/api/v1/apps/${applicationId}/connections/default?activate=TRUE"
 ```
 
-#### Response example
+##### Response example
 
 ```json
 {
@@ -5635,17 +5635,17 @@ curl -v -X POST \
 
 <ApiLifecycle access="ea" />
 
-<ApiOperation method="post" url="/api/v1/apps/${applicationId}/connections/lifecycle/activate" />
+<ApiOperation method="post" url="/api/v1/apps/${applicationId}/connections/default/lifecycle/activate" />
 
 Activates the default Provisioning Connection for an application.
 
-#### Request parameters
+##### Request parameters
 
 | Parameter       | Description                                | Parameter Type   | DataType   | Required |
 | :-------------- | :----------------------------------------- | :--------------- | :--------- | :------- |
 | applicationId   | `id` of an [app](#application-object)      | URL              | String     | TRUE     |
 
-#### Request example
+##### Request example
 
 ```bash
 curl -v -X POST \
@@ -5655,7 +5655,7 @@ curl -v -X POST \
 "https://${yourOktaDomain}/api/v1/apps/${applicationId}/connections/default/lifecycle/activate"
 ```
 
-#### Response example
+##### Response example
 
 ``` http
 HTTP/1.1 204 No Content
@@ -5669,13 +5669,13 @@ HTTP/1.1 204 No Content
 
 Deactivates the default Provisioning Connection for an application.
 
-#### Request parameters
+##### Request parameters
 
 | Parameter       | Description                                | Parameter Type   | DataType   | Required |
 | :-------------- | :----------------------------------------- | :--------------- | :--------- | :------- |
 | applicationId   | `id` of an [app](#application-object)      | URL              | String     | TRUE     |
 
-#### Request example
+##### Request example
 
 ```bash
 curl -v -X POST \
@@ -5685,17 +5685,17 @@ curl -v -X POST \
 "https://${yourOktaDomain}/api/v1/apps/${applicationId}/connections/default/lifecycle/deactivate"
 ```
 
-#### Response example
+##### Response example
 
 ``` http
 HTTP/1.1 204 No Content
 ```
 
-## Application Features operations
+## Application Feature operations
 
 <ApiLifecycle access="ea" />
 
->Note: Only Okta Org2Org application is supported
+> **Note:** The only currently supported application is Okta Org2Org.
 
 ### List Features for application
 
@@ -5703,21 +5703,22 @@ HTTP/1.1 204 No Content
 
 <ApiOperation method="get" url="/api/v1/apps/${applicationId}/features" />
 
-Fetch Features for an application.
+Fetches the Feature objects for an application.
 
->Note: Provisioning must be enabled for the application and currently only `USER_PROVISIONING` is supported. View [Provisioning Connections](#set-default-provisioning-connection-for-application) for enabling.
+> **Note:** Provisioning must be enabled for the application. To activate provisioning, see [Provisioning Connections](#set-default-provisioning-connection-for-application). The only application Feature currently supported is `USER_PROVISIONING`.
 
-#### Request parameters
+
+##### Request parameters
 
 | Parameter       | Description                                | Parameter Type   | DataType   | Required |
 | :-------------- | :----------------------------------------- | :--------------- | :--------- | :------- |
 | applicationId   | `id` of an [app](#application-object)      | URL              | String     | TRUE     |
 
-#### Response parameters
+##### Response parameters
 
-Array of [Application Features](#application-feature-object).
+An array of [Application Features](#application-feature-object).
 
-#### Request example
+##### Request example
 
 ```bash
 curl -v -X GET \
@@ -5727,7 +5728,7 @@ curl -v -X GET \
 "https://${yourOktaDomain}/api/v1/apps/${applicationId}/features"
 ```
 
-#### Response example
+##### Response example
 
 ```json
 [
@@ -5776,19 +5777,19 @@ curl -v -X GET \
 
 <ApiOperation method="get" url="/api/v1/apps/${applicationId}/features/${name}" />
 
-Fetch an Feature for an application.
+Fetches a Feature object for an application.
 
-#### Request parameters
+##### Request parameters
 
 | Parameter       | Description                                | Parameter Type   | DataType   | Required |
 | :-------------- | :----------------------------------------- | :--------------- | :--------- | :------- |
 | applicationId   | `id` of an [app](#application-object)      | URL              | String     | TRUE     |
 
-#### Response parameters
+##### Response parameters
 
 An [Application Feature](#application-feature).
 
-#### Request example
+##### Request example
 
 ```bash
 curl -v -X GET \
@@ -5798,7 +5799,7 @@ curl -v -X GET \
 "https://${yourOktaDomain}/api/v1/apps/${applicationId}/features/${name}"
 ```
 
-#### Response example
+##### Response example
 
 ```json
 {
@@ -5845,21 +5846,21 @@ curl -v -X GET \
 
 <ApiOperation method="put" url="/api/v1/apps/${applicationId}/features/${featureName}" />
 
-Update a Feature for an application.
+Updates a Feature object for an application.
 
-#### Request parameters
+##### Request parameters
 
 | Parameter       | Description                                | Parameter Type   | DataType   | Required |
 | :-------------- | :----------------------------------------- | :--------------- | :--------- | :------- |
 | applicationId   | `id` of an [app](#application-object)      | URL              | String     | TRUE     |
-| capabilities   | capabilites of the feature                  | Body              | [Capabilites Object](#capabilties-object) | TRUE     |
-| name   | name of the feature                      | URL              | String     | TRUE     |
+| capabilities   | Capabilites of the feature                  | Body              | [Capabilites Object](#capabilties-object) | TRUE     |
+| name   | Name of the feature                      | URL              | String     | TRUE     |
 
-#### Reponse Parameters
+##### Reponse Parameters
 
 Updated [Application Feature](#application-feature-object).
 
-#### Request Example
+##### Request Example
 
 ```bash
 curl -v -X PUT \
@@ -5904,7 +5905,7 @@ curl -v -X PUT \
 }' "https://${yourOktaDomain}/api/v1/apps/${applicationId}/features/${name}"
 ```
 
-#### Response example
+##### Response example
 
 ```json
 {
@@ -6063,22 +6064,22 @@ Applications have the following properties:
 
 | Property           | Description                                    | DataType                                                             | Nullable     | Unique     | Readonly     | MinLength     | MaxLength   |
 | :----------------- | :--------------------------------------------- | :------------------------------------------------------------------- | :----------- | :--------- | :----------- | :------------ | :---------- |
-| _embedded          | embedded resources related to the app          | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)       | TRUE         | FALSE      | TRUE         |               |             |
-| _links             | discoverable resources related to the app      | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)       | TRUE         | FALSE      | TRUE         |               |             |
-| accessibility      | access settings for app                        | [Accessibility object](#accessibility-object)                        | TRUE         | FALSE      | FALSE        |               |             |
-| created            | timestamp when app was created                 | Date                                                                 | FALSE        | FALSE      | TRUE         |               |             |
-| credentials        | credentials for the specified `signOnMode`     | [Application Credentials object](#application-credentials-object)    | TRUE         | FALSE      | FALSE        |               |             |
-| features           | enabled app features                           | [Features](#features)                                                | TRUE         | FALSE      | FALSE        |               |             |
-| id                 | unique key for app                             | String                                                               | FALSE        | TRUE       | TRUE         |               |             |
-| label              | unique user-defined display name for app       | String                                                               | FALSE        | TRUE       | FALSE        | 1             | 100         |
-| lastUpdated        | timestamp when app was last updated            | Date                                                                 | FALSE        | FALSE      | TRUE         |               |             |
-| name               | unique key for app definition                  | String ([App Names](#app-names))                | FALSE        | TRUE       | TRUE         | 1             | 255         |
+| _embedded          | Embedded resources related to the app          | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)       | TRUE         | FALSE      | TRUE         |               |             |
+| _links             | Discoverable resources related to the app      | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)       | TRUE         | FALSE      | TRUE         |               |             |
+| accessibility      | Access settings for app                        | [Accessibility object](#accessibility-object)                        | TRUE         | FALSE      | FALSE        |               |             |
+| created            | Timestamp when app was created                 | Date                                                                 | FALSE        | FALSE      | TRUE         |               |             |
+| credentials        | Credentials for the specified `signOnMode`     | [Application Credentials object](#application-credentials-object)    | TRUE         | FALSE      | FALSE        |               |             |
+| features           | Enabled app features                           | [Features](#features)                                                | TRUE         | FALSE      | FALSE        |               |             |
+| id                 | Unique key for app                             | String                                                               | FALSE        | TRUE       | TRUE         |               |             |
+| label              | Unique user-defined display name for app       | String                                                               | FALSE        | TRUE       | FALSE        | 1             | 100         |
+| lastUpdated        | Timestamp when app was last updated            | Date                                                                 | FALSE        | FALSE      | TRUE         |               |             |
+| name               | Unique key for app definition                  | String ([App Names](#app-names))                | FALSE        | TRUE       | TRUE         | 1             | 255         |
 | profile            | Valid JSON schema for specifying properties    | [JSON](#profile-object)                                              | TRUE         | FALSE      | FALSE        |               |             |
 | request_object_signing_alg| The type of JSON Web Key Set (JWKS) algorithm that must be used for signing request objects | `HS256`, `HS384`, `HS512`, `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, `ES512`  | TRUE      | FALSE     | FALSE      |
-| settings           | settings for app                               | Object ([App Settings](#app-settings))                | TRUE         | FALSE      | FALSE        |               |             |
-| signOnMode         | authentication mode of app                     | [SignOn Mode](#sign-on-modes)                                         | FALSE        | FALSE      | FALSE        |               |             |
-| status             | status of app                                  | `ACTIVE` or `INACTIVE`                                               | FALSE        | FALSE      | TRUE         |               |             |
-| visibility         | visibility settings for app                    | [Visibility object](#visibility-object)                              | TRUE         | FALSE      | FALSE        |               |             |
+| settings           | Settings for app                               | Object ([App Settings](#app-settings))                | TRUE         | FALSE      | FALSE        |               |             |
+| signOnMode         | Authentication mode of app                     | [SignOn Mode](#sign-on-modes)                                         | FALSE        | FALSE      | FALSE        |               |             |
+| status             | Status of app                                  | `ACTIVE` or `INACTIVE`                                               | FALSE        | FALSE      | TRUE         |               |             |
+| visibility         | Visibility settings for app                    | [Visibility object](#visibility-object)                              | TRUE         | FALSE      | FALSE        |               |             |
 
 Property details
 
@@ -6088,7 +6089,7 @@ Property details
 
 ##### App names
 
-The Okta Integration Network (OIN) defines the catalog of applications that can be added to your Okta organization. Each application has a unique name (key) that you must specify.
+The Okta Integration Network (OIN) is a catalog of applications that can be added to your Okta organization. Each application has a unique name (key) that you must specify.
 
 The catalog is currently not exposed via an API. While additional apps may be added via the API, only the following template applications are documented:
 
@@ -6111,20 +6112,18 @@ The current workaround is to manually configure the desired application via the 
 
 Each application has a schema that defines the required and optional settings for the application. When adding an application, you must specify the required settings.
 
-The catalog is currently not exposed via an API. While additional apps may be added via the API, only the following template applications are documented:
-
-The current workaround is to manually configure the desired application via the administrator UI in a preview (sandbox) organization and view the application via [Get Application](#get-application).
+The catalog is currently not exposed via an API. The current solution is to manually configure the desired application using the Okta Admin Dashboard and a preview (sandbox) Okta org. You can then view the application details using the [Get Application](#get-application) API.
 
 ###### Notes Object
 
 <ApiLifecycle access="ea" />
 
-An additional `notes` object can be passed within the `settings` object. The notes object contains the following:
+An additional `notes` object can be passed within the `settings` object. The `notes` object contains the following:
 
 | Property  | Description                                        | DataType | Nullable | Default | MinLength | MaxLength | Validation |
 | --------- | -------------------------------------------------- | -------- | -------- | ------- | --------- | --------- | ---------- |
 | admin       | Application notes for admins | String  | TRUE    | NULL   |           |           |            |
-| enduser       | Application notes for endusers                        | String  | TRUE    | NULL   |           |
+| enduser       | Application notes for end users                        | String  | TRUE    | NULL   |           |
 
 > **Note:** You can't currently manage app provisioning settings via the API. Use the administrator UI.
 
@@ -6198,7 +6197,7 @@ Specifies visibility settings for the application
 | Property          | Description                                        | DataType                            | Nullable | Default | MinLength | MaxLength | Validation |
 | ----------------- | -------------------------------------------------- | ----------------------------------- | -------- | ------- | --------- | --------- | ---------- |
 | appLinks          | Displays specific appLinks for the app             | [AppLinks object](#applinks-object) | FALSE    |         |           |           |            |
-| <ApiLifecycle access="ea" /> autoLaunch  |  Automatically sign into the app when user signs into Okta.            | Boolean | FALSE   | FALSE    |           |           |            |
+| <ApiLifecycle access="ea" /> autoLaunch  |  Automatically signs into the app when user signs into Okta.            | Boolean | FALSE   | FALSE    |           |           |            |
 | autoSubmitToolbar | Automatically sign in when user lands on the sign-in page | Boolean                             | FALSE    | FALSE   |           |           |            |
 | hide              | Hides this app for specific end-user apps          | [Hide object](#hide-object)         | FALSE    | FALSE   |           |           |            |
 
@@ -6864,7 +6863,7 @@ Property details
 
 ### Provisioning Connection object
 
-Defines the application provisioning connection.
+The provisioning connection object is a read only object that displays the method of authentication used for provisioning.
 
 #### Example
 ```json
@@ -6897,15 +6896,15 @@ Defines the application provisioning connection.
 
 | Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly | Default |
 | ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- |
-| authScheme              | defines how to  connection is authenticated     | `TOKEN`, `UNKNOWN`                                                           | FALSE    | FALSE  | FALSE    |           |
-| _links            | discoverable resources related to the connection            | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)              | TRUE    | FALSE   | TRUE    |           |
-| status            | status of the connection      | `ENABLED`, `DISABLED`, `UNKNOWN`  | FALSE    | FALSE   | TRUE    | `DISABLED` |
+| authScheme              | Defines the method of authentication    | `TOKEN`, `UNKNOWN`                                                           | FALSE    | FALSE  | TRUE    |           |
+| _links            | Discoverable resources related to the connection            | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)              | TRUE    | FALSE   | TRUE    |           |
+| status            | Status of the connection      | `ENABLED`, `DISABLED`, `UNKNOWN`  | FALSE    | FALSE   | TRUE    | `DISABLED` |
 
-An `UNKNOWN` `authScheme` signifies that the authentiication scheme used by the application is not supported yet or that the application does not support provisioning. An `UNKNOWN` `authScheme` will result in an `UNKNOWN` `status`.
+If the authScheme is `UNKNOWN`, then either the authentication scheme used by the application is not yet supported or the the application does not support provisioning. An object with an `UNKNOWN` `authScheme` results in an `UNKNOWN` `status`.
 
 ### Provisioning Connection Profile object
 
-Defines the application provisioning connection profile. Currently, only token based profile connection is supported.
+The application provisioning connection profile is used to configure the method of authentication and the credentials. Currently, only token based authentication is supported.
 
 #### Token based Provisioning Connection Profile example
 ```json
@@ -6921,12 +6920,12 @@ Defines the application provisioning connection profile. Currently, only token b
 
 | Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly |
 | ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- | --------- | ---------- |
-| authScheme              | defines how to  connection is authenticated     | `TOKEN` | FALSE    | FALSE  | FALSE    |
-| token            | token used to authenticate with application      | String | FALSE    | TRUE   | FALSE    |
+| authScheme              | Defines the method of authentication     | `TOKEN` | FALSE    | FALSE  | FALSE    |
+| token            | Token used to authenticate with application      | String | FALSE    | FALSE   | FALSE    |
 
 ### Application Feature object
 
-Defines the application feature.
+The Feature object is used to configure settings of the application. For example, the `USER_PROVISIONING` Feature object is used to configure the ability to create, read, update users in Okta accounts, deprovision accounts for deactivated users, and synchronize user attributes.
 
 #### Application Feature example
 ```json
@@ -6956,7 +6955,7 @@ Defines the application feature.
     },
     "_links": {
         "self": {
-            "href": "http://rain.okta1.com:1802/api/v1/apps/0oa1h43s0sZyK6Ft40g4/features/USER_PROVISIONING",
+            "href": "http://${yourOktaDomain}/api/v1/apps/${applicationId}/features/USER_PROVISIONING",
             "hints": {
                 "allow": [
                     "GET",
@@ -6972,24 +6971,24 @@ Defines the application feature.
 
 | Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly | Default |
 | ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- |
-| capabilities            | capabilites     | [Capabilities Object](#capabilties-object)                                                                  | FALSE    | FALSE   | TRUE    |           |
-| description            | description      | String  | FALSE    | FALSE   | TRUE    |           |
-| _links           | discoverable resources related to the app user     | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)     | TRUE    | FALSE   | TRUE    |           |
-| name              | identifiying name     | `USER_PROVISIONING`  | FALSE    | FALSE  | TRUE    |           |       |      |
-| status            | status    | `ENABLED`, `DISABLED`    | FALSE    | FALSE   | TRUE    |      `DISABLED`  |
+| capabilities            | Defines the configuration of specific settings related to an application feature    | [Capabilities Object](#capabilties-object)                                                                  | FALSE    | FALSE   | TRUE    |           |
+| description            | Description of the feature      | String  | FALSE    | FALSE   | TRUE    |           |
+| _links           | Discoverable resources related to the app user     | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)     | TRUE    | FALSE   | TRUE    |           |
+| name              | Identifiying name     | `USER_PROVISIONING`  | FALSE    | FALSE  | TRUE    |           |       |      |
+| status            | Status of the feature   | `ENABLED`, `DISABLED`    | FALSE    | FALSE   | TRUE    |      `DISABLED`  |
 
 ##### Capabilties object
 
-The Capabilities object determines the capabilities of an app feature.
+The Capabilities object is used to configure settings specific to an app feature.
 
 | Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly |
 | ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- | --------- | ---------- |
-| create            | determines whether the Okta creates or links a user in the application when assigning the app to a user in Okta | [Create Object](#create-object)  | TRUE    | FALSE   | FALSE    |
-| update            | determines whether the updates to a user's profile will be pushed to the application | [Update Object](#update-object)  | TRUE    | FALSE   | FALSE    |
+| create            | Determines whether Okta aassigns a new app account to each user managed by Okta | [Create Object](#create-object)  | TRUE    | FALSE   | FALSE    |
+| update            | Determines whether updates to a user's profile are pushed to the application | [Update Object](#update-object)  | TRUE    | FALSE   | FALSE    |
 
 ###### Create object
 
-The Create object is composed of a single setting that determines whether the application creates or links a user in the application when assigning the app to a user in Okta.
+The Create object is a single setting to specify whether Okta assigns a new app account to each user managed by Okta. Okta does not create a new account if it detects that the username specified in Okta already exists in the app. The user's Okta username is assigned by default.
 
 ```json
 {
@@ -7001,11 +7000,11 @@ The Create object is composed of a single setting that determines whether the ap
 
 | Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly |
 | ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- |
-| lifecycleCreate            | setting that determines whether the updates to a user in Okta will be update a user in the application   | [Lifecycle Create Setting Object](##lifecycle-create-setting-object)      | TRUE    | FALSE   | FALSE    |           |
+| lifecycleCreate            | Setting that determines whether the updates to a user in Okta will be update a user in the application   | [Lifecycle Create Setting Object](##lifecycle-create-setting-object)      | TRUE    | FALSE   | FALSE    |           |
 
 ###### Update object
 
-The Create object is composed of multiple settings that determine whether the updates to a user in Okta will update a user in the application.
+The Create object is composed of multiple settings that determines whether an Okta user profile, user deactivation, or password change will update a user in the application.
 
 ```json
 {
@@ -7025,29 +7024,29 @@ The Create object is composed of multiple settings that determine whether the up
 
 | Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly |
 | ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- |
-| lifecycleDeactivate           | setting that determines whether deprovisioning will occur when app is unassigned  | [Lifecycle Deactivate Setting Object](#lifecycle-deactivate-setting-object)   | TRUE    | FALSE   | FALSE    |
-| password           | setting that determines whether Okta creates and pushes a password in the application for each assigned user | [Password Setting Object](#password-setting-object)    | TRUE    | FALSE   | FALSE    |
-| profile           | setting that determines whether the updates to a user in Okta will be update a user in the application.     | [Profile Setting Object](#profile-setting-object)     | TRUE    | FALSE   | FALSE    |
+| lifecycleDeactivate           | Setting that determines whether deprovisioning will occur when app is unassigned  | [Lifecycle Deactivate Setting Object](#lifecycle-deactivate-setting-object)   | TRUE    | FALSE   | FALSE    |
+| password           | Setting that determines whether Okta creates and pushes a password in the application for each assigned user | [Password Setting Object](#password-setting-object)    | TRUE    | FALSE   | FALSE    |
+| profile           | Setting that determines whether the updates to a user in Okta will be update a user in the application.     | [Profile Setting Object](#profile-setting-object)     | TRUE    | FALSE   | FALSE    |
 
 ###### Lifecycle Create Setting object
 
-Creates or links a user in the application when assigning the app to a user in Okta.
+Assigns a new app account to each user managed by Okta. Okta does not create a new account if it detects that the username specified in Okta already exists in the app. The user's Okta username is assigned by default.
 
 | Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly | Default |
 | ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- |
-| status   | status of the setting     | `ENABLED`, `DISABLED` | FALSE    | FALSE   | FALSE    | `DISABLED` |
+| status   | Status of the setting     | `ENABLED`, `DISABLED` | FALSE    | FALSE   | FALSE    | `DISABLED` |
 
 ###### Lifecycle Deactivate Setting object
 
-Deactivates a user's application account when it is unassigned in Okta or their Okta account is deactivated. Accounts can be reactivated if the app is reassigned to a user in Okta.
+Deactivates a user's application account when it is unassigned in Okta or if their Okta account is deactivated. Accounts can be reactivated if the app is reassigned to a user in Okta.
 
 | Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly | Default |
 | ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- |
-| status   | status of the setting     | `ENABLED`, `DISABLED` | FALSE    | FALSE   | FALSE    | `DISABLED` |
+| status   | Status of the setting     | `ENABLED`, `DISABLED` | FALSE    | FALSE   | FALSE    | `DISABLED` |
 
 ###### Password Setting object
 
-Creates and pushes a password in the application for each assigned user.
+Ensures users' app passwords are always the same as their Okta passwords or allows Okta to generate a unique password for the user.
 
 ```json
 {
@@ -7061,14 +7060,14 @@ Creates and pushes a password in the application for each assigned user.
 
 | Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly | Default |
 | ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- | --------- | ---------- |
-| change | determines whether a change in a users password will also update the password in the application.   | `KEEP_EXISTING`, `CHANGE` | TRUE  | FALSE   | FALSE    | `KEEP_EXISTING` |
-| seed | determines whether the generated password is the users Okta password or a randomly generated password.   | `OKTA`, `RANDOM`  | TRUE  | FALSE | FALSE  |  `RANDOM`  |
-| status | status of the setting     | `ENABLED`, `DISABLED` | FALSE    | FALSE  | FALSE  |  `DISABLED` |
+| change | Determines whether a change in a users password will also update the password in the application.   | `KEEP_EXISTING`, `CHANGE` | TRUE  | FALSE   | FALSE    | `KEEP_EXISTING` |
+| seed | Determines whether the generated password is the users Okta password or a randomly generated password.   | `OKTA`, `RANDOM`  | TRUE  | FALSE | FALSE  |  `RANDOM`  |
+| status | Status of the setting     | `ENABLED`, `DISABLED` | FALSE    | FALSE  | FALSE  |  `DISABLED` |
 
 ###### Profile Update Setting object
 
-Okta updates a user's attributes in the application when the app is assigned. Future attribute changes made to the Okta user profile will automatically overwrite the corresponding attribute value in the application.
+Okta updates a user's attributes in the application when the app is assigned. Future changes made to the Okta user's profile automatically overwrite the corresponding attribute value in the application
 
 | Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly | Default |
 | ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- |
-| status   | status of the setting     | `ENABLED`, `DISABLED` | FALSE    | FALSE   | FALSE    | `DISABLED`  |
+| status   | Status of the setting     | `ENABLED`, `DISABLED` | FALSE    | FALSE   | FALSE    | `DISABLED`  |

--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -5506,6 +5506,191 @@ HTTP/1.1 201 Content Created
 Location: https://${yourOktaDomain}/bc/image/fileStoreRecord?id=fs01hfslJH2m3qUOe0g4
 ```
 
+## Application Provisioning Connection operations
+
+<ApiLifecycle access="ea" />
+
+>Note: Only Okta Org2Org application is supported
+
+### Get default Provisioning Connection for application
+
+<ApiLifecycle access="ea" />
+
+<ApiOperation method="get" url="/api/v1/apps/${applicationId}/connections/default" />
+
+Fetches the default Provisioning Connection for an application.
+
+#### Request parameters
+
+| Parameter       | Description                                | Parameter Type   | DataType   | Required |
+| :-------------- | :----------------------------------------- | :--------------- | :--------- | :------- |
+| applicationId   | `id` of an [app](#application-object)      | URL              | String     | TRUE     |
+
+#### Response parameters
+
+The fetched [Provisioning Connection](#provisioning-connection-object).
+
+#### Request example
+
+```bash
+curl -v -X GET \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+"https://${yourOktaDomain}/api/v1/apps/${applicationId}/connections/default"
+```
+
+#### Response example
+
+```json
+{
+    "authScheme": "TOKEN",
+    "status": "ENABLED",
+    "_links": {
+        "self": {
+            "href": "https://${yourOktaDomain}/api/v1/apps/${applicationId}/connections/default",
+            "hints": {
+                "allow": [
+                    "POST",
+                    "GET"
+                ]
+            }
+        },
+        "deactivate": {
+            "href": "https://${yourOktaDomain}/api/v1/apps/${applicationId}/connections/default/lifecycle/deactivate",
+            "hints": {
+                "allow": [
+                    "POST"
+                ]
+            }
+        }
+    }
+}
+```
+
+### Set default Provisioning Connection for application
+
+<ApiLifecycle access="ea" />
+
+<ApiOperation method="post" url="/api/v1/apps/${applicationId}/connections/default" />
+
+Sets the default Provisioning Connection for an application.
+
+#### Request parameters
+
+| Parameter       | Description                                | Parameter Type   | DataType   | Required | Default |
+| :-------------- | :----------------------------------------- | :--------------- | :--------- | :------- | :-------|
+| activate        | Activate the provisioning connection       | Query            | Boolean    | FALSE    | FALSE   |
+| applicationId   | `id` of an [app](#application-object)      | URL              | String     | TRUE     |         |
+| profile   | Provisioning profile     | Body              | [Provisioning Connection Profile](#provisioning-connection-profile-object)   | TRUE     |         |
+
+#### Response parameters
+
+The new default [Provisioning Connection](#provisioning-connection-object).
+
+#### Request example
+
+```bash
+curl -v -X POST \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+-d '{
+    "profile": {
+        "authScheme": "TOKEN",
+        "token": "TEST"
+    }
+}' "https://${yourOktaDomain}/api/v1/apps/${applicationId}/connections/default?activate=TRUE"
+```
+
+#### Response example
+
+```json
+{
+    "authScheme": "TOKEN",
+    "status": "ENABLED",
+    "_links": {
+        "self": {
+            "href": "https://${yourOktaDomain}/api/v1/apps/${applicationId}/connections/default",
+            "hints": {
+                "allow": [
+                    "POST",
+                    "GET"
+                ]
+            }
+        },
+        "deactivate": {
+            "href": "https://${yourOktaDomain}/api/v1/apps/${applicationId}/connections/default/lifecycle/deactivate",
+            "hints": {
+                "allow": [
+                    "POST"
+                ]
+            }
+        }
+    }
+}
+```
+
+### Activate default Provisioning Connection for application
+
+<ApiLifecycle access="ea" />
+
+<ApiOperation method="post" url="/api/v1/apps/${applicationId}/connections/lifecycle/activate" />
+
+Activates the default Provisioning Connection for an application.
+
+#### Request parameters
+
+| Parameter       | Description                                | Parameter Type   | DataType   | Required |
+| :-------------- | :----------------------------------------- | :--------------- | :--------- | :------- |
+| applicationId   | `id` of an [app](#application-object)      | URL              | String     | TRUE     |
+
+#### Request example
+
+```bash
+curl -v -X POST \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+"https://${yourOktaDomain}/api/v1/apps/${applicationId}/connections/default/lifecycle/activate"
+```
+
+#### Response example
+
+``` http
+HTTP/1.1 204 No Content
+```
+
+### Deactivate default Provisioning Connection for application
+
+<ApiLifecycle access="ea" />
+
+<ApiOperation method="post" url="/api/v1/apps/${applicationId}/connections/lifecycle/deactivate" />
+
+Deactivates the default Provisioning Connection for an application.
+
+#### Request parameters
+
+| Parameter       | Description                                | Parameter Type   | DataType   | Required |
+| :-------------- | :----------------------------------------- | :--------------- | :--------- | :------- |
+| applicationId   | `id` of an [app](#application-object)      | URL              | String     | TRUE     |
+
+#### Request example
+
+```bash
+curl -v -X POST \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+"https://${yourOktaDomain}/api/v1/apps/${applicationId}/connections/default/lifecycle/deactivate"
+```
+
+#### Response example
+
+``` http
+HTTP/1.1 204 No Content
+```
+
 ## Models
 
 * [Application object](#application-object)
@@ -6422,3 +6607,65 @@ Property details
 
  * `url` can't have query or fragment parameters.
  * `index` has to be a non-negative number and cannot be duplicated in a set of ACS endpoints configured for an app.
+
+### Provisioning Connection object
+
+Defines the application provisioning connection.
+
+#### Example
+```json
+{
+    "authScheme": "TOKEN",
+    "status": "DISABLED",
+    "_links": {
+        "activate": {
+            "href": "https://${yourOktaDomain}/api/v1/apps/${applicationId}/connections/default/lifecycle/activate",
+            "hints": {
+                "allow": [
+                    "POST"
+                ]
+            }
+        },
+        "self": {
+            "href": "https://${yourOktaDomain}/api/v1/apps/${applicationId}/connections/default",
+            "hints": {
+                "allow": [
+                    "POST",
+                    "GET"
+                ]
+            }
+        }
+    }
+}
+```
+
+#### Provisioning Connection properties
+
+| Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly | Default |
+| ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- |
+| authScheme              | defines how to  connection is authenticated     | `TOKEN`, `UNKNOWN`                                                           | FALSE    | FALSE  | FALSE    |           |
+| _links            | discoverable resources related to the connection            | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)              | TRUE    | FALSE   | TRUE    |           |
+| status            | status of the connection      | `ENABLED`, `DISABLED`, `UNKNOWN`  | FALSE    | FALSE   | TRUE    | `DISABLED` |
+
+An `UNKNOWN` `authScheme` signifies that the authentiication scheme used by the application is not supported yet or that the application does not support provisioning. An `UNKNOWN` `authScheme` will result in an `UNKNOWN` `status`.
+
+### Provisioning Connection Profile object
+
+Defines the application provisioning connection profile. Currently, only token based profile connection is supported.
+
+#### Token based Provisioning Connection Profile example
+```json
+{
+    "profile": {
+        "authScheme": "TOKEN",
+        "token": "TEST"
+    }
+}
+```
+
+#### Token based Provisioning Connection Profile properties
+
+| Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly |
+| ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- | --------- | ---------- |
+| authScheme              | defines how to  connection is authenticated     | `TOKEN` | FALSE    | FALSE  | FALSE    |
+| token            | token used to authenticate with application      | String | FALSE    | TRUE   | FALSE    |

--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -9,7 +9,7 @@ The Okta Application API provides operations to manage applications and/or assig
 
 ## Get started
 
-Explore the Apps API: [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/41a737560876d6003ce5)
+Explore the Apps API: [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/377eaf77fdbeaedced17)
 
 ## Application operations
 

--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -5487,7 +5487,7 @@ Update the logo for an application.
 | applicationId   | `id` of an [app](#application-object)      | URL              | String     | TRUE     |
 | file            | File containing logo                       | Body             | File       | TRUE     |
 
-**The file must be in PNG, JPG, or GIF format, and less than 1 MB in size.** For best results use landscape orientation, a transparent background, and a minimum **size** of 420px by 120px to prevent upscaling.
+The file must be in PNG, JPG, or GIF format, and less than 1 MB in size. For best results use landscape orientation, a transparent background, and a minimum size of 420px by 120px to prevent upscaling.
 
 ##### Request example
 
@@ -6112,9 +6112,9 @@ The current workaround is to manually configure the desired application via the 
 
 Each application has a schema that defines the required and optional settings for the application. When adding an application, you must specify the required settings.
 
-The catalog is currently not exposed via an API. The current solution is to manually configure the desired application using the Okta Admin Dashboard and a preview (sandbox) Okta org. You can then view the application details using the [Get Application](#get-application) API.
+Currently, the catalog isn't exposed via an API. The current solution is to manually configure the desired application using the Okta Admin Dashboard and a preview (sandbox) Okta org. You can then view the application details using the [Get Application](#get-application) API.
 
-###### Notes Object
+###### Notes object
 
 <ApiLifecycle access="ea" />
 
@@ -6197,7 +6197,7 @@ Specifies visibility settings for the application
 | Property          | Description                                        | DataType                            | Nullable | Default | MinLength | MaxLength | Validation |
 | ----------------- | -------------------------------------------------- | ----------------------------------- | -------- | ------- | --------- | --------- | ---------- |
 | appLinks          | Displays specific appLinks for the app             | [AppLinks object](#applinks-object) | FALSE    |         |           |           |            |
-| <ApiLifecycle access="ea" /> autoLaunch  |  Automatically signs into the app when user signs into Okta.            | Boolean | FALSE   | FALSE    |           |           |            |
+| <ApiLifecycle access="ea" /> autoLaunch  |  Automatically signs in to the app when user signs into Okta.            | Boolean | FALSE   | FALSE    |           |           |            |
 | autoSubmitToolbar | Automatically sign in when user lands on the sign-in page | Boolean                             | FALSE    | FALSE   |           |           |            |
 | hide              | Hides this app for specific end-user apps          | [Hide object](#hide-object)         | FALSE    | FALSE   |           |           |            |
 
@@ -6900,7 +6900,7 @@ The provisioning connection object is a read only object that displays the metho
 | _links            | Discoverable resources related to the connection            | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)              | TRUE    | FALSE   | TRUE    |           |
 | status            | Status of the connection      | `ENABLED`, `DISABLED`, `UNKNOWN`  | FALSE    | FALSE   | TRUE    | `DISABLED` |
 
-If the authScheme is `UNKNOWN`, then either the authentication scheme used by the application is not yet supported or the the application does not support provisioning. An object with an `UNKNOWN` `authScheme` results in an `UNKNOWN` `status`.
+If the authScheme is UNKNOWN, then either the authentication scheme used by the application isn't supported or the the application doesn't support provisioning. An object with an `UNKNOWN` `authScheme` results in an `UNKNOWN` `status`.
 
 ### Provisioning Connection Profile object
 
@@ -6983,12 +6983,12 @@ The Capabilities object is used to configure settings specific to an app feature
 
 | Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly |
 | ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- | --------- | ---------- |
-| create            | Determines whether Okta aassigns a new app account to each user managed by Okta | [Create Object](#create-object)  | TRUE    | FALSE   | FALSE    |
+| create            | Determines whether Okta assigns a new application account to each user managed by Okta | [Create Object](#create-object)  | TRUE    | FALSE   | FALSE    |
 | update            | Determines whether updates to a user's profile are pushed to the application | [Update Object](#update-object)  | TRUE    | FALSE   | FALSE    |
 
 ###### Create object
 
-The Create object is a single setting to specify whether Okta assigns a new app account to each user managed by Okta. Okta does not create a new account if it detects that the username specified in Okta already exists in the app. The user's Okta username is assigned by default.
+The Create object is a single setting to specify whether Okta assigns a new application account to each user managed by Okta. Okta doesn't create a new account if it detects that the username specified in Okta already exists in the application. The user's Okta username is assigned by default.
 
 | Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly |
 | ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- |
@@ -7004,7 +7004,7 @@ The Create object is a single setting to specify whether Okta assigns a new app 
 
 ###### Update object
 
-The Create object is composed of multiple settings that determines whether an Okta user profile, user deactivation, or password change will update a user in the application.
+There are multiple settings in the Create object that determine if an Okta user profile change, user deactivation, or a password change will update a user in the application.
 
 | Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly |
 | ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- |
@@ -7030,7 +7030,7 @@ The Create object is composed of multiple settings that determines whether an Ok
 
 ###### Lifecycle Create Setting object
 
-Assigns a new app account to each user managed by Okta. Okta does not create a new account if it detects that the username specified in Okta already exists in the app. The user's Okta username is assigned by default.
+Assigns a new application account to each user managed by Okta. Okta doesn't create a new account if it detects that the username specified in Okta already exists in the application. The user's Okta username is assigned by default.
 
 | Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly | Default |
 | ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- |
@@ -7066,7 +7066,7 @@ Ensures users' app passwords are always the same as their Okta passwords or allo
 
 ###### Profile Update Setting object
 
-Okta updates a user's attributes in the application when the app is assigned. Future changes made to the Okta user's profile automatically overwrite the corresponding attribute value in the application
+Okta updates a user's attributes in the application when the application is assigned. Future changes made to the Okta user's profile automatically overwrite the corresponding attribute value in the application.
 
 | Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly | Default |
 | ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- |

--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -5540,7 +5540,7 @@ curl -v -X GET \
 "https://${yourOktaDomain}/api/v1/apps/${applicationId}/connections/default"
 ```
 
-#### Response example
+##### Response example
 
 ```json
 {
@@ -6990,6 +6990,10 @@ The Capabilities object is used to configure settings specific to an app feature
 
 The Create object is a single setting to specify whether Okta assigns a new app account to each user managed by Okta. Okta does not create a new account if it detects that the username specified in Okta already exists in the app. The user's Okta username is assigned by default.
 
+| Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly |
+| ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- |
+| lifecycleCreate  | Setting that determines whether the updates to a user in Okta will be update a user in the application   | [Lifecycle Create Setting Object](##lifecycle-create-setting-object)      | TRUE    | FALSE   | FALSE    |           |
+
 ```json
 {
   "lifecycleCreate": {
@@ -6998,13 +7002,15 @@ The Create object is a single setting to specify whether Okta assigns a new app 
 }
 ```
 
-| Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly |
-| ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- |
-| lifecycleCreate            | Setting that determines whether the updates to a user in Okta will be update a user in the application   | [Lifecycle Create Setting Object](##lifecycle-create-setting-object)      | TRUE    | FALSE   | FALSE    |           |
-
 ###### Update object
 
 The Create object is composed of multiple settings that determines whether an Okta user profile, user deactivation, or password change will update a user in the application.
+
+| Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly |
+| ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- |
+| lifecycleDeactivate           | Setting that determines whether deprovisioning will occur when app is unassigned  | [Lifecycle Deactivate Setting Object](#lifecycle-deactivate-setting-object)   | TRUE    | FALSE   | FALSE    |
+| password           | Setting that determines whether Okta creates and pushes a password in the application for each assigned user | [Password Setting Object](#password-setting-object)    | TRUE    | FALSE   | FALSE    |
+| profile           | Setting that determines whether the updates to a user in Okta will be update a user in the application.     | [Profile Setting Object](#profile-setting-object)     | TRUE    | FALSE   | FALSE    |
 
 ```json
 {
@@ -7021,12 +7027,6 @@ The Create object is composed of multiple settings that determines whether an Ok
   }
 }
 ```
-
-| Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly |
-| ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- |
-| lifecycleDeactivate           | Setting that determines whether deprovisioning will occur when app is unassigned  | [Lifecycle Deactivate Setting Object](#lifecycle-deactivate-setting-object)   | TRUE    | FALSE   | FALSE    |
-| password           | Setting that determines whether Okta creates and pushes a password in the application for each assigned user | [Password Setting Object](#password-setting-object)    | TRUE    | FALSE   | FALSE    |
-| profile           | Setting that determines whether the updates to a user in Okta will be update a user in the application.     | [Profile Setting Object](#profile-setting-object)     | TRUE    | FALSE   | FALSE    |
 
 ###### Lifecycle Create Setting object
 
@@ -7048,6 +7048,12 @@ Deactivates a user's application account when it is unassigned in Okta or if the
 
 Ensures users' app passwords are always the same as their Okta passwords or allows Okta to generate a unique password for the user.
 
+| Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly | Default |
+| ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- | --------- | ---------- |
+| change | Determines whether a change in a users password will also update the password in the application.   | `KEEP_EXISTING`, `CHANGE` | TRUE  | FALSE   | FALSE    | `KEEP_EXISTING` |
+| seed | Determines whether the generated password is the users Okta password or a randomly generated password.   | `OKTA`, `RANDOM`  | TRUE  | FALSE | FALSE  |  `RANDOM`  |
+| status | Status of the setting     | `ENABLED`, `DISABLED` | FALSE    | FALSE  | FALSE  |  `DISABLED` |
+
 ```json
 {
   "password": {
@@ -7057,12 +7063,6 @@ Ensures users' app passwords are always the same as their Okta passwords or allo
   }
 }
 ```
-
-| Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly | Default |
-| ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- | --------- | ---------- |
-| change | Determines whether a change in a users password will also update the password in the application.   | `KEEP_EXISTING`, `CHANGE` | TRUE  | FALSE   | FALSE    | `KEEP_EXISTING` |
-| seed | Determines whether the generated password is the users Okta password or a randomly generated password.   | `OKTA`, `RANDOM`  | TRUE  | FALSE | FALSE  |  `RANDOM`  |
-| status | Status of the setting     | `ENABLED`, `DISABLED` | FALSE    | FALSE  | FALSE  |  `DISABLED` |
 
 ###### Profile Update Setting object
 

--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -6900,7 +6900,7 @@ The provisioning connection object is a read only object that displays the metho
 | _links            | Discoverable resources related to the connection            | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)              | TRUE    | FALSE   | TRUE    |           |
 | status            | Status of the connection      | `ENABLED`, `DISABLED`, `UNKNOWN`  | FALSE    | FALSE   | TRUE    | `DISABLED` |
 
-If the authScheme is UNKNOWN, then either the authentication scheme used by the application isn't supported or the the application doesn't support provisioning. An object with an `UNKNOWN` `authScheme` results in an `UNKNOWN` `status`.
+If the authScheme is `UNKNOWN`, then either the authentication scheme used by the application isn't supported or the the application doesn't support provisioning. An object with an `UNKNOWN` `authScheme` results in an `UNKNOWN` `status`.
 
 ### Provisioning Connection Profile object
 

--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -5466,6 +5466,46 @@ curl -v -X DELETE \
 HTTP/1.1 204 No Content
 ```
 
+## Application Logo operations
+
+<ApiLifecycle access="ea" />
+
+### Update Logo for application
+
+<ApiLifecycle access="ea" />
+
+<ApiOperation method="post" url="/api/v1/apps/${applicationId}/logo" />
+
+Update the logo for an application.
+
+> Note: It is only possible to update the logo for applications with a "login" `appLink`.
+
+#### Request parameters
+
+| Parameter       | Description                                | Parameter Type   | DataType   | Required |
+| :-------------- | :----------------------------------------- | :--------------- | :--------- | :------- |
+| applicationId   | `id` of an [app](#application-object)      | URL              | String     | TRUE     |
+| file            | file containing logo                       | Body             | File       | TRUE     |
+
+The file must be must be a `PNG`, `JPG`, or `GIF` and less than `1Mb`. For best results use landscape orientation, a transparent background, and a minimum of 420px by 120px to prevent upscaling.
+
+#### Request example
+
+```bash
+curl -v -X POST \
+-H "Accept: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+-F 'file=@/path/to/file' \
+"https://${yourOktaDomain}/api/v1/apps/${applicationId}/logo"
+```
+
+#### Response example
+
+``` http
+HTTP/1.1 201 Content Created
+Location: https://${yourOktaDomain}/bc/image/fileStoreRecord?id=fs01hfslJH2m3qUOe0g4
+```
+
 ## Models
 
 * [Application object](#application-object)

--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -5691,6 +5691,260 @@ curl -v -X POST \
 HTTP/1.1 204 No Content
 ```
 
+## Application Features operations
+
+<ApiLifecycle access="ea" />
+
+>Note: Only Okta Org2Org application is supported
+
+### List Features for application
+
+<ApiLifecycle access="ea" />
+
+<ApiOperation method="get" url="/api/v1/apps/${applicationId}/features" />
+
+Fetch Features for an application.
+
+>Note: Provisioning must be enabled for the application and currently only `USER_PROVISIONING` is supported. View [Provisioning Connections](#set-default-provisioning-connection-for-application) for enabling.
+
+#### Request parameters
+
+| Parameter       | Description                                | Parameter Type   | DataType   | Required |
+| :-------------- | :----------------------------------------- | :--------------- | :--------- | :------- |
+| applicationId   | `id` of an [app](#application-object)      | URL              | String     | TRUE     |
+
+#### Response parameters
+
+Array of [Application Features](#application-feature-object).
+
+#### Request example
+
+```bash
+curl -v -X GET \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+"https://${yourOktaDomain}/api/v1/apps/${applicationId}/features"
+```
+
+#### Response example
+
+```json
+[
+    {
+        "name": "USER_PROVISIONING",
+        "status": "ENABLED",
+        "description": "User provisioning settings from Okta to a downstream application",
+        "capabilities": {
+            "create": {
+                "lifecycleCreate": {
+                    "status": "DISABLED"
+                }
+            },
+            "update": {
+                "profile": {
+                    "status": "DISABLED"
+                },
+                "lifecycleDeactivate": {
+                    "status": "DISABLED"
+                },
+                "password": {
+                    "status": "DISABLED",
+                    "seed": "RANDOM",
+                    "change": "KEEP_EXISTING"
+                }
+            }
+        },
+        "_links": {
+            "self": {
+                "href": "http://${yourOktaDomain}/api/v1/apps/${applicationId}/features/USER_PROVISIONING",
+                "hints": {
+                    "allow": [
+                        "GET",
+                        "PUT"
+                    ]
+                }
+            }
+        }
+    }
+]
+```
+
+### Get Feature for application
+
+<ApiLifecycle access="ea" />
+
+<ApiOperation method="get" url="/api/v1/apps/${applicationId}/features/${name}" />
+
+Fetch an Feature for an application.
+
+#### Request parameters
+
+| Parameter       | Description                                | Parameter Type   | DataType   | Required |
+| :-------------- | :----------------------------------------- | :--------------- | :--------- | :------- |
+| applicationId   | `id` of an [app](#application-object)      | URL              | String     | TRUE     |
+
+#### Response parameters
+
+An [Application Feature](#application-feature).
+
+#### Request example
+
+```bash
+curl -v -X GET \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+"https://${yourOktaDomain}/api/v1/apps/${applicationId}/features/${name}"
+```
+
+#### Response example
+
+```json
+{
+    "name": "USER_PROVISIONING",
+    "status": "ENABLED",
+    "description": "User provisioning settings from Okta to a downstream application",
+    "capabilities": {
+        "create": {
+            "lifecycleCreate": {
+                "status": "DISABLED"
+            }
+        },
+        "update": {
+            "profile": {
+                "status": "DISABLED"
+            },
+            "lifecycleDeactivate": {
+                "status": "DISABLED"
+            },
+            "password": {
+                "status": "DISABLED",
+                "seed": "RANDOM",
+                "change": "KEEP_EXISTING"
+            }
+        }
+    },
+    "_links": {
+        "self": {
+            "href": "http://${yourOktaDomain}/api/v1/apps/${applicationId}/features/USER_PROVISIONING",
+            "hints": {
+                "allow": [
+                    "GET",
+                    "PUT"
+                ]
+            }
+        }
+    }
+}
+```
+
+### Update Feature for application
+
+<ApiLifecycle access="ea" />
+
+<ApiOperation method="put" url="/api/v1/apps/${applicationId}/features/${featureName}" />
+
+Update a Feature for an application.
+
+#### Request parameters
+
+| Parameter       | Description                                | Parameter Type   | DataType   | Required |
+| :-------------- | :----------------------------------------- | :--------------- | :--------- | :------- |
+| applicationId   | `id` of an [app](#application-object)      | URL              | String     | TRUE     |
+| capabilities   | capabilites of the feature                  | Body              | [Capabilites Object](#capabilties-object) | TRUE     |
+| name   | name of the feature                      | URL              | String     | TRUE     |
+
+#### Reponse Parameters
+
+Updated [Application Feature](#application-feature-object).
+
+#### Request Example
+
+```bash
+curl -v -X PUT \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+-d '{
+    "create": {
+        "lifecycleCreate": {
+            "status": "ENABLED"
+        }
+    },
+    "update": {
+        "lifecycleDeactivate": {
+            "status": "ENABLED"
+        },
+        "profile":{
+            "status": "ENABLED"
+        },
+        "password":{
+            "status": "ENABLED",
+            "seed": "RANDOM",
+            "change": "CYCLE"
+        }
+    }
+}' "https://${yourOktaDomain}/api/v1/apps/${applicationId}/features/${name}"
+```
+
+This endpoint supports partial updates.
+
+```bash
+curl -v -X PUT \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+-d '{
+    "create": {
+        "lifecycleCreate": {
+            "status": "DISABLED"
+        }
+    }
+}' "https://${yourOktaDomain}/api/v1/apps/${applicationId}/features/${name}"
+```
+
+#### Response example
+
+```json
+{
+    "name": "USER_PROVISIONING",
+    "status": "ENABLED",
+    "description": "User provisioning settings from Okta to a downstream application",
+    "capabilities": {
+        "create": {
+            "lifecycleCreate": {
+                "status": "DISABLED"
+            }
+        },
+        "update": {
+            "profile": {
+                "status": "DISABLED"
+            },
+            "lifecycleDeactivate": {
+                "status": "DISABLED"
+            },
+            "password": {
+                "status": "DISABLED",
+                "seed": "RANDOM",
+                "change": "KEEP_EXISTING"
+            }
+        }
+    },
+    "_links": {
+        "self": {
+            "href": "http://${yourOktaDomain}/api/v1/apps/${applicationId}/features/USER_PROVISIONING",
+            "hints": {
+                "allow": [
+                    "GET",
+                    "PUT"
+                ]
+            }
+        }
+    }
+}
+```
+
 ## Models
 
 * [Application object](#application-object)
@@ -6669,3 +6923,152 @@ Defines the application provisioning connection profile. Currently, only token b
 | ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- | --------- | ---------- |
 | authScheme              | defines how to  connection is authenticated     | `TOKEN` | FALSE    | FALSE  | FALSE    |
 | token            | token used to authenticate with application      | String | FALSE    | TRUE   | FALSE    |
+
+### Application Feature object
+
+Defines the application feature.
+
+#### Application Feature example
+```json
+{
+    "name": "USER_PROVISIONING",
+    "status": "ENABLED",
+    "description": "User provisioning settings from Okta to a downstream application",
+    "capabilities": {
+        "create": {
+            "lifecycleCreate": {
+                "status": "DISABLED"
+            }
+        },
+        "update": {
+            "profile": {
+                "status": "DISABLED"
+            },
+            "lifecycleDeactivate": {
+                "status": "DISABLED"
+            },
+            "password": {
+                "status": "DISABLED",
+                "seed": "RANDOM",
+                "change": "KEEP_EXISTING"
+            }
+        }
+    },
+    "_links": {
+        "self": {
+            "href": "http://rain.okta1.com:1802/api/v1/apps/0oa1h43s0sZyK6Ft40g4/features/USER_PROVISIONING",
+            "hints": {
+                "allow": [
+                    "GET",
+                    "PUT"
+                ]
+            }
+        }
+    }
+}
+```
+
+#### Application Feature properties
+
+| Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly | Default |
+| ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- |
+| capabilities            | capabilites     | [Capabilities Object](#capabilties-object)                                                                  | FALSE    | FALSE   | TRUE    |           |
+| description            | description      | String  | FALSE    | FALSE   | TRUE    |           |
+| _links           | discoverable resources related to the app user     | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)     | TRUE    | FALSE   | TRUE    |           |
+| name              | identifiying name     | `USER_PROVISIONING`  | FALSE    | FALSE  | TRUE    |           |       |      |
+| status            | status    | `ENABLED`, `DISABLED`    | FALSE    | FALSE   | TRUE    |      `DISABLED`  |
+
+##### Capabilties object
+
+The Capabilities object determines the capabilities of an app feature.
+
+| Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly |
+| ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- | --------- | ---------- |
+| create            | determines whether the Okta creates or links a user in the application when assigning the app to a user in Okta | [Create Object](#create-object)  | TRUE    | FALSE   | FALSE    |
+| update            | determines whether the updates to a user's profile will be pushed to the application | [Update Object](#update-object)  | TRUE    | FALSE   | FALSE    |
+
+###### Create object
+
+The Create object is composed of a single setting that determines whether the application creates or links a user in the application when assigning the app to a user in Okta.
+
+```json
+{
+  "lifecycleCreate": {
+    "status": "DISABLED"
+  }
+}
+```
+
+| Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly |
+| ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- |
+| lifecycleCreate            | setting that determines whether the updates to a user in Okta will be update a user in the application   | [Lifecycle Create Setting Object](##lifecycle-create-setting-object)      | TRUE    | FALSE   | FALSE    |           |
+
+###### Update object
+
+The Create object is composed of multiple settings that determine whether the updates to a user in Okta will update a user in the application.
+
+```json
+{
+  "profile": {
+      "status": "DISABLED"
+  },
+  "lifecycleDeactivate": {
+      "status": "DISABLED"
+  },
+  "password": {
+      "status": "DISABLED",
+      "seed": "RANDOM",
+      "change": "KEEP_EXISTING"
+  }
+}
+```
+
+| Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly |
+| ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- |
+| lifecycleDeactivate           | setting that determines whether deprovisioning will occur when app is unassigned  | [Lifecycle Deactivate Setting Object](#lifecycle-deactivate-setting-object)   | TRUE    | FALSE   | FALSE    |
+| password           | setting that determines whether Okta creates and pushes a password in the application for each assigned user | [Password Setting Object](#password-setting-object)    | TRUE    | FALSE   | FALSE    |
+| profile           | setting that determines whether the updates to a user in Okta will be update a user in the application.     | [Profile Setting Object](#profile-setting-object)     | TRUE    | FALSE   | FALSE    |
+
+###### Lifecycle Create Setting object
+
+Creates or links a user in the application when assigning the app to a user in Okta.
+
+| Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly | Default |
+| ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- |
+| status   | status of the setting     | `ENABLED`, `DISABLED` | FALSE    | FALSE   | FALSE    | `DISABLED` |
+
+###### Lifecycle Deactivate Setting object
+
+Deactivates a user's application account when it is unassigned in Okta or their Okta account is deactivated. Accounts can be reactivated if the app is reassigned to a user in Okta.
+
+| Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly | Default |
+| ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- |
+| status   | status of the setting     | `ENABLED`, `DISABLED` | FALSE    | FALSE   | FALSE    | `DISABLED` |
+
+###### Password Setting object
+
+Creates and pushes a password in the application for each assigned user.
+
+```json
+{
+  "password": {
+    "status": "ENABLED",
+    "seed": "OKTA",
+    "change": "CHANGE"
+  }
+}
+```
+
+| Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly | Default |
+| ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- | --------- | ---------- |
+| change | determines whether a change in a users password will also update the password in the application.   | `KEEP_EXISTING`, `CHANGE` | TRUE  | FALSE   | FALSE    | `KEEP_EXISTING` |
+| seed | determines whether the generated password is the users Okta password or a randomly generated password.   | `OKTA`, `RANDOM`  | TRUE  | FALSE | FALSE  |  `RANDOM`  |
+| status | status of the setting     | `ENABLED`, `DISABLED` | FALSE    | FALSE  | FALSE  |  `DISABLED` |
+
+###### Profile Update Setting object
+
+Okta updates a user's attributes in the application when the app is assigned. Future attribute changes made to the Okta user profile will automatically overwrite the corresponding attribute value in the application.
+
+| Property         | Description                                                  | DataType                                                                    | Nullable | Unique | Readonly | Default |
+| ---------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | ------ | -------- | --------- |
+| status   | status of the setting     | `ENABLED`, `DISABLED` | FALSE    | FALSE   | FALSE    | `DISABLED`  |

--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -5593,10 +5593,10 @@ Applications have the following properties:
 | id                 | unique key for app                             | String                                                               | FALSE        | TRUE       | TRUE         |               |             |
 | label              | unique user-defined display name for app       | String                                                               | FALSE        | TRUE       | FALSE        | 1             | 100         |
 | lastUpdated        | timestamp when app was last updated            | Date                                                                 | FALSE        | FALSE      | TRUE         |               |             |
-| name               | unique key for app definition                  | String ([App Names and Settings](#app-names-and-settings))                | FALSE        | TRUE       | TRUE         | 1             | 255         |
+| name               | unique key for app definition                  | String ([App Names](#app-names))                | FALSE        | TRUE       | TRUE         | 1             | 255         |
 | profile            | Valid JSON schema for specifying properties    | [JSON](#profile-object)                                              | TRUE         | FALSE      | FALSE        |               |             |
 | request_object_signing_alg| The type of JSON Web Key Set (JWKS) algorithm that must be used for signing request objects | `HS256`, `HS384`, `HS512`, `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, `ES512`  | TRUE      | FALSE     | FALSE      |
-| settings           | settings for app                               | Object ([App Names and Settings](#app-names-and-settings))                | TRUE         | FALSE      | FALSE        |               |             |
+| settings           | settings for app                               | Object ([App Settings](#app-settings))                | TRUE         | FALSE      | FALSE        |               |             |
 | signOnMode         | authentication mode of app                     | [SignOn Mode](#sign-on-modes)                                         | FALSE        | FALSE      | FALSE        |               |             |
 | status             | status of app                                  | `ACTIVE` or `INACTIVE`                                               | FALSE        | FALSE      | TRUE         |               |             |
 | visibility         | visibility settings for app                    | [Visibility object](#visibility-object)                              | TRUE         | FALSE      | FALSE        |               |             |
@@ -5607,9 +5607,9 @@ Property details
  * `profile` is only available for OAuth 2.0 client apps. See [Profile object](#profile-object).
  * When you specify a value for the `request_object_signing_alg` property, all request objects from the client are rejected if not signed with the specified algorithm. The algorithm must be used when the request object is passed by value (using the request parameter). If a value for `request_object_signing_alg` isn't specified, the default is any algorithm that is supported by both the client and the server.
 
-##### App names and settings
+##### App names
 
-The Okta Integration Network (OIN) defines the catalog of applications that can be added to your Okta organization. Each application has a unique name (key) and schema that defines the required and optional settings for the application. When adding an application, you must specify the unique app name in the request as well as any required settings.
+The Okta Integration Network (OIN) defines the catalog of applications that can be added to your Okta organization. Each application has a unique name (key) that you must specify.
 
 The catalog is currently not exposed via an API. While additional apps may be added via the API, only the following template applications are documented:
 
@@ -5618,7 +5618,8 @@ The catalog is currently not exposed via an API. While additional apps may be ad
 | Custom SAML 2.0     | [Add custom SAML 2.0 application](#add-custom-saml-application)               |
 | Custom SWA          | [Add custom SWA application](#add-custom-swa-application)                     |
 | bookmark            | [Add Bookmark application](#add-bookmark-application)                         |
-| oidc_client         | [Add OAuth 2.0 client application](#add-oauth-2-0-client-application)          |
+| oidc_client         | [Add OAuth 2.0 client application](#add-oauth-2-0-client-application)         |
+| okta_org2org        | [Add Okta Org2Org application](#add-okta-org2org-application)                 |
 | tempalte_sps        | [Add SWA application (no plugin)](#add-swa-application-no-plugin)             |
 | template_basic_auth | [Add Basic Authentication application](#add-basic-authentication-application) |
 | template_swa        | [Add plugin SWA application](#add-plugin-swa-application)                     |
@@ -5626,6 +5627,25 @@ The catalog is currently not exposed via an API. While additional apps may be ad
 | template_wsfed      | [Add WS-Federation application](#add-ws-federation-application)               |
 
 The current workaround is to manually configure the desired application via the administrator UI in a preview (sandbox) organization and view the application via [Get Application](#get-application).
+
+##### App settings
+
+Each application has a schema that defines the required and optional settings for the application. When adding an application, you must specify the required settings.
+
+The catalog is currently not exposed via an API. While additional apps may be added via the API, only the following template applications are documented:
+
+The current workaround is to manually configure the desired application via the administrator UI in a preview (sandbox) organization and view the application via [Get Application](#get-application).
+
+###### Notes Object
+
+<ApiLifecycle access="ea" />
+
+An additional `notes` object can be passed within the `settings` object. The notes object contains the following:
+
+| Property  | Description                                        | DataType | Nullable | Default | MinLength | MaxLength | Validation |
+| --------- | -------------------------------------------------- | -------- | -------- | ------- | --------- | --------- | ---------- |
+| admin       | Application notes for admins | String  | TRUE    | NULL   |           |           |            |
+| enduser       | Application notes for endusers                        | String  | TRUE    | NULL   |           |
 
 > **Note:** You can't currently manage app provisioning settings via the API. Use the administrator UI.
 
@@ -5699,6 +5719,7 @@ Specifies visibility settings for the application
 | Property          | Description                                        | DataType                            | Nullable | Default | MinLength | MaxLength | Validation |
 | ----------------- | -------------------------------------------------- | ----------------------------------- | -------- | ------- | --------- | --------- | ---------- |
 | appLinks          | Displays specific appLinks for the app             | [AppLinks object](#applinks-object) | FALSE    |         |           |           |            |
+| <ApiLifecycle access="ea" /> autoLaunch  |  Automatically sign into the app when user signs into Okta.            | Boolean | FALSE   | FALSE    |           |           |            |
 | autoSubmitToolbar | Automatically sign in when user lands on the sign-in page | Boolean                             | FALSE    | FALSE   |           |           |            |
 | hide              | Hides this app for specific end-user apps          | [Hide object](#hide-object)         | FALSE    | FALSE   |           |           |            |
 

--- a/packages/@okta/vuepress-site/docs/reference/postman-collections/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/postman-collections/index.md
@@ -14,7 +14,7 @@ Import any Okta API collection for Postman from the following list:
 | Administrator Roles                 | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/4f1233beeef282acbcfb)                   |
 | Advanced Server Access              | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/fba803e43a4ae53667d4)                   |
 | API Access Management (OAuth 2.0)   | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/01108eafad818f5aa3c7)                   |
-| Apps                                | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/41a737560876d6003ce5)                   |
+| Apps                                | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/377eaf77fdbeaedced17)                   |
 | Authentication                      | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/6f4f9ca4145db4d80270)                   |
 | Authorization Servers               | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/6e58e52a03637c290665)                   |
 | Custom Templates                    | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/6806eb23befaf5bb3b6c)                   |


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
Add docs for changes/additions to Apps API endpoints. i have separated out the PR into 4 commits for easier reviewing. 

All new docs are under Apps section of docs.
Modified:
Apps > `Models` > `Application Object` > separateed `App Names and Settings` to `App Names` and `App Settings`

New sections added:
Apps > `Application Logo operations`
Apps > `Application Provisioning Connection operations`
Apps > `Application Features operations`

Apps > `Models` > `Provisioning Connection object`
Apps > `Models` > `Provisioning Connection Profile object`
Apps > `Models` > `Application Feature object` 

commit 1:
* adds `notes` to the application settings object.
* adds `autoLaunch` to application `visibility` object
---
commit 2:
* add documentation for logo upload: `{{url}}/api/v1/apps/{{appId}}/logo`
---
commit 3:
* add documentation for provisioning connections api's
* add documentation for provisioning connection objects
---
commit 4:
* add documentation for application feature api's
* add documentation for application features objects
---
- **Is this PR related to a Monolith release?** Yes, must be released along with EA of changes. Release: 2021.1.0

### Resolves:

* [OKTA-347617](https://oktainc.atlassian.net/browse/OKTA-347617)
