### PR TITLE
SLA updates to OIN Guide

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/submit-app/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/submit-app/overview/index.md
@@ -13,11 +13,11 @@ This guide covers submissions that use one or more of these protocols:
 * [System for Cross-domain Identity Management (SCIM)](http://www.simplecloud.info/)
 * [OpenID Connect (OIDC)](https://openid.net/connect/)
 
-    **Note:** To support the potentially large numbers of Okta orgs accessing it through the OIN, an OIDC integration can't use a custom authorization server, including the `default` server.
+    >**Note:** To support the potentially large numbers of Okta orgs accessing it through the OIN, an OIDC integration can't use a custom authorization server, including the `default` server.
 
 * [Security Assertion Markup Language (SAML)](https://en.wikipedia.org/wiki/SAML_2.0)
 
-    **Note:** SAML integrations must use SHA256 encryption for security. If you are using SHA-1 for encryption, see our guide on how to [Upgrade SAML Apps to SHA256](/docs/guides/updating-saml-cert/overview/).
+    >**Note:** SAML integrations must use SHA256 encryption for security. If you are using SHA-1 for encryption, see our guide on how to [Upgrade SAML Apps to SHA256](/docs/guides/updating-saml-cert/overview/).
 
 ## Prerequisites
 

--- a/packages/@okta/vuepress-site/docs/guides/submit-app/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/submit-app/overview/index.md
@@ -36,13 +36,17 @@ After you have built a functioning integration, a few steps are required to subm
 
 1. Work with the Okta OIN team to test your integration using your input and then get it published to the OIN Catalog.
 
-The service-level agreement for OIN publication time is:
+For submissions that contain a SCIM component, the service-level agreement for publication to the OIN is:
 
 * Initial review by Okta - 5 business days
 * QA testing by Okta - 5 business days
 * Final publication in the OIN Catalog - 1 business day
 
-All submissions go through these phases. The Okta OIN team sends you an email that identifies any issues found in the initial review and QA testing phases. At any point in the process, you can check the status of your submission in the [OIN Manager](https://oinmanager.okta.com).
+The Okta OIN team reviews all OIDC and SAML submissions on a best-case basis. SWA app integrations are no longer accepted for publication in the OIN catalog; however, existing SWA apps are still maintained by the OIN team.
+
+The Okta OIN team sends you an email that identifies any issues found in the initial review and QA testing phases. At any point in the process, you can check the status of your submission in the [OIN Manager](https://oinmanager.okta.com).
+
+If you have an urgent customer requirement to add your app integration to their Okta org before it is published in the OIN Catalog, you can help them to create one using the Okta App Integration Wizard. See [Create a new Okta app integration](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Apps_App_Integration_Wizard) and pick the instructions that correspond to your application protocol.
 
 ## Submission support
 

--- a/packages/@okta/vuepress-site/docs/guides/submit-app/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/submit-app/overview/index.md
@@ -28,25 +28,19 @@ As a prerequisite to submission, you must have a functional integration created 
 
 ## Submission process
 
-After you have built a functioning integration, a few steps are required to submit it to Okta for review and publication in the OIN:
+After you have built a functioning app integration, a few steps are required to submit it to Okta for review and publication in the OIN:
 
 1. Create a customer-facing configuration guide.
-1. Submit your integration to Okta through the OIN Manager tool. Your submission must provide Okta with the general and protocol-specific metadata needed to create a customized integration for publication in the OIN.
+1. Submit your integration to Okta through the OIN Manager tool. Your submission must provide Okta with the general and protocol-specific metadata that is required to create a customized integration for publication in the OIN.
     >**Note:** In the OIN manager, the Profile Sourcing option (formerly known as Profile Mastering) is enabled for developer orgs by Okta Developer Support. You can contact <developers@okta.com> to have this capability temporarily activated when submitting a SCIM app integration.
 
 1. Work with the Okta OIN team to test your integration using your input and then get it published to the OIN Catalog.
 
-For submissions that contain a SCIM component, the service-level agreement for publication to the OIN is:
+The Okta OIN team reviews all submissions on a best-case basis.
 
-* Initial review by Okta - 5 business days
-* QA testing by Okta - 5 business days
-* Final publication in the OIN Catalog - 1 business day
+If the Okta OIN team identifies any issues in the initial review and QA testing phases, you are sent an email with the specific details. At any point in the process, you can check the status of your submission in the [OIN Manager](https://oinmanager.okta.com).
 
-The Okta OIN team reviews all OIDC and SAML submissions on a best-case basis. SWA app integrations are no longer accepted for publication in the OIN catalog; however, existing SWA apps are still maintained by the OIN team.
-
-The Okta OIN team sends you an email that identifies any issues found in the initial review and QA testing phases. At any point in the process, you can check the status of your submission in the [OIN Manager](https://oinmanager.okta.com).
-
-If you have an urgent customer requirement to add your app integration to their Okta org before it is published in the OIN Catalog, you can help them to create one using the Okta App Integration Wizard. See [Create a new Okta app integration](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Apps_App_Integration_Wizard) and pick the instructions that correspond to your application protocol.
+  >**Note:** SWA app integrations are no longer accepted for publication in the OIN catalog; however, existing SWA apps are still maintained by the OIN team.
 
 ## Submission support
 


### PR DESCRIPTION
## Description:
- **What's changed?** 
Resolves OKTA-342532 on removing SLA text for OIN submissions
- **Is this PR related to a Monolith release?** 
No - this goes live with the release of 2020.12.0 on production, but is not directly tied to the monolith release.

### Resolves:

* [OKTA-342532](https://oktainc.atlassian.net/browse/OKTA-342532)
