### PR TITLE
Fix Incorrect Link Specify User Type of a New User

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/user-types/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/user-types/index.md
@@ -308,7 +308,7 @@ HTTP/1.1 204 No Content
 
 ## Specify the User Type of a new user
 
-The [Create User](/docs/reference/api/users/#create-user-with-non-default-user-type) operation accepts a type specification as part of the request body. The specification is a map, but currently the only key permitted is `id`. The type specification is also added to the [User object](/docs/reference/api/users/#user-object), but after user creation the type may only be updated by an administrator on a [full replace of an existing user](/docs/reference/api/user-types/#update-user-type), not a partial update.
+The [Create User](/docs/reference/api/users/#create-user-with-non-default-user-type) operation accepts a type specification as part of the request body. The specification is a map, but currently the only key permitted is `id`. The type specification is also added to the [User object](/docs/reference/api/users/#user-object), but after user creation the type may only be updated by an administrator on a [full replace of an existing user](/docs/reference/api/users/#update-user), not a partial update.
 
 ##### Example
 

--- a/packages/@okta/vuepress-site/docs/reference/api/users/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/users/index.md
@@ -1624,7 +1624,7 @@ in the request is deleted.
 
 `profile` and `credentials` can be updated independently or together with a single request.
 
->**Note:** Currently, the User Type of a user can only be changed via a full replacement [PUT operation](/docs/reference/api/user-types/#update-user-type). If the Request Parameters of a partial update include the `type` element from the [User object](#user-object), the value must match the existing type of the user. Only administrators are permitted to change the user type of a user; end users are not allowed to change their own user type.
+>**Note:** Currently, the User Type of a user can only be changed via a full replacement PUT operation. If the Request Parameters of a partial update include the `type` element from the [User object](#user-object), the value must match the existing type of the user. Only administrators are permitted to change the user type of a user; end users are not allowed to change their own user type.
 
 ##### Response Parameters
 


### PR DESCRIPTION
## Description:
- **What's changed?** Fix link on "full replace of an existing user" under the "Specify the User Type of a new user" section
- **Is this PR related to a Monolith release?** no

