### PR TITLE
Add Okta CLI to QuickStart Guides

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/index.md
@@ -72,7 +72,7 @@ If you're using Okta as an identity layer in your app for the first time, we rec
     * [OAuth 2.0 and OpenID Connect overview](/docs/concepts/oauth-openid/)
     * [Authorization servers](/docs/concepts/auth-servers/)
     * [Policies](/docs/concepts/policies/)
-    * [Quickstart: Signing in your first user](/docs/guides/quickstart/)
+    * [Quickstart: Signing in your first user](/docs/guides/quickstart/cli/create-org/)
     * [Set up self-service registration](/docs/guides/set-up-self-service-registration/before-you-begin/)
 
 2. Sign users in

--- a/packages/@okta/vuepress-site/docs/guides/quickstart/create-org/cli/create-org.md
+++ b/packages/@okta/vuepress-site/docs/guides/quickstart/create-org/cli/create-org.md
@@ -11,7 +11,7 @@ Creating an org is easy using the [Okta CLI](https://github.com/okta/okta-cli):
 
 3. Okta creates the org. The CLI returns your Okta domain and lets you know that a verification code is being sent to your email.
 
-   Make a note of your Okta domain: It’s the base of the URL you use to access your org. Authorization requests for users will be directed to an endpoint that has this as its base, and any Okta API endpoints you call will also have this URL as their base.
+> **Note:** Make a note of your Okta domain: It’s the base of the URL you use to access your org. Authorization requests for users will be directed to an endpoint that has this as its base, and any Okta API endpoints you call will also have this URL as their base.
 
 4. Check your email for the verification code. Enter it at the CLI's prompt.
 

--- a/packages/@okta/vuepress-site/docs/guides/quickstart/create-org/cli/create-org.md
+++ b/packages/@okta/vuepress-site/docs/guides/quickstart/create-org/cli/create-org.md
@@ -1,0 +1,18 @@
+Creating an org is easy using the [Okta CLI](https://github.com/okta/okta-cli):
+
+1. After installing the Okta CLI, run the command `okta register`.
+
+2. You are prompted to supply the following information:
+
+    - First name
+    - Last name
+    - Email address
+    - Company
+
+3. Okta creates the org. The CLI returns your Okta domain and lets you know that a verification code is being sent to your email.
+
+   Make a note of your Okta domain: It’s the base of the URL you use to access your org. Authorization requests for users will be directed to an endpoint that has this as its base, and any Okta API endpoints you call will also have this URL as their base.
+
+4. Check your email for the verification code. Enter it at the CLI's prompt.
+
+5. The CLI provides a link to set your password. Open the URL in your web browser.

--- a/packages/@okta/vuepress-site/docs/guides/quickstart/create-org/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/quickstart/create-org/index.md
@@ -10,31 +10,7 @@ An org is free, and you can use it to handle authentication for up to 1,000 user
 
 #### Create your org
 
-You can create an account on our website:
-
-1. Go to: <https://developer.okta.com/signup>
-
-2. Fill out the form. You'll need to supply:
-	 - email address
-	 - first name
-	 - last name
-	 - company
-	 - country
-	 - state/province
-
-3. Click to agree to the terms.
-
-4. Click **Get Started**.
-
-5. You receive an email to activate your account. The email gives you a temporary password and also lets you know your Okta domain.
-
-	Your Okta domain is important: It’s the base of the URL you use to access your org.  Authorization requests for users will be directed to an endpoint that has this as its base, and any Okta API endpoints you call will also have this URL as their base.
-
-	Record your Okta domain and your temporary password. Click the **Activate your account** button in the email.
-
-6. You're prompted to sign in to your org. Supply your email address and the temporary password that was provided in the email.
-
-7. You're prompted to change your password and to choose a security question. You're also prompted to choose a security image. The image is displayed whenever Okta prompts you to sign in, providing some assurance that it’s Okta asking.
+<StackSelector snippet="create-org" />
 
 #### Next steps
 

--- a/packages/@okta/vuepress-site/docs/guides/quickstart/create-org/website/create-org.md
+++ b/packages/@okta/vuepress-site/docs/guides/quickstart/create-org/website/create-org.md
@@ -1,6 +1,6 @@
 You can create an account on our website:
 
-1. Go to: <https://developer.okta.com/signup>
+1. Go to: <https://developer.okta.com/signup>.
 
 2. Fill out the form with the following information:
 
@@ -11,8 +11,8 @@ You can create an account on our website:
 
 3. Click **Get Started**.
 
-4. You receive an email to activate your account.
+4. Click the link in the email that you receive to activate your account.
 
-   Your Okta domain is important: It’s the base of the URL you use to access your org.  Authorization requests for users will be directed to an endpoint that has this as its base, and any Okta API endpoints you call will also have this URL as their base.
+> **Note:** Your Okta domain is important. It’s the base of the URL that you use to access your org.  Authorization requests for users are directed to an endpoint that has this as its base, and any Okta API endpoints you call also have this URL as their base.
 
-5. You're prompted to change your password.
+5. Change your password at the prompt.

--- a/packages/@okta/vuepress-site/docs/guides/quickstart/create-org/website/create-org.md
+++ b/packages/@okta/vuepress-site/docs/guides/quickstart/create-org/website/create-org.md
@@ -1,0 +1,19 @@
+You can create an account on our website:
+
+1. Go to: <https://developer.okta.com/signup>
+
+2. Fill out the form. You'll need to supply:
+
+    - First name
+    - Last name
+    - Email address
+    - Company
+
+3. Click **Get Started**.
+
+4. You receive an email to activate your account.
+
+   Your Okta domain is important: It’s the base of the URL you use to access your org.  Authorization requests for users will be directed to an endpoint that has this as its base, and any Okta API endpoints you call will also have this URL as their base.
+
+5. You're prompted to change your password.
+

--- a/packages/@okta/vuepress-site/docs/guides/quickstart/create-org/website/create-org.md
+++ b/packages/@okta/vuepress-site/docs/guides/quickstart/create-org/website/create-org.md
@@ -2,7 +2,7 @@ You can create an account on our website:
 
 1. Go to: <https://developer.okta.com/signup>
 
-2. Fill out the form. You'll need to supply:
+2. Fill out the form with the following information:
 
     - First name
     - Last name
@@ -16,4 +16,3 @@ You can create an account on our website:
    Your Okta domain is important: It’s the base of the URL you use to access your org.  Authorization requests for users will be directed to an endpoint that has this as its base, and any Okta API endpoints you call will also have this URL as their base.
 
 5. You're prompted to change your password.
-

--- a/packages/@okta/vuepress-site/docs/guides/quickstart/register-app/cli/register-app.md
+++ b/packages/@okta/vuepress-site/docs/guides/quickstart/register-app/cli/register-app.md
@@ -1,0 +1,7 @@
+To use the Okta CLI:
+
+1. Enter the command: `okta apps create`
+2. Give your app a name.
+3. Select **SPA** (for Angular, React or Vue) or **Web** for Type of Application.
+4. Select **Other**.
+5. For Login redirect URI, enter: `http://localhost:8080/login/callback`

--- a/packages/@okta/vuepress-site/docs/guides/quickstart/register-app/cli/register-app.md
+++ b/packages/@okta/vuepress-site/docs/guides/quickstart/register-app/cli/register-app.md
@@ -1,7 +1,7 @@
 To use the Okta CLI:
 
-1. Enter the command: `okta apps create`
+1. Enter the command: `okta apps create`.
 2. Give your app a name.
-3. Select **SPA** (for Angular, React or Vue) or **Web** for Type of Application.
+3. Select **SPA** (for Angular, React or Vue) or **Web** as the  **Type of Application**.
 4. Select **Other**.
-5. For Login redirect URI, enter: `http://localhost:8080/login/callback`
+5. For the **Login redirect URI**, enter: `http://localhost:8080/login/callback`.

--- a/packages/@okta/vuepress-site/docs/guides/quickstart/register-app/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/quickstart/register-app/index.md
@@ -27,31 +27,11 @@ To start, find the example applications provided by Okta on GitHub for the langu
 
 Specifically, look for the `okta-hosted-login` example (there are samples provided for several use cases).
 
-You can try building the example app as-is to start or you can use it as a template for modifying your own app. When you have an app running, you're ready to connect it to your Okta org. 
+You can try building the example app as-is to start or you can use it as a template for modifying your own app. When you have an app running, you're ready to connect it to your Okta org.
 
 #### Tell Okta about the app
 
-In the Developer Console, complete these steps:
-
-1. Click **Applications**.
-
-2. Click **Add Application**.
-
-3. Select **Web** as the type of application. Click **Next**.
-
-4. Enter the **Name** of your app.
-
-5. Leave **Base URI** set to the default. This is the domain where your app runs. For this quick start guide, we'll use `localhost`, which is where the sample apps run by default. You might need to change the port, depending on the default port your framework uses to serve `localhost` pages. 
-
-6. For **Login redirect URIs**, enter: `http://localhost:8080/login/callback`. Okta sends OAuth authorization responses to the specified URIs, which are also known as callback endpoints.
-
-5. Leave **Logout redirect URIs** set to the default. This setting lets you specify a URI to redirect the user’s browser to when they sign out.
-
-6. Leave **Group assignments** set to the default, which is "Everyone". Users can only sign in to apps that they are assigned to. Group assignments let you manage assignments for large numbers of users at once.
-
-7. For **Grant type allowed**, under "Client acting on behalf of a user", select **Authorization Code**. This is the OAuth 2.0 grant type that Okta will provide.
-
-8. Click **Done**.
+<StackSelector snippet="register-app" />
 
 #### Get values from Okta to set in the app
 

--- a/packages/@okta/vuepress-site/docs/guides/quickstart/register-app/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/quickstart/register-app/index.md
@@ -27,7 +27,7 @@ To start, find the example applications provided by Okta on GitHub for the langu
 
 Specifically, look for the `okta-hosted-login` example (there are samples provided for several use cases).
 
-You can try building the example app as-is to start or you can use it as a template for modifying your own app. When you have an app running, you're ready to connect it to your Okta org.
+You can try building the example app as-is to start, or you can use it as a template for modifying your own app. When you have an app running, you're ready to connect it to your Okta org.
 
 #### Tell Okta about the app
 
@@ -50,4 +50,3 @@ Remaining in Developer Console, go to **API > Authorization Servers** and gather
 You now have the specific values for Client ID, Client Secret, and Issuer ID, which your app needs to use. The various example apps all provide ways of setting these values, but some of the example apps expect you to set environment variables, while some expect settings in a configuration file. Consult the README file for the example app you're using and set the three values.
 
 <NextSectionLink/>
-

--- a/packages/@okta/vuepress-site/docs/guides/quickstart/register-app/website/register-app.md
+++ b/packages/@okta/vuepress-site/docs/guides/quickstart/register-app/website/register-app.md
@@ -1,0 +1,21 @@
+In the Developer Console, complete these steps:
+
+1. Click **Applications**.
+
+2. Click **Add Application**.
+
+3. Select **Web** as the type of application. Click **Next**.
+
+4. Enter the **Name** of your app.
+
+5. Leave **Base URI** set to the default. This is the domain where your app runs. For this quick start guide, we'll use `localhost`, which is where the sample apps run by default. You might need to change the port, depending on the default port your framework uses to serve `localhost` pages.
+
+6. For **Login redirect URIs**, enter: `http://localhost:8080/login/callback`. Okta sends OAuth authorization responses to the specified URIs, which are also known as callback endpoints.
+
+5. Leave **Logout redirect URIs** set to the default. This setting lets you specify a URI to redirect the user’s browser to when they sign out.
+
+6. Leave **Group assignments** set to the default, which is "Everyone". Users can only sign in to apps that they are assigned to. Group assignments let you manage assignments for large numbers of users at once.
+
+7. For **Grant type allowed**, under "Client acting on behalf of a user", select **Authorization Code**. This is the OAuth 2.0 grant type that Okta will provide.
+
+8. Click **Done**.

--- a/packages/@okta/vuepress-site/docs/guides/quickstart/register-app/website/register-app.md
+++ b/packages/@okta/vuepress-site/docs/guides/quickstart/register-app/website/register-app.md
@@ -8,14 +8,14 @@ In the Developer Console, complete these steps:
 
 4. Enter the **Name** of your app.
 
-5. Leave **Base URI** set to the default. This is the domain where your app runs. For this quick start guide, we'll use `localhost`, which is where the sample apps run by default. You might need to change the port, depending on the default port your framework uses to serve `localhost` pages.
+5. Leave **Base URI** set to the default. This is the domain where your app runs. For this quick start guide, we use `localhost`, which is where the sample apps run by default. You might need to change the port, depending on the default port your framework uses to serve `localhost` pages.
 
 6. For **Login redirect URIs**, enter: `http://localhost:8080/login/callback`. Okta sends OAuth authorization responses to the specified URIs, which are also known as callback endpoints.
 
 5. Leave **Logout redirect URIs** set to the default. This setting lets you specify a URI to redirect the user’s browser to when they sign out.
 
-6. Leave **Group assignments** set to the default, which is "Everyone". Users can only sign in to apps that they are assigned to. Group assignments let you manage assignments for large numbers of users at once.
+6. Leave **Group assignments** set to the default, which is **Everyone**. Users can only sign in to apps that they are assigned to. Group assignments let you manage assignments for large numbers of users at once.
 
-7. For **Grant type allowed**, under "Client acting on behalf of a user", select **Authorization Code**. This is the OAuth 2.0 grant type that Okta will provide.
+7. For **Grant type allowed**, under "Client acting on behalf of a user", select **Authorization Code**. This is the OAuth 2.0 grant type that Okta provides.
 
 8. Click **Done**.


### PR DESCRIPTION
Reverts https://github.com/okta/okta-developer-docs/pull/1521 and cleans things up a bit.

## Description:
- **What's changed?** Add the Okta CLI
- **Is this PR related to a Monolith release?** No.