### PR TITLE
changed all occurrences of jsonwebtoken.io to token.dev

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/configure-access-policy/limit-scopes-clients-can-access/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/configure-access-policy/limit-scopes-clients-can-access/index.md
@@ -72,7 +72,7 @@ Let's test your access policy and get back an access token.
 
      `http://yourRedirectUriHere.com#access_token=eyJraWQiOiJYc2hYcGZTSHdEMk1zU2pvSTlZTmozWF9KdE1mclpmYWFOUklfNlBCVjQwIi[...]i7U9uW0mI0Bb8SbUeKZjzuxP9aDog&token_type=Bearer&expires_in=3600&scope=openid+email&state=WM6D`
 
-     To check the returned access token, you can copy that URL and paste it into any [JWT decoder](https://jsonwebtoken.io). Check the payload to confirm that it contains the scopes that you are expecting.
+     To check the returned access token, you can copy that URL and paste it into any [JWT decoder](https://token.dev). Check the payload to confirm that it contains the scopes that you are expecting.
 
 ```json
 {

--- a/packages/@okta/vuepress-site/docs/guides/customize-authz-server/test-authz-server/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-authz-server/test-authz-server/index.md
@@ -76,7 +76,7 @@ Enter the credentials for a user who is mapped to your Open ID Connect applicati
 
 `https://yourRedirectUriHere.com/#id_token=eyJhbGciOiJSUzI1NiIsImtpZCI6ImluZUdjZVQ4SzB1SnZyWGVUX082WnZLQlB2RFowO[...]z7UvPoMEIjuBTH-zNkTS5T8mGbY8y7532VeWKA&state=WM6D`
 
-To check the returned ID Token, you can copy the value and paste it into any JWT decoder (for example: <https://jsonwebtoken.io>). Using a JWT decoder you can check the payload to confirm that it contains all of the claims that you are expecting, including custom ones. If you included a `nonce` value, that is also included:
+To check the returned ID Token, you can copy the value and paste it into any JWT decoder (for example: <https://token.dev>). Using a JWT decoder you can check the payload to confirm that it contains all of the claims that you are expecting, including custom ones. If you included a `nonce` value, that is also included:
 
 ```json
 {

--- a/packages/@okta/vuepress-site/docs/guides/customize-tokens-dynamic/request-token-claim/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-tokens-dynamic/request-token-claim/index.md
@@ -72,6 +72,6 @@ To test the full authentication flow that returns an ID token or an access token
     https://yourRedirectUriHere.com#access_token=eyJraWQiOiIxLVN5M2w2dFl2VTR4MXBSLXR5cVZQWERX[...]YNXrsr1gTzD6C60h0UfLiLUhA&token_type=Bearer&expires_in=3600&scope=openid&state=myState
     ```
 
-5. To check the returned ID token or access token payload, you can copy the value and paste it into any JWT decoder (for example: <https://jsonwebtoken.io>). Using a JWT decoder, confirm that the token contains all of the claims that you are expecting, including the custom one. If you specified a nonce, that is also included.
+5. To check the returned ID token or access token payload, you can copy the value and paste it into any JWT decoder (for example: <https://token.dev>). Using a JWT decoder, confirm that the token contains all of the claims that you are expecting, including the custom one. If you specified a nonce, that is also included.
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/customize-tokens-groups-claim/request-token-claim/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-tokens-groups-claim/request-token-claim/index.md
@@ -72,6 +72,6 @@ To test the full authentication flow that returns an ID token or an access token
     https://yourRedirectUriHere.com#access_token=eyJraWQiOiIxLVN5M2w2dFl2VTR4MXBSLXR5cVZQWERX[...]YNXrsr1gTzD6C60h0UfLiLUhA&token_type=Bearer&expires_in=3600&scope=openid&state=myState
     ```
 
-5. To check the returned ID token or access token payload, you can copy the value and paste it into any JWT decoder (for example: <https://jsonwebtoken.io>). Using a JWT decoder, confirm that the token contains all of the claims that you are expecting, including the custom one. If you specified a nonce, that is also included.
+5. To check the returned ID token or access token payload, you can copy the value and paste it into any JWT decoder (for example: <https://token.dev>). Using a JWT decoder, confirm that the token contains all of the claims that you are expecting, including the custom one. If you specified a nonce, that is also included.
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/customize-tokens-returned-from-okta/request-token-claim/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-tokens-returned-from-okta/request-token-claim/index.md
@@ -71,6 +71,6 @@ To test the full authentication flow that returns an ID token or an access token
     https://yourRedirectUriHere.com#access_token=eyJraWQiOiIxLVN5M2w2dFl2VTR4MXBSLXR5cVZQWERX[...]YNXrsr1gTzD6C60h0UfLiLUhA&token_type=Bearer&expires_in=3600&scope=openid&state=myState
     ```
 
-5. To check the returned ID token or access token payload, you can copy the value and paste it into any JWT decoder (for example: <https://jsonwebtoken.io>). Using a JWT decoder, confirm that the token contains all of the claims that you are expecting, including the custom one. If you specified a nonce, that is also included.
+5. To check the returned ID token or access token payload, you can copy the value and paste it into any JWT decoder (for example: <https://token.dev>). Using a JWT decoder, confirm that the token contains all of the claims that you are expecting, including the custom one. If you specified a nonce, that is also included.
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/customize-tokens-static/request-token-claim/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-tokens-static/request-token-claim/index.md
@@ -72,6 +72,6 @@ To test the full authentication flow that returns an ID token or an access token
     https://yourRedirectUriHere.com#access_token=eyJraWQiOiIxLVN5M2w2dFl2VTR4MXBSLXR5cVZQWERX[...]YNXrsr1gTzD6C60h0UfLiLUhA&token_type=Bearer&expires_in=3600&scope=openid&state=myState
     ```
 
-5. To check the returned ID token or access token payload, you can copy the value and paste it into any JWT decoder (for example: <https://jsonwebtoken.io>). Using a JWT decoder, confirm that the token contains all of the claims that you are expecting, including the custom one. If you specified a nonce, that is also included.
+5. To check the returned ID token or access token payload, you can copy the value and paste it into any JWT decoder (for example: <https://token.dev>). Using a JWT decoder, confirm that the token contains all of the claims that you are expecting, including the custom one. If you specified a nonce, that is also included.
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta-serviceapp/create-sign-jwt/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta-serviceapp/create-sign-jwt/index.md
@@ -6,7 +6,7 @@ title: Create and sign the JWT
 
 Create and sign the JWT with your private key for use as a JWT assertion in the request for a scoped access token. You can create this `client_credentials` JWT in several ways.
 
-For testing purposes, use [this tool](https://www.jsonwebtoken.dev/) to generate and sign a JWT. This tool supports both JWT and PEM formats. For a production use case, see [Build a JWT with a private key](/docs/guides/build-self-signed-jwt/java/jwt-with-private-key/) for both a Java and a JavaScript example of signing the JWT.
+For testing purposes, use [this tool](https://token.dev/) to generate and sign a JWT. This tool supports both JWT and PEM formats. For a production use case, see [Build a JWT with a private key](/docs/guides/build-self-signed-jwt/java/jwt-with-private-key/) for both a Java and a JavaScript example of signing the JWT.
 
 > **Note:** After the service app has Okta-scoped grants, only an admin with Super Admin role permissions can rotate the keys.
 

--- a/packages/@okta/vuepress-site/docs/guides/request-user-consent/verification/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/request-user-consent/verification/index.md
@@ -4,7 +4,7 @@ title: Verification
 
 There are several ways to verify that you've successfully created a user grant:
 
-* Check the ID token payload if you requested an ID token. To check the ID token payload, you can copy the token value and paste it into any [JWT decoder](https://www.jsonwebtoken.io/). The payload should look similar to this. Note that no scopes are returned in an ID token:
+* Check the ID token payload if you requested an ID token. To check the ID token payload, you can copy the token value and paste it into any [JWT decoder](https://token.dev/). The payload should look similar to this. Note that no scopes are returned in an ID token:
 
     ```json
     {


### PR DESCRIPTION
## Description:

We've launched token.dev as a replacement for jsonwebtoken.io. We'll be configuring jsonwebtoken.io to redirect to token.dev soon, but we wanted to replace the references in the docs.
