### PR TITLE
OKTA-353661 - Password Import Inline Hook Reference Minor Update

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/password-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/password-hook/index.md
@@ -33,7 +33,7 @@ If your service returns a response that indicates that the password is valid, Ok
 
 The outbound call from Okta to your external service includes the following objects in its JSON payload:
 
-### data.credential
+### data.context.credential
 
 This object contains `username` and `password` properties. These are the user name and password that the end user supplied when attempting to sign in to Okta.
 


### PR DESCRIPTION

## Description:
- **What's changed?** Updated Password Import Inline Hook Reference to align text with code sample. Replaced `data.credential` with `data.context.credential`
- **Is this PR related to a Monolith release?** 

### Resolves:

* [OKTA-353661](https://oktainc.atlassian.net/browse/OKTA-353661)
