### PR TITLE
Fix omission re modifying base properties

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/schemas/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/schemas/index.md
@@ -322,7 +322,7 @@ The following response is only a subset of properties for brevity.
 
 <ApiOperation method="post" url="/api/v1/meta/schemas/user/${typeId}" />
 
-Updates one or more [custom User Profile properties](#user-profile-schema-property-object) in the schema, a [permission](#schema-property-permission-object) for a [User Profile base property](#user-profile-base-subschema), or the nullability of the `firstName` and `lastName` properties in the [User Profile base schema](#user-profile-base-subschema).
+Updates one or more [custom User Profile properties](#user-profile-schema-property-object) in the schema, and/or makes limited changes to [base User Profile properties](#user-profile-base-subschema) ([permissions](#schema-property-permission-object), nullability of the `firstName` and `lastName` properties, or [pattern](#login-pattern-validation) for `login`).
 
 ##### Request parameters
 


### PR DESCRIPTION
When we made the `format` field of the `login` property modifiable (to support non-email logins), we documented it under "User Profile base subschema" but missed another place that links to there: the description of the "Update User Profile Schema property" command.  I felt that the list of allowed modifications there was getting unwieldy, so I rearranged the sentence to make it more concise.

## Description:
- Description of "Update Schema" now says it can change the login format.
- Bugfix; not related to a Monolith release

### Resolves:

* [OKTA-348953](https://oktainc.atlassian.net/browse/OKTA-348953)