### PR TITLE
Remove X-Device-Fingerprint from docs

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api-overview/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api-overview/index.md
@@ -117,10 +117,6 @@ The public IP address of your application will be automatically used as the clie
 
 The `Accept-Language` HTTP header advertises which languages the client is able to understand, for example `Accept-Language: en-US`. Include it if it is available.
 
-## Device Fingerprint
-
-The `X-Device-Fingerprint` HTTP header supplies the device fingerprint used in an authentication request.
-
 ## Errors
 
 > **Note:** JSON responses, including errors, may contain user input. To help prevent potential cross-site scripting attacks, make sure to properly escape all values before use in a browser or any HTML context.


### PR DESCRIPTION
This header was deprecated on 12/7/2020 I believe, should probably remove it from the docs.

<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
