### PR TITLE
Removed offline_access scope from example

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/refresh-tokens/get-refresh-token/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/refresh-tokens/get-refresh-token/index.md
@@ -55,7 +55,7 @@ POST https://${yourOktaDomain}/oauth2/default/v1/token?grant_type=authorization_
  &redirect_uri=http%3A%2F%2Flocalhost%3A8080
  &code=DPA9Utz2LkWlsronqehy
  &state=9606b31k-51d1-4dca-987c-346e3d8767n9
- &scope=openid%20offline_access
+ &scope=openid
 ```
 
 The following is an example request to the `/token` endpoint to obtain an access token, an ID token (by including the `openid` scope), and a refresh token for the [Authorization Code with PKCE flow](/docs/guides/implement-auth-code-pkce/overview/). The value for `code` is the code that you receive in the response from the request to the `/authorize` endpoint.


### PR DESCRIPTION
The example did include the offline_access scope to the token end point, contradicting "The authorization code flow is unique in that the `offline_access` scope must be requested as part of the code request to the `/authorize` endpoint and not the request sent to the `/token` endpoint." testing show it should be left out of the request.

<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
