### PR TITLE
Fixed Create User with Password response example

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/users/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/users/index.md
@@ -244,7 +244,7 @@ curl -v -X POST \
 ```json
 {
   "id": "00ub0oNGTSWTBKOLGLNR",
-  "status": "STAGED",
+  "status": "ACTIVE",
   "created": "2013-07-02T21:36:25.344Z",
   "activated": null,
   "statusChanged": null,


### PR DESCRIPTION
`status` in response will be `ACTIVE` (not `STAGED`) when `activate=true` is used in the request.

<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Fixed Create User with Password response example.
- **Is this PR related to a Monolith release?** No.