### PR TITLE
updating .NET link

### DIFF
--- a/packages/@okta/vuepress-site/code/index.md
+++ b/packages/@okta/vuepress-site/code/index.md
@@ -27,7 +27,7 @@ Code and resources for your platform.
 <Cards class="cols-4">
   <Card href="/code/go/" :showHeaderIcon=true headerIcon="code-go" :showFooter=false>Go</Card>
   <Card href="/code/java/" :showHeaderIcon=true headerIcon="code-java" :showFooter=false>Java</Card>
-  <Card href="/code/dotnet/" :showHeaderIcon=true headerIcon="code-dotnet" :showFooter=false>.Net</Card>
+  <Card href="/code/dotnet/aspnetcore/" :showHeaderIcon=true headerIcon="code-dotnet" :showFooter=false>.Net</Card>
   <Card href="/code/nodejs/" :showHeaderIcon=true headerIcon="code-nodejs" :showFooter=false>Node.js</Card>
   <Card href="/code/php/" :showHeaderIcon=true headerIcon="code-php" :showFooter=false>PHP</Card>
   <Card href="/code/python/" :showHeaderIcon=true headerIcon="code-python" :showFooter=false>Python</Card>


### PR DESCRIPTION
link needs to go to https://developer.okta.com/code/dotnet/aspnetcore/ to prevent a broken empty page

<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
