### PR TITLE
Adjust spacing between social icons on mobile/tablet

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_footer.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_footer.scss
@@ -148,6 +148,8 @@ footer.redesign {
         ul.link-list {
           display: flex;
           justify-content: space-between;
+          max-width: 225px;
+          margin: 0 auto;
         }
 
         span.link-list--text {


### PR DESCRIPTION
## Description:
- **What's changed?** Adjust spacing between social icons on mobile/tablet
### Resolves:

* [OKTA-355567](https://oktainc.atlassian.net/browse/OKTA-355567)

![Screen Shot 2021-01-07 at 2 18 19 PM](https://user-images.githubusercontent.com/72201855/103934622-48960b80-50f3-11eb-868f-6fcfe89b108a.png)
![Screen Shot 2021-01-07 at 2 18 28 PM](https://user-images.githubusercontent.com/72201855/103934623-48960b80-50f3-11eb-85b1-0cb3c9cb2b38.png)

