### PR TITLE
Fixed attributeStatements.values data type

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -6529,7 +6529,7 @@ Specifies (optional) attribute statements for a SAML application
 | name       | The reference name of the attribute statement                                                | String       | FALSE    |
 | namespace  | The name format of the attribute                                                             | String       | FALSE    |
 | type       | The type of attribute statements object                                                      | `EXPRESSION` | FALSE    |
-| values     | The value of the attribute; Supports [Okta EL](/docs/reference/okta-expression-language/)    | String       | FALSE    |
+| values     | The values of the attribute; Supports [Okta EL](/docs/reference/okta-expression-language/)   | Array        | FALSE    |
 
 ### Single Logout object
 


### PR DESCRIPTION
attributeStatements.values is an Array of String, not a single String.

## Description:
- **What's changed?** Fixed attributeStatements.values data type.
- **Is this PR related to a Monolith release?** No.