### PR TITLE
Add a signup success page

### DIFF
--- a/packages/@okta/vuepress-site/signup/thank-you/index.md
+++ b/packages/@okta/vuepress-site/signup/thank-you/index.md
@@ -1,0 +1,5 @@
+---
+layout: AuthorizationLayout
+---
+
+<ThankYou />

--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_thankYou.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_thankYou.scss
@@ -1,0 +1,26 @@
+.thank-you {
+  padding: 0 30px;
+}
+
+.thank-you--title {
+  text-align: center;
+  color: white;
+  margin-top: -5px;
+    margin-bottom: 15px;
+
+  img {
+    min-width: 40px;
+    margin-bottom: 10px;
+  }
+
+  h2 {
+    color: white;
+    margin: .5em 0;
+    margin-bottom: 16px;
+  }
+}
+
+.thank-you--description {
+  text-align: center;
+  color: white;
+}

--- a/packages/@okta/vuepress-theme-prose/assets/css/prose.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/prose.scss
@@ -59,3 +59,4 @@
 @import 'components/pricing';
 @import 'components/oktaIntegrationNetwork';
 @import 'components/terms';
+@import 'components/thankYou';

--- a/packages/@okta/vuepress-theme-prose/global-components/Login.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/Login.vue
@@ -47,6 +47,7 @@
 
 <script>
 export default {
+  name: "Login",
   components: {
     CompanyLogos: () => import("../components/CompanyLogos")
   }

--- a/packages/@okta/vuepress-theme-prose/global-components/ThankYou.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/ThankYou.vue
@@ -1,0 +1,21 @@
+<template>
+  <section class="thank-you">
+    <div class="thank-you--title">
+      <img
+        src="https://www.okta.com/sites/default/files/icon--welcome.svg"
+        alt="mail icon"
+      />
+      <h2>Verify Your Email Address</h2>
+    </div>
+    <p class="thank-you--description">
+      We just sent a verification email to the address you entered. Please go to
+      your inbox and verify your account to continue.
+    </p>
+  </section>
+</template>
+
+<script>
+export default {
+  name: "ThankYou"
+};
+</script>


### PR DESCRIPTION
## Description:
- **What's changed?** Add a signup success page

### Resolves:
* [OKTA-361043](https://oktainc.atlassian.net/browse/OKTA-361043)

### Screenshots:
![Screen Shot 2021-01-15 at 11 18 00 AM](https://user-images.githubusercontent.com/72201855/104751708-bfe72300-5723-11eb-9eee-8f3f4243daba.png)
![Screen Shot 2021-01-15 at 11 18 07 AM](https://user-images.githubusercontent.com/72201855/104751710-bfe72300-5723-11eb-9d2b-b8f603110672.png)

Went without this section:
![Screen Shot 2021-01-15 at 10 24 09 AM](https://user-images.githubusercontent.com/72201855/104751753-ce353f00-5723-11eb-8e31-f2725d6f2ec1.png)

Because this exact information is already in the footer right below where it would be:
![Screen Shot 2021-01-15 at 10 24 12 AM](https://user-images.githubusercontent.com/72201855/104751816-e311d280-5723-11eb-91c7-4344c3b28d3b.png)
