### PR TITLE
Adjust copyright text

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/config.js
+++ b/packages/@okta/vuepress-site/.vuepress/config.js
@@ -277,7 +277,7 @@ module.exports = {
       ],
 
       forum_url: 'https://devforum.okta.com/',
-      copyright_text: 'Copyright © 2020 Okta.'
+      copyright_text: 'Copyright © 2021 Okta.'
     },
   },
 


### PR DESCRIPTION
## Description:
- **What's changed?**
- Change `2020` for `2021` in footer's copyright text

### Resolves:
* [OKTA-361721](https://oktainc.atlassian.net/browse/OKTA-361721)

### Screenshots:
![Screen Shot 2021-01-17 at 4 30 59 PM](https://user-images.githubusercontent.com/72201855/104856581-7ba18180-58e1-11eb-80f3-8ff41c1662dd.png)
