### PR TITLE
Fix mixed up link and image for android

### DIFF
--- a/packages/@okta/vuepress-site/index.md
+++ b/packages/@okta/vuepress-site/index.md
@@ -46,8 +46,8 @@ tiles:
         link: /docs/guides/sign-into-mobile-app/react-native/before-you-begin/
         image: /img/homepage/stackselectors/react.png
       - name: Android
-        link: /code/android/
-        image: /docs/guides/sign-into-mobile-app/android/before-you-begin/
+        link: /docs/guides/sign-into-mobile-app/android/before-you-begin/
+        image: /img/homepage/stackselectors/android.png
       - name: IOS
         link: /docs/guides/sign-into-mobile-app/ios/before-you-begin/
         image: /img/homepage/stackselectors/ios.png


### PR DESCRIPTION
## Description:
- **What's changed?** Seems the icon link and doc link were mixed up when rebasing, this addresses it
### Resolves:
* [OKTA-360151](https://oktainc.atlassian.net/browse/OKTA-360151)

### Screenshots:
Before
![Screen Shot 2021-01-19 at 1 25 39 PM](https://user-images.githubusercontent.com/72201855/105090675-b4ba2d00-5a6c-11eb-8b09-cbf1f790d568.png)

After
![Screen Shot 2021-01-19 at 3 40 57 PM](https://user-images.githubusercontent.com/72201855/105090694-bd126800-5a6c-11eb-929f-cf0fa49eeb5f.png)