### PR TITLE
iOS SSO: Add a note about Default Rule

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/shared-sso-android-ios/session-and-persistent-sso/ios/enablesso.md
+++ b/packages/@okta/vuepress-site/docs/guides/shared-sso-android-ios/session-and-persistent-sso/ios/enablesso.md
@@ -23,6 +23,8 @@ Before you begin, be sure to:
     GET https://${yourOktaDomain}/api/v1/policies/00p2sy9ploJnRwPwp5g7/rules
     ```
 7. In the response, locate the rule that you want to modify, copy its `id` value, and copy the `actions` property section of the JSON payload.
+    > **Note:** The rule named `Default Rule` cannot be modified. Therefore, copy `id` of a custom rule. If you see only `Default Rule` in the response then [create a custom rule](/docs/guides/customize-authz-server/create-rules-for-policy/).
+
     > **Tip:** You can also highlight the rule ID, right-click, and set it as the value for the `ruleId` variable in your environment.
 8. Click the **Update Sign On Rule** request to open it.
 9. In the request URL, replace the `policyId` and `ruleId` variables with the policy ID and rule ID that you copied previously. If you assigned these as variables in your environment, skip this step.

--- a/packages/@okta/vuepress-site/docs/guides/shared-sso-android-ios/session-and-persistent-sso/ios/enablesso.md
+++ b/packages/@okta/vuepress-site/docs/guides/shared-sso-android-ios/session-and-persistent-sso/ios/enablesso.md
@@ -23,7 +23,7 @@ Before you begin, be sure to:
     GET https://${yourOktaDomain}/api/v1/policies/00p2sy9ploJnRwPwp5g7/rules
     ```
 7. In the response, locate the rule that you want to modify, copy its `id` value, and copy the `actions` property section of the JSON payload.
-    > **Note:** The rule named `Default Rule` cannot be modified. Therefore, copy `id` of a custom rule. If you see only `Default Rule` in the response then [create a custom rule](/docs/guides/customize-authz-server/create-rules-for-policy/).
+    > **Note:** The rule named `Default Rule` cannot be modified. Therefore, copy the `id` value of a custom rule instead. If you only see a `Default Rule` in the response, then you should first [create a custom rule](/docs/guides/customize-authz-server/create-rules-for-policy/).
 
     > **Tip:** You can also highlight the rule ID, right-click, and set it as the value for the `ruleId` variable in your environment.
 8. Click the **Update Sign On Rule** request to open it.


### PR DESCRIPTION
Resolves: OKTA-321310

## Description:
- **What's changed?** 
Add a note about `Default Rule` to make sure that a user copied a custom rule' `id` for further correct requests.

- **Is this PR related to a Monolith release?** 
No

### Resolves:

* [OKTA-321310](https://oktainc.atlassian.net/browse/OKTA-321310)


<img width="794" alt="Screenshot 2021-01-21 at 12 09 37" src="https://user-images.githubusercontent.com/77254185/105336128-8a3db080-5be1-11eb-9599-85a7cf0e06b7.png">
