### PR TITLE
Removed non-existent anchor link

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/implement-auth-code-pkce/use-flow/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-auth-code-pkce/use-flow/index.md
@@ -9,7 +9,7 @@ Your first step is to generate a code verifier and challenge:
 * Code verifier: Random URL-safe string with a minimum length of 43 characters.
 * Code challenge: Base64 URL-encoded SHA-256 hash of the code verifier.
 
-You need to add code in your native app to create the code verifier and code challenge. For examples of code that handles this, see the examples on this page.
+You need to add code in your native app to create the code verifier and code challenge.
 
 The PKCE generator code creates output like this:
 

--- a/packages/@okta/vuepress-site/docs/guides/implement-auth-code-pkce/use-flow/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-auth-code-pkce/use-flow/index.md
@@ -9,7 +9,7 @@ Your first step is to generate a code verifier and challenge:
 * Code verifier: Random URL-safe string with a minimum length of 43 characters.
 * Code challenge: Base64 URL-encoded SHA-256 hash of the code verifier.
 
-You need to add code in your native app to create the code verifier and code challenge. For examples of code that handles this, see [the examples on this page](#examples).
+You need to add code in your native app to create the code verifier and code challenge. For examples of code that handles this, see the examples on this page.
 
 The PKCE generator code creates output like this:
 


### PR DESCRIPTION
## Description:
- **What's changed?** 
- This link leads to an anchor that does not exist. I pulled up google cache and found it used to just say, look below, so I don't think it was ever meant to be a link. Please let me know if I'm off here. (reported by Tim Lopez in #web)

- **Is this PR related to a Monolith release?** 
No

### Resolves:
n/a, reported by someone in #web slack channel

