### PR TITLE
Updating deprecated loginRedirect method with the correct one

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/add-signin-button/angular/login-redirect.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/add-signin-button/angular/login-redirect.md
@@ -26,9 +26,11 @@ export class AppComponent {
   }
 
   login() {
-    this.oktaAuth.loginRedirect('/profile');
+    this.oktaAuth.signInWithRedirect({
+      originalUri: '/profile'
+    });    
   }
 }
 ```
 
-The `loginRedirect()` method lets you specify the path you'd like the user to be navigated to after authenticating.
+The `signInWithRedirect()` method lets you specify the path you'd like the user to be navigated to after authenticating through the `originalUri` field.


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?**
> The Angular docs refers to a deprecated method "loginRedirect" that does not exist anymore (https://developer.okta.com/docs/guides/sign-into-spa/angular/add-signin-button/). This has now been updated to the correct method "signInWithRedirect".
- **Is this PR related to a Monolith release?** 
> No

**Before:**
<img width="935" alt="Before" src="https://user-images.githubusercontent.com/77295104/105738240-d00db800-5f04-11eb-80f9-8072e7c8a71a.png">

**After:**
<img width="921" alt="After" src="https://user-images.githubusercontent.com/77295104/105738243-d0a64e80-5f04-11eb-96da-50e5ff95c6dd.png">


### Resolves:

* [OKTA-362112](https://oktainc.atlassian.net/browse/OKTA-362112)
