### PR TITLE
Fixed broken link for Golang samples

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/protect-your-api/next-steps/go/samples.md
+++ b/packages/@okta/vuepress-site/docs/guides/protect-your-api/next-steps/go/samples.md
@@ -1,1 +1,1 @@
-We have multiple samples available in our [Golang Samples repo](https://github.com/okta/samples-golang/tree/develop/resource-server) on GitHub.
+We have multiple samples available in our [Golang Samples repo](https://github.com/okta/samples-golang) on GitHub.


### PR DESCRIPTION
## Description:
- **What's changed?** 
Current link is broken, edited to: https://github.com/okta/samples-golang

- **Is this PR related to a Monolith release?**
No

### Resolves:

n/a, reported in https://okta.slack.com/archives/CM6EN4KUN/p1611627599019800
