### PR TITLE
added note for optional steps for IdP configuration

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/add-an-external-idp/register-app-in-okta/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/add-an-external-idp/register-app-in-okta/index.md
@@ -1,6 +1,9 @@
 ---
 title: Register an App in Okta
 ---
+
+> **Note:** If you only need to authenticate user into Okta and not have them redirected to a particular OIDC client the IdP configuration would be complete at this point and [routing rules](https://help.okta.com/en/prod/Content/Topics/Security/Identity_Provider_Discovery.htm) have to be set to redirect users from the Okta login page to the correct provider.
+
 You can either use an existing OpenID Connect app or create one. This is the app that consumes the response from the Identity Provider after authentication and authorization. Users that sign in for the first time are created in Okta and are associated with this application.
 
 1. In your Okta org, click **Applications**, and then **Add Application**.

--- a/packages/@okta/vuepress-site/docs/guides/add-an-external-idp/register-app-in-okta/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/add-an-external-idp/register-app-in-okta/index.md
@@ -2,7 +2,7 @@
 title: Register an App in Okta
 ---
 
-> **Note:** If you only need to authenticate user into Okta and not have them redirected to a particular OIDC client the IdP configuration would be complete at this point and [routing rules](https://help.okta.com/en/prod/Content/Topics/Security/Identity_Provider_Discovery.htm) have to be set to redirect users from the Okta login page to the correct provider.
+> **Note:** If you only need to authenticate users into Okta and not have them redirected to a particular OIDC client the IdP configuration would be complete at this point and [routing rules](https://help.okta.com/en/prod/Content/Topics/Security/Identity_Provider_Discovery.htm) have to be set to redirect users from the Okta login page to the correct provider.
 
 You can either use an existing OpenID Connect app or create one. This is the app that consumes the response from the Identity Provider after authentication and authorization. Users that sign in for the first time are created in Okta and are associated with this application.
 


### PR DESCRIPTION
a lot of people that are trying to create an IdP for a workforce scenario are confused by this step as it is not needed for them and the configuration is already complete by this point

<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->

add a note on the "Register an app in Okta" step for configuring identity providers that it is not mandatory to continue with next steps in order to use the provider

- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
