### PR TITLE
removed reference to ZeroSSL

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/gather-information/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/gather-information/index.md
@@ -6,7 +6,6 @@ Before you get started, make sure that you have the following information:
 * A domain that you own, for example, `example.com`.
 * A subdomain that you want to use, for example, `login.example.com`.
 * A valid TLS certificate for your subdomain. If you don't have one, you can generate one with a service such as:
-  * [ZeroSSL](https://zerossl.com/)
   * [Let's Encrypt](https://letsencrypt.org/)
 
     Make sure that you have the TLS certificate (PEM-encoded) for your subdomain and the 2048-bit private key (PEM-encoded) before beginning.


### PR DESCRIPTION
## Description:
- **What's changed?** 
- ZeroSSL offers a SHA-384 encrypted cert, which does not work for Okta, so we should not refer to it as a possible vendor for certs.

- **Is this PR related to a Monolith release?**
- no

### Resolves:

n/a, surfaced from https://okta.slack.com/archives/CM6EN4KUN/p1611780594037700 and https://github.com/okta/okta-developer-docs/pull/1855