### PR TITLE
Fixed broken link to go samples

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/next-steps/go/samples.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/next-steps/go/samples.md
@@ -1,1 +1,1 @@
-We have multiple samples available in our [Golang Samples repo](https://github.com/okta/samples-golang/tree/develop/resource-server) on GitHub.
+We have multiple samples available in our [Golang Samples repo](https://github.com/okta/samples-golang) on GitHub.

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/next-steps/go/samples.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/next-steps/go/samples.md
@@ -1,1 +1,1 @@
-We have multiple samples available in our [Golang Samples repo](https://github.com/okta/samples-golang) on GitHub.
+We have multiple samples available in our [Golang Samples repo](https://github.com/okta/samples-golang/tree/master/resource-server) on GitHub.


### PR DESCRIPTION
## Description:
- **What's changed?**
- Fixed broken link to golang sample apps: https://github.com/okta/samples-golang (correct link)
- 
- **Is this PR related to a Monolith release?** 
no

### Resolves:
reported by SE:
https://okta.slack.com/archives/CM6EN4KUN/p1611786166042600
