### PR TITLE
remove /live-widget from conductor.yml

### DIFF
--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -1995,5 +1995,3 @@ redirects:
     to: https://www.okta.com/contact-sales/
   - from: /login-widget-gallery/
     to: /
-  - from: /live-widget/
-    to: /


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- Removing /live-widget from conductor.yml so we can redirect it to the old Drupal page

### Resolves:

* [OKTA-362883](https://oktainc.atlassian.net/browse/OKTA-362883)
