### PR TITLE
Fixed missing 9 for availability

### DIFF
--- a/packages/@okta/vuepress-site/pricing/index.md
+++ b/packages/@okta/vuepress-site/pricing/index.md
@@ -14,7 +14,7 @@ links:
 
 features:
   hiAvailability:
-    name: 99.9% availability
+    name: 99.99% availability
   serviceAssurance:
     name: Service level assurance
   capacity:


### PR DESCRIPTION
## Description:
- **What's changed?** 
- Fixed missing "9" for our availability claim of four 9's: 99.99%

- **Is this PR related to a Monolith release?** <!-- If so, which one? -->
- no

### Resolves:

* Reported to me by PMM (Jiong Liu)