### PR TITLE
Beta Guide: Third-Party Risk Integration

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/config.js
+++ b/packages/@okta/vuepress-site/.vuepress/config.js
@@ -337,7 +337,13 @@ module.exports = {
               '/docs/guides/sign-into-web-app-remediation/handle-remediation/',
               '/docs/guides/sign-into-web-app-remediation/get-tokens/',
               '/docs/guides/sign-into-web-app-remediation/next-steps/',
-              '/docs/reference/api/authenticators-admin/'
+              '/docs/reference/api/authenticators-admin/',
+              '/docs/guides/third-party-risk-integration/overview/', //Beta release of Risk APIs and Guide
+              '/docs/guides/third-party-risk-integration/create-service-app/',
+              '/docs/guides/third-party-risk-integration/update-default-provider/',
+              '/docs/guides/third-party-risk-integration/test-integration/',
+              '/docs/reference/api/risk-providers/',
+              '/docs/reference/api/risk-events/'
           ]
         }
       ]

--- a/packages/@okta/vuepress-site/docs/guides/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/index.md
@@ -55,6 +55,7 @@ guides:
  - sign-users-out
  - sign-your-own-saml-csr
  - style-the-widget
+ - third-party-risk-integration
  - unlock-mobile-app-with-biometrics
  - updating-saml-cert
  - validate-access-tokens

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/create-service-app/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/create-service-app/index.md
@@ -1,3 +1,101 @@
 ---
 title: Create a service application for third-party risk provider
 ---
+
+Your Okta org requires the set up of an OAuth service application to integrate and authenticate third-party risk signals from a third-party risk provider.
+
+Use the following high-level steps to configure this service application:
+
+1. [Create a public-private key pair](/docs/guides/third-party-integration/create-service-app)
+2. [Create and verify the service application](/docs/guides/third-party-integration/create-service-app)
+3. [Add a scope grant to the service application](/docs/guides/third-party-integration/create-service-app)
+
+For background information on this general process, see [Implement OAuth for Okta with a Service App](/docs/guides/implement-oauth-for-okta-serviceapp/overview/).
+
+### Create a public-private key pair
+Prior to creating the service application for the third-party risk provider, you need to create a public-private key pair for client authentication. Use a tool such as the [JSON Web Key Generator](https://mkjwk.org/) to generate  a public-private key pair for an example setup.
+
+To generate a public-private key pair:
+1. Navigate to [JSON Web Key Generator](https://mkjwk.org/).
+2. Use the following values when generating the pair:
+
+    - **Key Size**: 2048
+    - **Key Use**: Signature
+    - **Algorithm**: RS256
+    - **Key ID**: SHA-256
+
+3. Click **Generate**.
+4. Copy the **Public Key** JSON value to your Postman environment's `publicKey` variable.
+5. Make sure to save the JSON value for the **Public and Private Key pair**, which is required during testing.
+
+For background information on this process, see [Create a public/private key pair](/docs/guides/implement-oauth-for-okta-serviceapp/create-publicprivate-keypair).
+
+### Create a service application
+Create the service application that integrates with the third-party Risk Provider using the previously generated public key for authentication.
+
+To create the service application:
+1. Call the following POST API from the Risk Integration Postman collection: Admin: API to create OAuth service client (for the provider) (`{{url}}/oauth2/v1/clients`).
+
+2. Review the response, which includes the `jwks` key pair. Note, the `clint_name` value is the same value you gave to the `providerName` variable. A sample response follows:
+
+    ```JSON
+    {
+    "client_id": "0oaaaboyxsbrWdsk81d6",
+    "client_id_issued_at": 1611263018,
+    "client_name": "Risk Provider Company",
+    "client_uri": null,
+    "logo_uri": null,
+    "redirect_uris": [
+        "https://httpbin.org/get"
+    ],
+    "response_types": [
+        "token"
+    ],
+    "grant_types": [
+        "client_credentials"
+    ],
+    "jwks": {
+        "keys": [
+            {
+                "kty": "RSA",
+                "alg": "RS256",
+                "kid": null,
+                "use": "sig",
+                "e": "AQAB",
+                "n": "uNj5u6PSWYR0VOTEhVsVEMfiFCVcNBKyRGM0YHQjGlhEHO-28Dw68l8U1KdHdiNVrvL21S-bfQFyQWSTF5_w5x966SmNMPHtjkxoJ_BOxyed3bKkbfLZgq8GM5lsAwTE-NIbMmPciX9Z4VEapaiKbEqg3KSGVzJcEH18E8AiIMgQ0ts7NTJ33sOwtqdTsQfho5crqtPIy1Z0Svvraq-UA7-elDWj9duqLE-YIRx-6U9hdBJ5Q7bC12H_TwcyNoLLwvtdi2X8NNV93CLJ1xoDAS9o8FDmWWUqciXq4XLww1kJRFvOMMT7LLefYdhV1Ef7MTZrpTOlwoDfDDdltTUUmw"
+            }
+        ]
+    },
+    "token_endpoint_auth_method": "private_key_jwt",
+    "application_type": "service"
+    }
+    ```
+
+3. From the response, copy the `client_id` value, in this example `0oaaaboyxsbrWdsk81d6`, to your Postman environment's `clientId` variable.
+
+4. Verify the application is available by calling the following GET API from the Risk Integration Postman collection: Admin: API to get all OAuth service clients (`{{url}}/oauth2/v1/clients`).
+
+This call retrieves all service applications from your Okta org, including the new Risk Integration service application.
+
+For background information on this process, see [Create a service app and grant scopes](/docs/guides/implement-oauth-for-okta-serviceapp/create-serviceapp-grantscopes/).
+
+### Add scope grant to application
+You must now define the allowed Risk scope for use with the third-party Risk Provider service application.
+
+To add the Risk scope grant to the service application:
+
+1. Call the following POST API from the Risk Integration Postman collection: Admin: API to grant scopes to the OAuth service client (`{{url}}/api/v1/apps/{{clientId}}/grants`).
+
+    This call adds the `scopeId` to  the value of: `okta.riskEvents.manage`.
+
+2. Review the response for this addition. A sample portion of the response follows:
+
+    ```JSON
+     "_embedded": {
+        "scope": {
+            "id": "okta.riskEvents.manage"
+        }
+    },
+    ```
+
+For background information on granting scopes, see [Grant allowed scopes](docs/guides/implement-oauth-for-okta-serviceapp/create-serviceapp-grantscopes/#grant-allowed-scopes).

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/create-service-app/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/create-service-app/index.md
@@ -1,0 +1,3 @@
+---
+title: Create a service application for third-party risk provider
+---

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/create-service-app/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/create-service-app/index.md
@@ -10,7 +10,7 @@ Use the following high-level steps to configure this service application:
 2. [Create and verify the service application](/docs/guides/third-party-risk-integration/create-service-app/#create-a-service-application)
 3. [Add a scope grant to the service application](/docs/guides/third-party-risk-integration/create-service-app/#add-scope-grant-to-application)
 
-For background information on this general process, see [Implement OAuth for Okta with a Service App](/docs/guides/implement-oauth-for-okta-serviceapp/overview/).
+For information on this general process, see [Implement OAuth for Okta with a Service App](/docs/guides/implement-oauth-for-okta-serviceapp/overview/).
 
 ### Create a public-private key pair
 Prior to creating the service application for the third-party risk provider, you need to create a public-private key pair for client authentication. Use a tool such as the [JSON Web Key Generator](https://mkjwk.org/) to generate  a public-private key pair for an example setup.

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/create-service-app/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/create-service-app/index.md
@@ -93,7 +93,7 @@ For background information on this process, see [Create a service app and grant 
 ### Add scope grant to application
 You must now define the allowed Risk scope for use with the third-party risk provider service application.
 
-1. Call the following POST API from the Risk Integration Postman collection: **Admin: API to grant scopes to the OAuth service client** (`{{url}}/api/v1/apps/{{clientId}}/grants`).
+1. Call the following POST API from the Risk Integration Postman collection: **Admin: API to grant scopes to the OAuth service client** (`/api/v1/apps/${clientId}/grants`).
 
     This call adds the `scopeId` to  the value of: `okta.riskEvents.manage`.
 

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/create-service-app/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/create-service-app/index.md
@@ -2,7 +2,7 @@
 title: Create a service app for third-party risk provider
 ---
 
-Your Okta org requires the set up of an OAuth service application to integrate and consume risk signals from a third-party risk provider.
+Your Okta org requires the set up of an OAuth service application to integrate and consume risk events from a third-party risk provider.
 
 Use the following high-level steps to configure this service application:
 
@@ -41,9 +41,9 @@ Prior to creating the service application for the third-party risk provider, you
 For background information on this process, see [Create a public/private key pair](/docs/guides/implement-oauth-for-okta-serviceapp/create-publicprivate-keypair).
 
 ### Create a service application
-Create the service application that integrates with the third-party Risk Provider using the previously generated public key for authentication.
+Create the service application that integrates with the third-party risk provider using the previously generated public key for authentication.
 
-1. Copy the name of your third-party Risk Provider to your Postman environment's `providerName` variable. In this example, use `Risk Provider Example`.
+1. Copy the name of your third-party risk provider to your Postman environment's `providerName` variable. In this example, use `Risk Provider Example`.
 
 2. Call the following POST API from the Risk Integration Postman collection: **Admin: API to create OAuth service client (for the provider)** (`{{url}}/oauth2/v1/clients`).
 
@@ -91,7 +91,7 @@ This call retrieves all service applications from your Okta org, including the n
 For background information on this process, see [Create a service app and grant scopes](/docs/guides/implement-oauth-for-okta-serviceapp/create-serviceapp-grantscopes/).
 
 ### Add scope grant to application
-You must now define the allowed Risk scope for use with the third-party Risk Provider service application.
+You must now define the allowed Risk scope for use with the third-party risk provider service application.
 
 1. Call the following POST API from the Risk Integration Postman collection: **Admin: API to grant scopes to the OAuth service client** (`{{url}}/api/v1/apps/{{clientId}}/grants`).
 

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/create-service-app/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/create-service-app/index.md
@@ -2,7 +2,7 @@
 title: Create a service app for third-party risk provider
 ---
 
-Your Okta org requires the set up of an OAuth service application to integrate and consume third-party risk signals from a third-party risk provider.
+Your Okta org requires the set up of an OAuth service application to integrate and consume risk signals from a third-party risk provider.
 
 Use the following high-level steps to configure this service application:
 
@@ -36,22 +36,24 @@ Prior to creating the service application for the third-party risk provider, you
     }
     ```
 4. Copy the **Public Key** JSON value to your Postman environment's `publicKey` variable.
-5. Make sure to save the JSON value for the **Public and Private Key pair**, which is required during testing.
+5. Make sure to save the JSON value for the **Public and Private Keypair**, which is required during testing.
 
 For background information on this process, see [Create a public/private key pair](/docs/guides/implement-oauth-for-okta-serviceapp/create-publicprivate-keypair).
 
 ### Create a service application
 Create the service application that integrates with the third-party Risk Provider using the previously generated public key for authentication.
 
-1. Call the following POST API from the Risk Integration Postman collection: **Admin: API to create OAuth service client (for the provider)** (`{{url}}/oauth2/v1/clients`).
+1. Copy the name of your third-party Risk Provider to your Postman environment's `providerName` variable. In this example, use `Risk Provider Example`.
 
-2. Review the response, which includes the `jwks` key pair. Note, the `clint_name` value is the same value you gave to the `providerName` variable. A sample response follows:
+2. Call the following POST API from the Risk Integration Postman collection: **Admin: API to create OAuth service client (for the provider)** (`{{url}}/oauth2/v1/clients`).
+
+3. Review the response, which includes the `jwks` key pair. Note, the `clint_name` value is the same value you gave to the `providerName` variable. A sample response follows:
 
     ```JSON
     {
     "client_id": "0oaaaboyxsbrWdsk81d6",
     "client_id_issued_at": 1611263018,
-    "client_name": "Risk Provider Company",
+    "client_name": "Risk Provider Example",
     "client_uri": null,
     "logo_uri": null,
     "redirect_uris": [
@@ -80,9 +82,9 @@ Create the service application that integrates with the third-party Risk Provide
     }
     ```
 
-3. From the response, copy the `client_id` value, in this example `0oaaaboyxsbrWdsk81d6`, to your Postman environment's `clientId` variable.
+4. From the response, copy the `client_id` value, in this example `0oaaaboyxsbrWdsk81d6`, to your Postman environment's `clientId` variable.
 
-4. Verify the application is available by calling the following GET API from the Risk Integration Postman collection: **Admin: API to get all OAuth service clients** (`{{url}}/oauth2/v1/clients`).
+5. Verify the application is available by calling the following GET API from the Risk Integration Postman collection: **Admin: API to get all OAuth service clients** (`{{url}}/oauth2/v1/clients`).
 
 This call retrieves all service applications from your Okta org, including the new Risk Integration service application.
 

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/create-service-app/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/create-service-app/index.md
@@ -6,9 +6,9 @@ Your Okta org requires the set up of an OAuth service application to integrate a
 
 Use the following high-level steps to configure this service application:
 
-1. [Create a public-private key pair](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair)
-2. [Create and verify the service application](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair)
-3. [Add a scope grant to the service application](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair)
+1. [Create a public-private key pair](/docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair)
+2. [Create and verify the service application](/docs/guides/third-party-risk-integration/create-service-app/#create-a-service-application)
+3. [Add a scope grant to the service application](/docs/guides/third-party-risk-integration/create-service-app/#add-scope-grant-to-application)
 
 For background information on this general process, see [Implement OAuth for Okta with a Service App](/docs/guides/implement-oauth-for-okta-serviceapp/overview/).
 
@@ -107,6 +107,6 @@ You must now define the allowed Risk scope for use with the third-party risk pro
     },
     ```
 
-For background information on granting scopes, see [Grant allowed scopes](docs/guides/implement-oauth-for-okta-serviceapp/create-serviceapp-grantscopes/#grant-allowed-scopes).
+For background information on granting scopes, see [Grant allowed scopes](/docs/guides/implement-oauth-for-okta-serviceapp/create-serviceapp-grantscopes/#grant-allowed-scopes).
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/create-service-app/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/create-service-app/index.md
@@ -47,7 +47,7 @@ Create the service application that integrates with the third-party Risk Provide
 
 2. Call the following POST API from the Risk Integration Postman collection: **Admin: API to create OAuth service client (for the provider)** (`{{url}}/oauth2/v1/clients`).
 
-3. Review the response, which includes the `jwks` key pair. Note, the `clint_name` value is the same value you gave to the `providerName` variable. A sample response follows:
+3. Review the response, which includes the `jwks` key pair. Note, the `client_name` value is the same value you gave as the `providerName` variable. A sample response follows:
 
     ```JSON
     {

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/create-service-app/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/create-service-app/index.md
@@ -1,21 +1,20 @@
 ---
-title: Create a service application for third-party risk provider
+title: Create a service app for third-party risk provider
 ---
 
 Your Okta org requires the set up of an OAuth service application to integrate and authenticate third-party risk signals from a third-party risk provider.
 
 Use the following high-level steps to configure this service application:
 
-1. [Create a public-private key pair](/docs/guides/third-party-integration/create-service-app)
-2. [Create and verify the service application](/docs/guides/third-party-integration/create-service-app)
-3. [Add a scope grant to the service application](/docs/guides/third-party-integration/create-service-app)
+1. [Create a public-private key pair](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair)
+2. [Create and verify the service application](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair)
+3. [Add a scope grant to the service application](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair)
 
 For background information on this general process, see [Implement OAuth for Okta with a Service App](/docs/guides/implement-oauth-for-okta-serviceapp/overview/).
 
 ### Create a public-private key pair
 Prior to creating the service application for the third-party risk provider, you need to create a public-private key pair for client authentication. Use a tool such as the [JSON Web Key Generator](https://mkjwk.org/) to generate  a public-private key pair for an example setup.
 
-To generate a public-private key pair:
 1. Navigate to [JSON Web Key Generator](https://mkjwk.org/).
 2. Use the following values when generating the pair:
 
@@ -24,7 +23,18 @@ To generate a public-private key pair:
     - **Algorithm**: RS256
     - **Key ID**: SHA-256
 
-3. Click **Generate**.
+3. Click **Generate**. A sample **Public Key** value follows:
+
+    ```JSON
+    {
+    "kty": "RSA",
+    "e": "AQAB",
+    "use": "sig",
+    "kid": "NhIpAobkW_7CfLFA2d1UUB8odnWbZMebCR8dm-O6aMM",
+    "alg": "RS256",
+    "n": "pqEM9uy9rPs6M8E3zGqnSjdgHRYj9pZ2LCb0sRzpg2r1BItPXknLPmrcVI0K4a84FpDRRoOc5zV-YILYIPA8JdAnazQiiGHfzzrNsTfcT-iD45-4Fb7tyuU2KQdwwZpP0FfWNcILgbdJbYdjfPM7AuKg3zok7xzZnk-wTJkGzdcya-0X5jX4hKl48hm8506CBep6fKhwZbjMXTt3R2bm-zqxYqjC5dXawx0ICniRnZyzNscmO6e3SYd0WDB-etQTHehbj1r0v6NOVZBWwsQEMP7_WZoUUS02mOODYSh-TI-deJ3Aw61iG5rKsQDgOZzGy2ZazyXJGhhfngGgzL4xfw"
+    }
+    ```
 4. Copy the **Public Key** JSON value to your Postman environment's `publicKey` variable.
 5. Make sure to save the JSON value for the **Public and Private Key pair**, which is required during testing.
 
@@ -33,8 +43,7 @@ For background information on this process, see [Create a public/private key pai
 ### Create a service application
 Create the service application that integrates with the third-party Risk Provider using the previously generated public key for authentication.
 
-To create the service application:
-1. Call the following POST API from the Risk Integration Postman collection: Admin: API to create OAuth service client (for the provider) (`{{url}}/oauth2/v1/clients`).
+1. Call the following POST API from the Risk Integration Postman collection: **Admin: API to create OAuth service client (for the provider)** (`{{url}}/oauth2/v1/clients`).
 
 2. Review the response, which includes the `jwks` key pair. Note, the `clint_name` value is the same value you gave to the `providerName` variable. A sample response follows:
 
@@ -73,7 +82,7 @@ To create the service application:
 
 3. From the response, copy the `client_id` value, in this example `0oaaaboyxsbrWdsk81d6`, to your Postman environment's `clientId` variable.
 
-4. Verify the application is available by calling the following GET API from the Risk Integration Postman collection: Admin: API to get all OAuth service clients (`{{url}}/oauth2/v1/clients`).
+4. Verify the application is available by calling the following GET API from the Risk Integration Postman collection: **Admin: API to get all OAuth service clients** (`{{url}}/oauth2/v1/clients`).
 
 This call retrieves all service applications from your Okta org, including the new Risk Integration service application.
 
@@ -82,9 +91,7 @@ For background information on this process, see [Create a service app and grant 
 ### Add scope grant to application
 You must now define the allowed Risk scope for use with the third-party Risk Provider service application.
 
-To add the Risk scope grant to the service application:
-
-1. Call the following POST API from the Risk Integration Postman collection: Admin: API to grant scopes to the OAuth service client (`{{url}}/api/v1/apps/{{clientId}}/grants`).
+1. Call the following POST API from the Risk Integration Postman collection: **Admin: API to grant scopes to the OAuth service client** (`{{url}}/api/v1/apps/{{clientId}}/grants`).
 
     This call adds the `scopeId` to  the value of: `okta.riskEvents.manage`.
 
@@ -99,3 +106,5 @@ To add the Risk scope grant to the service application:
     ```
 
 For background information on granting scopes, see [Grant allowed scopes](docs/guides/implement-oauth-for-okta-serviceapp/create-serviceapp-grantscopes/#grant-allowed-scopes).
+
+<NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/create-service-app/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/create-service-app/index.md
@@ -2,7 +2,7 @@
 title: Create a service app for third-party risk provider
 ---
 
-Your Okta org requires the set up of an OAuth service application to integrate and authenticate third-party risk signals from a third-party risk provider.
+Your Okta org requires the set up of an OAuth service application to integrate and consume third-party risk signals from a third-party risk provider.
 
 Use the following high-level steps to configure this service application:
 

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/index.md
@@ -1,6 +1,6 @@
 ---
 title: Third-Party Risk Provider Integration
-excerpt: Provides documentation on configuring an Okta org to receive risk signals from a third-party provider
+excerpt: Provides documentation on configuring an Okta org to receive risk events from a third-party provider
 layout: Guides
 sections:
  - overview

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/index.md
@@ -1,0 +1,10 @@
+---
+title: Third-Party Risk Provider Integration
+excerpt: Provides documentation on configuring an Okta org to receive risk signals from a third-party provider
+layout: Guides
+sections:
+ - overview
+ - create-service-app
+ - update-default-provider
+ - test-integration
+---

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
@@ -1,0 +1,3 @@
+---
+title: Overview
+---

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
@@ -4,18 +4,17 @@ title: Third-Party Risk Provider Integration Overview
 
 <ApiLifecycle access="beta" /> This is a beta feature guide.
 
-The Okta Risk Engine evaluates authentication attempts by reviewing the risk score of the sign-in based on context and historical data. Using Okta Risk APIs, third-party Risk Providers can integrate with the Okta Risk Engine using a standard Okta service application. The third-party Risk Provider can send risk signals or events, which can be used when calculating the authentication risk based on the risk policy configured in the Okta org. The risk signals are additionally logged as part of the System Log.
+The Okta Risk Engine evaluates authentication attempts by reviewing the risk score of the sign-in based on context and historical data. Using Okta Risk APIs, third-party Risk Providers can integrate with the Okta Risk Engine using a standard Okta service application. The third-party Risk Provider can send risk signals, or events, which can be used when calculating the authentication risk based on the risk policy configured in the Okta org. The risk signals are additionally logged as part of the System Log.
 
 This guide provides an example third-party Risk Provider implementation with your Okta org.
 
->**Note**: Third Party Partners
-Third party risk signals are received from Non-Okta Applications. You are not required to receive or utilize third party risk signals within Okta Risk Engine, but if you configure Okta Risk Engine to utilize third party risk signals, then you are consenting to Okta receiving and sharing data with the Non-Okta Application as necessary to provide this functionality. You may only utilize these third party risk signals if you are a customer of both Okta and the Non-Okta Application. Okta cannot guarantee continued partnerships or functionality with any Non-Okta Applications.
+>**Note**: Third party risk signals are received from Non-Okta Applications. You are not required to receive or utilize third party risk signals within Okta Risk Engine, but if you configure Okta Risk Engine to utilize third party risk signals, then you are consenting to Okta receiving and sharing data with the Non-Okta Application as necessary to provide this functionality. You may only utilize these third party risk signals if you are a customer of both Okta and the Non-Okta Application. Okta cannot guarantee continued partnerships or functionality with any Non-Okta Applications.
 
 ### Prerequisites
 To use this guide, you need the following:
 
 - An Okta developer org. [Create an org for free](/signup/).
-- Enable your Okta developer org with the following feature flags (FF): `RISK_SCORING` and `CONSUME_EXTERNAL_RISK_SIGNALS`. Contact your Okta customer support representative to enable these features.
+- To enable your Okta developer org with the following feature flags (FF): `RISK_SCORING` and `CONSUME_EXTERNAL_RISK_SIGNALS`. Contact your Okta customer support representative to enable these features.
 - A [Postman client](https://www.postman.com/downloads/) to configure and test the Risk Provider integration. See [Get Started with the Okta APIs](/code/rest/) for information on setting up Postman.
 - Download the Risk API Collection:
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/1c449b51a4a0adf90198)
@@ -31,7 +30,11 @@ Creating a third-party Risk Provider integration follows the general configurati
 
 - [Implement OAuth for Okta with a Service App](/docs/guides/implement-oauth-for-okta-serviceapp/overview/)
 - [Risk Provider API](/docs/reference/apis/risk-providers)
-- [Risk Events API](/docs/reference/apis/risk-events)]
+- [Risk Events API](/docs/reference/apis/risk-events)
 - [Risk Scoring and Risk Based Authentication](https://help.okta.com/en/prod/Content/Topics/Security/Security_Risk_Scoring.htm)
+
+## Support
+
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
@@ -20,7 +20,7 @@ To use this guide, you need the following:
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/1c449b51a4a0adf90198)
 
 ### High-level configurations
-Creating a third-party risk provider integration follows the general configurations for creating an OAuth service application using the OAuth client credentials grant flow. The service application provides an integration for the default risk provider and the Okta Risk Engine, and Risk Event API calls can test for a successful setup. Follow the high-level steps below to set up an example third-part risk provider integration.
+Creating a third-party risk provider integration follows the general configurations for creating an OAuth service application using the OAuth client credentials grant flow. The service application provides an integration for the default risk provider and the Okta Risk Engine, and Risk Event API calls can test for a successful setup. Follow the high-level steps below to set up an example third-party risk provider integration.
 
 1. [Create self-service application for the risk provider](/docs/guides/third-party-risk-integration/create-service-app)
 2. [Update the default risk provider](/docs/guides/third-party-risk-integration/update-default-provider)

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
@@ -1,29 +1,29 @@
 ---
-title: Third-Party Risk Provider Integration Overview
+title: Third-party risk provider integration overview
 ---
 
 <ApiLifecycle access="beta" />
 
-The Okta Risk Engine evaluates authentication attempts by reviewing the risk score of the sign-in based on context and historical data. Using Okta Risk APIs, third-party Risk Providers can integrate with the Okta Risk Engine using a standard Okta service application. The third-party Risk Provider can send risk signals, or events, which can be used when calculating the authentication risk based on the risk policy configured in the Okta org. The risk signals are additionally logged as part of the System Log.
+The Okta Risk Engine evaluates authentication attempts by reviewing the risk score of the sign-in based on context and historical data. Using Okta Risk APIs, third-party risk providers can integrate with the Okta Risk Engine using a standard Okta service application. The third-party risk provider can send risk events, which can be used when calculating the authentication risk based on the risk policy configured in the Okta org. The risk events are additionally logged as part of the System Log.
 
-This guide provides an example third-party Risk Provider implementation with your Okta org.
+This guide provides an example third-party risk provider implementation with your Okta org.
 
->**Note:** Third-party risk signals are received from non-Okta Applications. You are not required to receive or utilize third-party risk signals within Okta Risk Engine, but if you configure Okta Risk Engine to utilize third-party risk signals, then you are consenting to Okta receiving and sharing data with the non-Okta Application as necessary to provide this functionality. You may only utilize these third-party risk signals if you are a customer of both Okta and the non-Okta Application. Okta cannot guarantee continued partnerships or functionality with any Non-Okta Applications.
+>**Note:** Third-party risk events are received from non-Okta Applications. You are not required to receive or utilize third-party risk events within Okta Risk Engine, but if you configure Okta Risk Engine to utilize third-party risk events, then you are consenting to Okta receiving and sharing data with the non-Okta Application as necessary to provide this functionality. You may only utilize these third-party risk events if you are a customer of both Okta and the non-Okta Application. Okta cannot guarantee continued partnerships or functionality with any Non-Okta Applications.
 
 ### Prerequisites
 To use this guide, you need the following:
 
 - An Okta developer org. [Create an org for free](/signup/).
-- To enable your Okta developer org with the following feature flags (FF): `RISK_SCORING` and `CONSUME_EXTERNAL_RISK_SIGNALS`. Contact your Okta customer support representative to enable these features.
-- A [Postman client](https://www.postman.com/downloads/) to configure and test the Risk Provider integration. See [Get Started with the Okta APIs](/code/rest/) for information on setting up Postman.
+- To configure your Okta org for third-party risk providers. Contact your Okta customer support representative for this configuration.
+- A [Postman client](https://www.postman.com/downloads/) to configure and test the risk provider integration. See [Get Started with the Okta APIs](/code/rest/) for information on setting up Postman.
 - Download the Risk API Collection:
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/1c449b51a4a0adf90198)
 
 ### High-level configurations
-Creating a third-party Risk Provider integration follows the general configurations for creating an OAuth service application using the OAuth client credentials grant flow. The service application provides an integration for the default Risk Provider and the Okta Risk Engine, and Risk Event API calls can test for a successful setup. Follow the high-level steps below to set up an example third-part Risk Provider integration.
+Creating a third-party risk provider integration follows the general configurations for creating an OAuth service application using the OAuth client credentials grant flow. The service application provides an integration for the default risk provider and the Okta Risk Engine, and Risk Event API calls can test for a successful setup. Follow the high-level steps below to set up an example third-part risk provider integration.
 
-1. [Create self-service application for the Risk Provider](/docs/guides/third-party-risk-integration/create-service-app)
-2. [Update the default Risk Provider](/docs/guides/third-party-risk-integration/update-default-provider)
+1. [Create self-service application for the risk provider](/docs/guides/third-party-risk-integration/create-service-app)
+2. [Update the default risk provider](/docs/guides/third-party-risk-integration/update-default-provider)
 3. [Test the integration](/docs/guides/third-party-risk-integration/test-integration)
 
 ### See also
@@ -33,8 +33,8 @@ Creating a third-party Risk Provider integration follows the general configurati
 - [Risk Events API](/docs/reference/apis/risk-events)
 - [Risk Scoring and Risk Based Authentication](https://help.okta.com/en/prod/Content/Topics/Security/Security_Risk_Scoring.htm)
 
-## Support
+<!-- ## Support
 
-If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).
+If you need help or have an issue, post a question in our [Developer Forum](https://devforum.okta.com).-->
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
@@ -4,9 +4,12 @@ title: Overview
 
 <ApiLifecycle access="beta" /> This is a beta feature guide.
 
-[Overview blurb on Risk Integration, Risk Providers, and Risk Signals, and overall configuration. Discussion on risk authtenticaion and analysis. Okta version and then extension.
+The Okta Risk Engine evaluates authentication attempts by reviewing the risk score of the sign-in based on context and historical data. Using Okta Risk APIs, third-party Risk Providers can now integrate with the Okta Risk Engine using a standard Okta service application. The third-party risk signals from the Risk Provider can be used when calculating the risk based on the risk policy configured in the Okta org, as well as logged as part of the System Log.
 
-This guide provides an example third-party Risk Provider implementation]
+This guide provides an example third-party Risk Provider implementation with your Okta org.
+
+>**Note**: Third Party Partners
+Third party risk signals are received from Non-Okta Applications. You are not required to receive or utilize third party risk signals within Okta Risk Engine, but if you configure Okta Risk Engine to utilize third party risk signals, then you are consenting to Okta receiving and sharing data with the Non-Okta Application as necessary to provide this functionality. You may only utilize these third party risk signals if you are a customer of both Okta and the Non-Okta Application. Okta cannot guarantee continued partnerships or functionality with any Non-Okta Applications.
 
 ### Prerequisites
 To use this guide, you need the following:
@@ -18,16 +21,17 @@ To use this guide, you need the following:
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/1c449b51a4a0adf90198)
 
 ### High-level Configurations
-Creating a third-party Risk Provider integration follows the general configurations for creating an OAuth service application using the OAuth client credentials grant flow, which can be reviewed in [Implement OAuth for Okta with a Service App](/docs/guides/implement-oauth-for-okta-serviceapp/overview/). The service application provides an integration for the default Risk Provider and the Okta Risk Engine, and Risk Event API calls can test for a successful setup. Follow the high-level steps below, documented in the subsequent three sections.
+Creating a third-party Risk Provider integration follows the general configurations for creating an OAuth service application using the OAuth client credentials grant flow. The service application provides an integration for the default Risk Provider and the Okta Risk Engine, and Risk Event API calls can test for a successful setup. Follow the high-level steps below to set up an example third-part Risk Provider integration.
 
-1. Create self-service application for the Risk Provider
-2. Update the default Risk Provider (only three, default name )
-3. Test the integration
-
+1. [Create self-service application for the Risk Provider](/docs/guides/third-party-risk-integration/create-service-app)
+2. [Update the default Risk Provider](/docs/guides/third-party-risk-integration/update-default-provider)
+3. [Test the integration](/docs/guides/third-party-risk-integration/test-integration)
 
 ### See also
-- risk provider api
-- risk events api
-- client credentials flow link
+
+- [Implement OAuth for Okta with a Service App](/docs/guides/implement-oauth-for-okta-serviceapp/overview/)
+- [Risk Provider API](/docs/reference/apis/risk-providers)
+- [Risk Events API](/docs/reference/apis/risk-events)]
+- [Risk Scoring and Risk Based Authentication](https://help.okta.com/en/prod/Content/Topics/Security/Security_Risk_Scoring.htm)
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
@@ -8,7 +8,7 @@ The Okta Risk Engine evaluates authentication attempts by reviewing the risk sco
 
 This guide provides an example third-party Risk Provider implementation with your Okta org.
 
->**Note**: Third party risk signals are received from Non-Okta Applications. You are not required to receive or utilize third party risk signals within Okta Risk Engine, but if you configure Okta Risk Engine to utilize third party risk signals, then you are consenting to Okta receiving and sharing data with the Non-Okta Application as necessary to provide this functionality. You may only utilize these third party risk signals if you are a customer of both Okta and the Non-Okta Application. Okta cannot guarantee continued partnerships or functionality with any Non-Okta Applications.
+>**Note:** Third-party risk signals are received from non-Okta Applications. You are not required to receive or utilize third-party risk signals within Okta Risk Engine, but if you configure Okta Risk Engine to utilize third-party risk signals, then you are consenting to Okta receiving and sharing data with the non-Okta Application as necessary to provide this functionality. You may only utilize these third-party risk signals if you are a customer of both Okta and the non-Okta Application. Okta cannot guarantee continued partnerships or functionality with any Non-Okta Applications.
 
 ### Prerequisites
 To use this guide, you need the following:

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
@@ -2,7 +2,7 @@
 title: Third-Party Risk Provider Integration Overview
 ---
 
-<ApiLifecycle access="beta" /> This is a beta feature guide.
+<ApiLifecycle access="beta" />
 
 The Okta Risk Engine evaluates authentication attempts by reviewing the risk score of the sign-in based on context and historical data. Using Okta Risk APIs, third-party Risk Providers can integrate with the Okta Risk Engine using a standard Okta service application. The third-party Risk Provider can send risk signals, or events, which can be used when calculating the authentication risk based on the risk policy configured in the Okta org. The risk signals are additionally logged as part of the System Log.
 

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
@@ -4,26 +4,30 @@ title: Overview
 
 <ApiLifecycle access="beta" /> This is a beta feature guide.
 
-[Overview blurb on Risk Integration, Risk Providers, and Risk Signals, and overall configuration.
+[Overview blurb on Risk Integration, Risk Providers, and Risk Signals, and overall configuration. Discussion on risk authtenticaion and analysis. Okta version and then extension.
 
-This guide provides an example implementation ....blah[]
+This guide provides an example third-party Risk Provider implementation]
 
 ### Prerequisites
 To use this guide, you need the following:
-- An Okta developer org. [Create an org for free](signup/).
-- A [Postman client](https://www.postman.com/downloads/) to configure and test the Risk Provider integration. See [Get Started with the Okta APIs](/code/rest/) for information on setting up Postman.
+
+- An Okta developer org. [Create an org for free](/signup/).
 - Enable your Okta developer org with the following feature flags (FF): `RISK_SCORING` and `CONSUME_EXTERNAL_RISK_SIGNALS`. Contact your Okta customer support representative to enable these features.
+- A [Postman client](https://www.postman.com/downloads/) to configure and test the Risk Provider integration. See [Get Started with the Okta APIs](/code/rest/) for information on setting up Postman.
+- Download the Risk API Collection:
+[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/1c449b51a4a0adf90198)
 
+### High-level Configurations
+Creating a third-party Risk Provider integration follows the general configurations for creating an OAuth service application using the OAuth client credentials grant flow, which can be reviewed in [Implement OAuth for Okta with a Service App](/docs/guides/implement-oauth-for-okta-serviceapp/overview/). The service application provides an integration for the default Risk Provider and the Okta Risk Engine, and Risk Event API calls can test for a successful setup. Follow the high-level steps below, documented in the subsequent three sections.
 
-Use the client credentials grant flow ...
-
-
-1. Create self-service application
-2. Update default Risk Provider (only three, default name )
+1. Create self-service application for the Risk Provider
+2. Update the default Risk Provider (only three, default name )
 3. Test the integration
 
 
-
-
+### See also
+- risk provider api
+- risk events api
+- client credentials flow link
 
 <NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
@@ -1,3 +1,5 @@
 ---
 title: Overview
 ---
+
+<ApiLifecycle access="beta" />

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
@@ -2,4 +2,15 @@
 title: Overview
 ---
 
-<ApiLifecycle access="beta" />
+<ApiLifecycle access="beta" /> This is a beta feature guide.
+
+Overview blurb on Risk Integration, Risk Providers, and Risk Signals, and overall configuration.
+
+This guide provides an example implementation ....blah
+
+### Prerequisites
+
+
+1. Create self-service application
+2. Update default Risk Provider (only three, default name )
+3. Test the integration

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
@@ -1,10 +1,10 @@
 ---
-title: Overview
+title: Third-Party Risk Provider Integration Overview
 ---
 
 <ApiLifecycle access="beta" /> This is a beta feature guide.
 
-The Okta Risk Engine evaluates authentication attempts by reviewing the risk score of the sign-in based on context and historical data. Using Okta Risk APIs, third-party Risk Providers can now integrate with the Okta Risk Engine using a standard Okta service application. The third-party risk signals from the Risk Provider can be used when calculating the risk based on the risk policy configured in the Okta org, as well as logged as part of the System Log.
+The Okta Risk Engine evaluates authentication attempts by reviewing the risk score of the sign-in based on context and historical data. Using Okta Risk APIs, third-party Risk Providers can integrate with the Okta Risk Engine using a standard Okta service application. The third-party Risk Provider can send risk signals or events, which can be used when calculating the authentication risk based on the risk policy configured in the Okta org. The risk signals are additionally logged as part of the System Log.
 
 This guide provides an example third-party Risk Provider implementation with your Okta org.
 
@@ -20,7 +20,7 @@ To use this guide, you need the following:
 - Download the Risk API Collection:
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/1c449b51a4a0adf90198)
 
-### High-level Configurations
+### High-level configurations
 Creating a third-party Risk Provider integration follows the general configurations for creating an OAuth service application using the OAuth client credentials grant flow. The service application provides an integration for the default Risk Provider and the Okta Risk Engine, and Risk Event API calls can test for a successful setup. Follow the high-level steps below to set up an example third-part Risk Provider integration.
 
 1. [Create self-service application for the Risk Provider](/docs/guides/third-party-risk-integration/create-service-app)

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
@@ -14,3 +14,9 @@ This guide provides an example implementation ....blah
 1. Create self-service application
 2. Update default Risk Provider (only three, default name )
 3. Test the integration
+
+
+
+
+
+<NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
@@ -17,7 +17,7 @@ To use this guide, you need the following:
 - To configure your Okta org for third-party risk providers. Contact your Okta customer support representative for this configuration.
 - A [Postman client](https://www.postman.com/downloads/) to configure and test the risk provider integration. See [Get Started with the Okta APIs](/code/rest/) for information on setting up Postman.
 - Download the Risk API Collection:
-[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/1c449b51a4a0adf90198)
+[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/47546754d382762468c6)
 
 ### High-level configurations
 Creating a third-party risk provider integration follows the general configurations for creating an OAuth service application using the OAuth client credentials grant flow. The service application provides an integration for the default risk provider and the Okta Risk Engine, and Risk Event API calls can test for a successful setup. Follow the high-level steps below to set up an example third-party risk provider integration.

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
@@ -4,11 +4,18 @@ title: Overview
 
 <ApiLifecycle access="beta" /> This is a beta feature guide.
 
-Overview blurb on Risk Integration, Risk Providers, and Risk Signals, and overall configuration.
+[Overview blurb on Risk Integration, Risk Providers, and Risk Signals, and overall configuration.
 
-This guide provides an example implementation ....blah
+This guide provides an example implementation ....blah[]
 
 ### Prerequisites
+To use this guide, you need the following:
+- An Okta developer org. [Create an org for free](signup/).
+- A [Postman client](https://www.postman.com/downloads/) to configure and test the Risk Provider integration. See [Get Started with the Okta APIs](/code/rest/) for information on setting up Postman.
+- Enable your Okta developer org with the following feature flags (FF): `RISK_SCORING` and `CONSUME_EXTERNAL_RISK_SIGNALS`. Contact your Okta customer support representative to enable these features.
+
+
+Use the client credentials grant flow ...
 
 
 1. Create self-service application

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
@@ -4,7 +4,7 @@ title: Test the integration
 
 With the creation of a service application for the third-party risk provider, and the update of the third-party risk provider profile, you can now test the integration using the Risk Events API.
 
-In practice, this API is used by the third-party provider to send risk events to an Okta org for risk policy evaluation or the system log. The third-party provider requires access to the public-private key pair and the service application ID (`clientId`) created by the Okta administrator in the [Create service application](docs/guides/third-party-risk-integration/create-service-app/) topic.
+In practice, this API is used by the third-party provider to send risk events to an Okta org for risk policy evaluation or the system log. The third-party provider requires access to the public-private key pair and the service application ID (`clientId`) created by the Okta administrator in the [Create service application](/docs/guides/third-party-risk-integration/create-service-app/) topic.
 
 In this test, the API sends a sample payload risk event to the Okta org, which can be consumed by Okta and used to calculate the risk of the authentication.
 
@@ -12,16 +12,16 @@ In this test, the API sends a sample payload risk event to the Okta org, which c
 
 Use the following high-level steps to test the risk provider integration:
 
-1. [Create a client assertion for the access token](docs/guides/third-party-risk-integration/test-integration/#create-a-client-assertion)
-2. [Create an access token](docs/guides/third-party-risk-integration/test-integration/#create-an-access-token)
-3. [Send a risk event to the Okta org](docs/guides/third-party-risk-integration/test-integration/#send-a-risk-event-to-okta)
-4. [Confirm the response and system log](docs/guides/third-party-risk-integration/test-integration/confirm-the-response)
+1. [Create a client assertion for the access token](/docs/guides/third-party-risk-integration/test-integration/#create-a-client-assertion)
+2. [Create an access token](/docs/guides/third-party-risk-integration/test-integration/#create-an-access-token)
+3. [Send a risk event to the Okta org](/docs/guides/third-party-risk-integration/test-integration/#send-a-risk-event-to-okta)
+4. [Confirm the response and system log](/docs/guides/third-party-risk-integration/test-integration/#confirm-the-response)
 
 ### Create a client assertion
 This procedure creates a signed JSON Web Token (JWT), which is used as the client assertion value required in the request for a scoped access token.
 
 1. Navigate to [Generate JWT](https://www.jsonwebtoken.dev/) to create a JWT.
-2. In the **JWK KEY** field, copy the **Public and Private Keypair** generated when you created the service application ([Create a public-private key pair](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair).)
+2. In the **JWK KEY** field, copy the **Public and Private Keypair** generated when you created the service application ([Create a public-private key pair](/docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair).)
 3. In the **Payload** field, add the following JSON payload, substituting your service application ID (client ID) and your Okta org URL:
 
     ```JSON

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
@@ -14,11 +14,11 @@ Use the following high-level steps to test the Risk Provider integration:
 4. [Confirm the response and system log](docs/guides/third-party-risk-integration/test-integration/)
 
 ### Create a client assertion
-This procedure creates a signed JSON Web Token (JWT), which is used as the client assertion value required in the request for a scoped access token (the following step).
+This procedure creates a signed JSON Web Token (JWT), which is used as the client assertion value required in the request for a scoped access token (the following procedure).
 
 1. Navigate to [Generate JWT](https://www.jsonwebtoken.dev/) to create a JWT.
-2. In the **JWK KEY** field, copy the **Public and Private Key pair** generated when creating the service application ([Create a public-private key pair](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair).)
-3. In the **Payload** field, add the following JSON payload substituting your self-service client ID and your Okta org URL:
+2. In the **JWK KEY** field, copy the **Public and Private Key pair** generated when you created the service application ([Create a public-private key pair](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair).)
+3. In the **Payload** field, add the following JSON payload, substituting your service application ID (client ID) and your Okta org URL:
 
     ```JSON
     {
@@ -86,4 +86,4 @@ This procedure reviews the Admin Console's System Log to identify the risk signa
 1. Sign in to your Okta org as an administrator.
 2. From the Admin Console, navigate to the System Log (**Reports** > **System Log**).
 3. Review the log file or search for the event `security.risk.signal.consume`, which is logged when a Risk Provider sends a risk signal to Okta.
-4. With a risk action of `enforce_and_log`, and if a risk-based policy is set up, the third-party Risk Provider signal is used when calculating the authentication risk. This information is logged in the `user.session.start` event.
+4. With a risk action of `enforce_and_log`, and a risk-based policy setup, the third-party Risk Provider signal is used when calculating the authentication risk. This information is logged in the `user.session.start` event.

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
@@ -4,7 +4,7 @@ title: Test the integration
 
 With the creation of a service application for the third-party risk provider, and the update of the third-party risk provider profile, you can now test the integration using the Risk Events API. In this test, the API sends a sample payload risk signal to the Okta org, which can be consumed by Okta and used to calculate the risk of the authentication.
 
->**Note**: Only IP related risk signals are available for consumption by the Okta org.
+>**Note:** Only IP-related risk signals are available for consumption by the Okta org.
 
 Use the following high-level steps to test the Risk Provider integration:
 

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
@@ -2,16 +2,20 @@
 title: Test the integration
 ---
 
-With the creation of a service application for the third-party risk provider, and the update of the third-party risk provider profile, you can now test the integration using the Risk Events API. In this test, the API sends a sample payload risk event to the Okta org, which can be consumed by Okta and used to calculate the risk of the authentication.
+With the creation of a service application for the third-party risk provider, and the update of the third-party risk provider profile, you can now test the integration using the Risk Events API.
+
+In practice, this API is used by the third-party provider to send risk events to an Okta org for risk policy evaluation or the system log. The third-party provider requires access to the public-private key pair and the service application ID (`clientId`) created by the Okta administrator in the [Create service application](docs/guides/third-party-risk-integration/create-service-app/) topic.
+
+In this test, the API sends a sample payload risk event to the Okta org, which can be consumed by Okta and used to calculate the risk of the authentication.
 
 >**Note:** Only IP-related risk events are available for consumption by the Okta org.
 
 Use the following high-level steps to test the risk provider integration:
 
-1. [Create a client assertion for the access token](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair)
-2. [Create an access token](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair)
-3. [Send a risk event to the Okta org](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair)
-4. [Confirm the response and system log](docs/guides/third-party-risk-integration/test-integration/)
+1. [Create a client assertion for the access token](docs/guides/third-party-risk-integration/test-integration/#create-a-client-assertion)
+2. [Create an access token](docs/guides/third-party-risk-integration/test-integration/#create-an-access-token)
+3. [Send a risk event to the Okta org](docs/guides/third-party-risk-integration/test-integration/#send-a-risk-event-to-okta)
+4. [Confirm the response and system log](docs/guides/third-party-risk-integration/test-integration/confirm-the-response)
 
 ### Create a client assertion
 This procedure creates a signed JSON Web Token (JWT), which is used as the client assertion value required in the request for a scoped access token.

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
@@ -1,0 +1,3 @@
+---
+title: Test the integration
+---

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
@@ -4,6 +4,8 @@ title: Test the integration
 
 With the creation of a service application for the third-party risk provider, and the update of the third-party risk provider profile, you can now test the integration using the Risk Events API. In this test, the API sends a sample payload risk signal to the Okta org, which can be consumed by Okta and used to calculate the risk of the authentication.
 
+>**Note**: Only IP related risk signals are available for consumption by the Okta org.
+
 Use the following high-level steps to test the Risk Provider integration:
 
 1. [Create a client assertion for the access token](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair)

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
@@ -4,9 +4,9 @@ title: Test the integration
 
 With the creation of a service application for the third-party risk provider, and the update of the third-party risk provider profile, you can now test the integration using the Risk Events API. In this test, the API sends a sample payload risk signal to the Okta org, which can be consumed by Okta and used to calculate the risk of the authentication.
 
->**Note:** Only IP-related risk signals are available for consumption by the Okta org.
+>**Note:** Only IP-related risk events are available for consumption by the Okta org.
 
-Use the following high-level steps to test the Risk Provider integration:
+Use the following high-level steps to test the risk provider integration:
 
 1. [Create a client assertion for the access token](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair)
 2. [Create an access token](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair)
@@ -14,7 +14,7 @@ Use the following high-level steps to test the Risk Provider integration:
 4. [Confirm the response and system log](docs/guides/third-party-risk-integration/test-integration/)
 
 ### Create a client assertion
-This procedure creates a signed JSON Web Token (JWT), which is used as the client assertion value required in the request for a scoped access token (the following procedure).
+This procedure creates a signed JSON Web Token (JWT), which is used as the client assertion value required in the request for a scoped access token.
 
 1. Navigate to [Generate JWT](https://www.jsonwebtoken.dev/) to create a JWT.
 2. In the **JWK KEY** field, copy the **Public and Private Key pair** generated when you created the service application ([Create a public-private key pair](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair).)
@@ -34,7 +34,7 @@ This procedure creates a signed JSON Web Token (JWT), which is used as the clien
 For further background information on this process, see [Create and sign the JWT](/docs/guides/implement-oauth-for-okta-serviceapp/create-sign-jwt/).
 
 ### Create an access token
-This procedure creates an access token using the `clientAssertion` value required for authentication into the Risk Provider service application.
+This procedure creates an access token using the `clientAssertion` value required for authentication into the risk provider service application.
 
 1. Call the following POST API from the Risk Integration Postman collection: **Partner: API to get the access token** (`{{url}}/oauth2/v1/token`).
 2. Review the response from the call, and copy the `access_token` value to your Postman's `accessToken` environment variable. A sample response follows:
@@ -51,10 +51,10 @@ This procedure creates an access token using the `clientAssertion` value require
 
 For further background information on this process, see [Get an access token](/docs/guides/implement-oauth-for-okta-serviceapp/get-access-token/).
 
-### Send a risk signal to Okta
+### Send a risk event to Okta
 This procedure sends a sample risk signal payload to the Okta org.
 
-1. Call the following POST API from the Risk Integration Postman collection: **Partner: API to send RiskEvents (Auth using access token)** (`{{url}}/api/v1/risk/events/ip`). A sample payload follows, which includes two signals:
+1. Call the following POST API from the Risk Integration Postman collection: **Partner: API to send RiskEvents (Auth using access token)** (`{{url}}/api/v1/risk/events/ip`). A sample payload follows, which includes two events:
 
     ```JSON
     [
@@ -76,7 +76,7 @@ This procedure sends a sample risk signal payload to the Okta org.
     ]
     ```
 
-2. Review the request status of the API call. If the status is `202 Accepted`, the risk signals were consumed by the Okta org.
+2. Review the request status of the API call. If the status is `202 Accepted`, the risk events were consumed by the Okta org.
 
 For reference information on this API, see [Risk Events](/docs/reference/api/risk-events).
 
@@ -85,5 +85,5 @@ This procedure reviews the Admin Console's System Log to identify the risk signa
 
 1. Sign in to your Okta org as an administrator.
 2. From the Admin Console, navigate to the System Log (**Reports** > **System Log**).
-3. Review the log file or search for the event `security.risk.signal.consume`, which is logged when a Risk Provider sends a risk signal to Okta.
-4. With a risk action of `enforce_and_log`, and a risk-based policy setup, the third-party Risk Provider signal is used when calculating the authentication risk. This information is logged in the `user.session.start` event.
+3. Review the log file or search for the event `security.risk.signal.consume`, which is logged when a risk provider sends a risk signal to Okta.
+4. With a risk action of `enforce_and_log`, and a risk-based policy setup, the third-party risk provider signal is used when calculating the authentication risk. This information is logged in the `user.session.start` event.

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
@@ -17,7 +17,7 @@ Use the following high-level steps to test the risk provider integration:
 This procedure creates a signed JSON Web Token (JWT), which is used as the client assertion value required in the request for a scoped access token.
 
 1. Navigate to [Generate JWT](https://www.jsonwebtoken.dev/) to create a JWT.
-2. In the **JWK KEY** field, copy the **Public and Private Key pair** generated when you created the service application ([Create a public-private key pair](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair).)
+2. In the **JWK KEY** field, copy the **Public and Private Keypair** generated when you created the service application ([Create a public-private key pair](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair).)
 3. In the **Payload** field, add the following JSON payload, substituting your service application ID (client ID) and your Okta org URL:
 
     ```JSON

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
@@ -2,7 +2,7 @@
 title: Test the integration
 ---
 
-With the creation of a service application for the third-party risk provider, and the update of the third-party risk provider profile, you can now test the integration using the Risk Events API. In this test, the API sends a sample payload risk signal to the Okta org, which can be consumed by Okta and used to calculate the risk of the authentication.
+With the creation of a service application for the third-party risk provider, and the update of the third-party risk provider profile, you can now test the integration using the Risk Events API. In this test, the API sends a sample payload risk event to the Okta org, which can be consumed by Okta and used to calculate the risk of the authentication.
 
 >**Note:** Only IP-related risk events are available for consumption by the Okta org.
 
@@ -10,7 +10,7 @@ Use the following high-level steps to test the risk provider integration:
 
 1. [Create a client assertion for the access token](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair)
 2. [Create an access token](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair)
-3. [Send a risk signal to the Okta org](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair)
+3. [Send a risk event to the Okta org](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair)
 4. [Confirm the response and system log](docs/guides/third-party-risk-integration/test-integration/)
 
 ### Create a client assertion
@@ -52,9 +52,9 @@ This procedure creates an access token using the `clientAssertion` value require
 For further background information on this process, see [Get an access token](/docs/guides/implement-oauth-for-okta-serviceapp/get-access-token/).
 
 ### Send a risk event to Okta
-This procedure sends a sample risk signal payload to the Okta org.
+This procedure sends a sample risk event payload to the Okta org.
 
-1. Call the following POST API from the Risk Integration Postman collection: **Partner: API to send RiskEvents (Auth using access token)** (`{{url}}/api/v1/risk/events/ip`). A sample payload follows, which includes two events:
+1. Call the following POST API from the Risk Integration Postman collection: **Partner: API to send RiskEvents (Auth using access token)** (`/api/v1/risk/events/ip`). A sample payload follows, which includes two events:
 
     ```JSON
     [
@@ -78,12 +78,14 @@ This procedure sends a sample risk signal payload to the Okta org.
 
 2. Review the request status of the API call. If the status is `202 Accepted`, the risk events were consumed by the Okta org.
 
+> **Note:** Rate limits of three calls per minute, per risk provider, apply to the `/api/v1/risk/events/ip` endpoint. Each call can contain multiple risk events.
+
 For reference information on this API, see [Risk Events](/docs/reference/api/risk-events).
 
 ### Confirm the response
-This procedure reviews the Admin Console's System Log to identify the risk signal information logged after calling the Risk Event API.
+This procedure reviews the Admin Console's System Log to identify the risk event information logged after calling the Risk Event API.
 
 1. Sign in to your Okta org as an administrator.
 2. From the Admin Console, navigate to the System Log (**Reports** > **System Log**).
-3. Review the log file or search for the event `security.risk.signal.consume`, which is logged when a risk provider sends a risk signal to Okta.
-4. With a risk action of `enforce_and_log`, and a risk-based policy setup, the third-party risk provider signal is used when calculating the authentication risk. This information is logged in the `user.session.start` event.
+3. Review the log file or search for the event `security.risk.signal.consume`, which is logged when a risk provider sends a risk event to Okta.
+4. With a risk action of `enforce_and_log`, and a risk-based policy setup, the third-party risk provider event is used when calculating the authentication risk. This information is logged in the `user.session.start` event.

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
@@ -4,7 +4,7 @@ title: Test the integration
 
 With the creation of a service application for the third-party risk provider, and the update of the third-party risk provider profile, you can now test the integration using the Risk Events API.
 
-In practice, this API is used by the third-party provider to send risk events to an Okta org for risk policy evaluation or the system log. The third-party provider requires access to the public-private key pair and the service application ID (`clientId`) created by the Okta administrator in the [Create service application](/docs/guides/third-party-risk-integration/create-service-app/) topic.
+In practice, this API is used by the third-party provider to send risk events to an Okta org for risk policy evaluation or the system log. The third-party provider requires access to the public-private key pair and the service application ID (`clientId`) created by the Okta administrator in the [Create service application](/docs/guides/third-party-risk-integration/create-service-app/) section.
 
 In this test, the API sends a sample payload risk event to the Okta org, which can be consumed by Okta and used to calculate the risk of the authentication.
 

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/test-integration/index.md
@@ -1,3 +1,87 @@
 ---
 title: Test the integration
 ---
+
+With the creation of a service application for the third-party risk provider, and the update of the third-party risk provider profile, you can now test the integration using the Risk Events API. In this test, the API sends a sample payload risk signal to the Okta org, which can be consumed by Okta and used to calculate the risk of the authentication.
+
+Use the following high-level steps to test the Risk Provider integration:
+
+1. [Create a client assertion for the access token](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair)
+2. [Create an access token](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair)
+3. [Send a risk signal to the Okta org](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair)
+4. [Confirm the response and system log](docs/guides/third-party-risk-integration/test-integration/)
+
+### Create a client assertion
+This procedure creates a signed JSON Web Token (JWT), which is used as the client assertion value required in the request for a scoped access token (the following step).
+
+1. Navigate to [Generate JWT](https://www.jsonwebtoken.dev/) to create a JWT.
+2. In the **JWK KEY** field, copy the **Public and Private Key pair** generated when creating the service application ([Create a public-private key pair](docs/guides/third-party-risk-integration/create-service-app/#create-a-public-private-key-pair).)
+3. In the **Payload** field, add the following JSON payload substituting your self-service client ID and your Okta org URL:
+
+    ```JSON
+    {
+    "aud": "https://<url>/oauth2/v1/token",
+    "iss": "<clientId>",
+    "sub": "<clientId>"
+    }
+    ```
+
+4. Click **Generate JWT**.
+5. Copy the resulting JWT value to your Postman's `clientAssertion` environment variable.
+
+For further background information on this process, see [Create and sign the JWT](/docs/guides/implement-oauth-for-okta-serviceapp/create-sign-jwt/).
+
+### Create an access token
+This procedure creates an access token using the `clientAssertion` value required for authentication into the Risk Provider service application.
+
+1. Call the following POST API from the Risk Integration Postman collection: **Partner: API to get the access token** (`{{url}}/oauth2/v1/token`).
+2. Review the response from the call, and copy the `access_token` value to your Postman's `accessToken` environment variable. A sample response follows:
+
+    ```JSON
+    {
+    "token_type": "Bearer",
+    "expires_in": 3600,
+    "access_token": "eyJraWQiOiJPeXd3TmtXSnBuX1ZaQzB4aUZKUlRIRmdvQXJwOXBaSkROZktiZG4wemVBIiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULlYwbHNUVVUxT3RIMlotOWhGcXExSlhteEF5ZXBqWVc0YXVLSnlwTjJiRTgiLCJpc3MiOiJodHRwczovL2R1ZmZpZWxkLm9rdGFwcmV2aWV3LmNvbSIsImF1ZCI6Imh0dHBzOi8vZHVmZmllbGQub2t0YXByZXZpZXcuY29tIiwic3ViIjoiMG9hYWFib3l4c2JyV2RzazgxZDYiLCJpYXQiOjE2MTEzNDcwNDAsImV4cCI6MTYxMTM1MDY0MCwiY2lkIjoiMG9hYWFib3l4c2JyV2RzazgxZDYiLCJzY3AiOlsib2t0YS5yaXNrRXZlbnRzLm1hbmFnZSJdfQ.YUYhkfj-vjW2zEWIfhdcqMMONRVUV81gdia1wf3C2HZ7qMG6u8aGsRpdaMBotHOeno3ECQupf_hcWpUOPJ6OJX1Zdycn6ui7nDcIar6JfSs6VoyOf_e4pNnj2iBPEy9_F4qlk08Z4tBPL9XMMzUnFKL3ZfMTspBNFwpzXAlrj_wzhDS2TrE0O2Z5EAQc1hKmx7cbCOPOmhtbHDjB1OYDiKlK1Z2OlXvHLxhHGDAVQaPf8tMMD8gqQQ3_Lxifi55gCv5h3ZfVyrJtfZK5v3ZrfapK1u1JbvjvJ2fvjUce0Lf2Jl0Gq8nwD0SZZTYdDxcwJny0F1rjq_FDulaBc0JrUw",
+    "scope": "okta.riskEvents.manage"
+    }
+    ```
+    >**Note**: The access token expires in 60 minutes (or the value set in the property `expires_in`).
+
+For further background information on this process, see [Get an access token](/docs/guides/implement-oauth-for-okta-serviceapp/get-access-token/).
+
+### Send a risk signal to Okta
+This procedure sends a sample risk signal payload to the Okta org.
+
+1. Call the following POST API from the Risk Integration Postman collection: **Partner: API to send RiskEvents (Auth using access token)** (`{{url}}/api/v1/risk/events/ip`). A sample payload follows, which includes two signals:
+
+    ```JSON
+    [
+     {
+       "timestamp": "2021-01-20T00:00:00.001Z",
+       "subjects": [
+          {
+            "ip": "6.7.6.7",
+            "riskLevel": "LOW",
+            "message": "none"
+          },
+          {
+            "ip": "1.1.1.1",
+            "riskLevel": "HIGH" ,
+            "message": "Detected Attack tooling and suspicious activity"
+          }
+        ]
+    }
+    ]
+    ```
+
+2. Review the request status of the API call. If the status is `202 Accepted`, the risk signals were consumed by the Okta org.
+
+For reference information on this API, see [Risk Events](/docs/reference/api/risk-events).
+
+### Confirm the response
+This procedure reviews the Admin Console's System Log to identify the risk signal information logged after calling the Risk Event API.
+
+1. Sign in to your Okta org as an administrator.
+2. From the Admin Console, navigate to the System Log (**Reports** > **System Log**).
+3. Review the log file or search for the event `security.risk.signal.consume`, which is logged when a Risk Provider sends a risk signal to Okta.
+4. With a risk action of `enforce_and_log`, and if a risk-based policy is set up, the third-party Risk Provider signal is used when calculating the authentication risk. This information is logged in the `user.session.start` event.

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/update-default-provider/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/update-default-provider/index.md
@@ -2,7 +2,7 @@
 title: Update default third-party risk provider
 ---
 
-The Okta org contains a default risk provider profile, which must be configured for your third-party risk provider by the Okta administrator using the risk provider API. On your Okta org, you can have as many as three third-party risk providers available to send risk events to the Okta Risk Engine.
+The Okta org contains a default risk provider profile, which must be configured for the third-party risk provider by your Okta administrator using the risk provider API. On your Okta org, you can have as many as three third-party risk providers available to send risk events to the Okta Risk Engine.
 
 Each third-party risk provider can also be configured to send three action types to the Okta Risk Engine: `none`, `log_only` (default), and `enforce_and_log`. In this example, the action is set to `enforce_and_log`, which uses the third-party risk event when calculating the risk for a sign-in.
 

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/update-default-provider/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/update-default-provider/index.md
@@ -2,17 +2,17 @@
 title: Update default third-party risk provider
 ---
 
-The Okta org contains a default Risk Provider profile, which must be configured for your third-party risk provider by using the Risk Provider API. On your Okta org, you can have as many as three third-party Risk Providers available to send risk signals to the Okta Risk Engine.
+The Okta org contains a default Risk Provider profile, which must be configured for your third-party Risk Provider by using the Risk Provider API. On your Okta org, you can have as many as three third-party Risk Providers available to send risk signals to the Okta Risk Engine.
 
 Each third-party risk provider can also be configured to send three action types to the Okta Risk Engine: `none`, `log_only` (default), and `enforce_and_log`. In this example, the action is set to `enforce_and_log`, which uses the third-party risk signal when calculating the risk for a sign-in.
 
 For further detail on the Risk Provider API see the following reference documentation: [Risk Provider API](/docs/reference/api/risk-providers).
 
-In this example, follow the following two procedures to set up your third-party Risk Provider:
-- [Retrieve Default Risk Provider](/docs/guides/third-party-risk-integration/update-default-provider/#retrieve-default-risk-provider)
-- [Update the Risk Provider ](/docs/guides/third-party-risk-integration/update-default-provider/#update-risk-provider)
+In this example, use the following two procedures to set up your third-party Risk Provider:
+- [Retrieve the default Risk Provider](/docs/guides/third-party-risk-integration/update-default-provider/#retrieve-the-default-risk-provider)
+- [Update the Risk Provider ](/docs/guides/third-party-risk-integration/update-default-provider/#update-the-risk-provider)
 
-### Retrieve Default Risk Provider
+### Retrieve the default Risk Provider
 This procedure retrieves the default Risk Provider profile and Provider ID.
 
 1. Call the following GET API from the Risk Integration Postman collection: **Admin: API to get all Provider Settings** (`{{url}}/api/v1/risk/providers`).
@@ -41,9 +41,8 @@ This procedure retrieves the default Risk Provider profile and Provider ID.
     ]
     ```
 3. From the response, copy the `id` value, in this example `rkpa9y5jpfe8l4ktr1d6`, to your Postman environment's `providerId` variable.
-4. Copy the name of your third-party Risk Provider to your Postman environment's `providerName` variable. In this example, use `Risk Provider Example`.
 
-### Update Risk Provider
+### Update the Risk Provider
 This procedure updates the default Risk Provider profile with the service application ID, risk Provider name, and the risk provider action.
 
 1. Call the following PUT API from the Risk Integration Postman collection: **Admin: API to Update Provider Settings** (`{{url}}/api/v1/risk/providers/{{providerId}}`), which updates the default Risk Provider's data. This data is included in the request body:

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/update-default-provider/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/update-default-provider/index.md
@@ -2,7 +2,7 @@
 title: Update default third-party risk provider
 ---
 
-The Okta org contains a default risk provider profile, which must be configured for your third-party risk provider by using the risk provider API. On your Okta org, you can have as many as three third-party risk providers available to send risk events to the Okta Risk Engine.
+The Okta org contains a default risk provider profile, which must be configured for your third-party risk provider by the Okta administrator using the risk provider API. On your Okta org, you can have as many as three third-party risk providers available to send risk events to the Okta Risk Engine.
 
 Each third-party risk provider can also be configured to send three action types to the Okta Risk Engine: `none`, `log_only` (default), and `enforce_and_log`. In this example, the action is set to `enforce_and_log`, which uses the third-party risk event when calculating the risk for a sign-in.
 

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/update-default-provider/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/update-default-provider/index.md
@@ -1,14 +1,16 @@
 ---
 title: Update default third-party risk provider
 ---
-what is happening here?
 
+The Okta org contains a default Risk Provider profile, which must be configured for your third-party risk provider by using the Risk Provider API. On your Okta org, you can have as many as three third-party Risk Providers available to send risk signals to the Okta Risk Engine.
 
-The Risk Provider can have only 3 actions: `none`, `log_only` (default), and `enforce_and_log`.
+Each third-party risk provider can also be configured to send three action types to the Okta Risk Engine: `none`, `log_only` (default), and `enforce_and_log`. In this example, the action is set to `enforce_and_log`, which uses the third-party risk signal when calculating the risk for a sign-in.
 
-For further detail on this API see the following reference documentation: [Risk Provider API](/docs/reference/api/risk-providers).
+For further detail on the Risk Provider API see the following reference documentation: [Risk Provider API](/docs/reference/api/risk-providers).
 
-
+In this example, follow the following two procedures to set up your third-party Risk Provider:
+- [Retrieve Default Risk Provider](/docs/guides/third-party-risk-integration/update-default-provider/#retrieve-default-risk-provider)
+- [Update the Risk Provider ](/docs/guides/third-party-risk-integration/update-default-provider/#update-risk-provider)
 
 ### Retrieve Default Risk Provider
 This procedure retrieves the default Risk Provider profile and Provider ID.
@@ -53,6 +55,7 @@ This procedure updates the default Risk Provider profile with the service applic
     "action": "enforce_and_log"
     }
     ```
+
 2. Review the response from the call to make sure the Risk Provider now contains the required data. A sample response follows:
 
     ```JSON

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/update-default-provider/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/update-default-provider/index.md
@@ -15,7 +15,7 @@ This procedure retrieves the default Risk Provider profile and Provider ID.
 
 1. Call the following GET API from the Risk Integration Postman collection: **Admin: API to get all Provider Settings** (`{{url}}/api/v1/risk/providers`).
 
-2. Review the response, which includes the Provider ID, name, and action properties. A sample response follows:
+2. Review the response, which includes the Provider ID, default name, and action properties. A sample response follows:
 
     ```JSON
     [
@@ -39,6 +39,7 @@ This procedure retrieves the default Risk Provider profile and Provider ID.
     ]
     ```
 3. From the response, copy the `id` value, in this example `rkpa9y5jpfe8l4ktr1d6`, to your Postman environment's `providerId` variable.
+4. Copy the name of your third-party Risk Provider to your Postman environment's `providerName` variable. In this example, use `Risk Provider Example`.
 
 ### Update Risk Provider
 This procedure updates the default Risk Provider profile with the service application ID, risk Provider name, and the risk provider action.
@@ -57,7 +58,7 @@ This procedure updates the default Risk Provider profile with the service applic
     ```JSON
     {
     "id": "rkpa9y5jpfe8l4ktr1d6",
-    "name": "Risk Provider Default",
+    "name": "Risk Provider Example",
     "clientId": "0oaaaboyxsbrWdsk81d6",
     "action": "enforce_and_log",
     "_links": {

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/update-default-provider/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/update-default-provider/index.md
@@ -1,0 +1,3 @@
+---
+title: Update default third-party risk provider
+---

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/update-default-provider/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/update-default-provider/index.md
@@ -1,3 +1,77 @@
 ---
 title: Update default third-party risk provider
 ---
+what is happening here?
+
+
+The Risk Provider can have only 3 actions: `none`, `log_only` (default), and `enforce_and_log`.
+
+For further detail on this API see the following reference documentation: [Risk Provider API](/docs/reference/api/risk-providers).
+
+
+
+### Retrieve Default Risk Provider
+This procedure retrieves the default Risk Provider profile and Provider ID.
+
+1. Call the following GET API from the Risk Integration Postman collection: **Admin: API to get all Provider Settings** (`{{url}}/api/v1/risk/providers`).
+
+2. Review the response, which includes the Provider ID, name, and action properties. A sample response follows:
+
+    ```JSON
+    [
+    {
+        "id": "rkpa9y5jpfe8l4ktr1d6",
+        "name": "Default ",
+        "clientId": "null",
+        "action": "log_only",
+        "_links": {
+            "self": {
+                "href": "https://test.oktapreview.com/api/v1/risk/providers/rkpa9y5jpfe8l4ktr1d6",
+                "hints": {
+                    "allow": [
+                        "GET",
+                        "PUT"
+                    ]
+                }
+            }
+        }
+    }
+    ]
+    ```
+3. From the response, copy the `id` value, in this example `rkpa9y5jpfe8l4ktr1d6`, to your Postman environment's `providerId` variable.
+
+### Update Risk Provider
+This procedure updates the default Risk Provider profile with the service application ID, risk Provider name, and the risk provider action.
+
+1. Call the following PUT API from the Risk Integration Postman collection: **Admin: API to Update Provider Settings** (`{{url}}/api/v1/risk/providers/{{providerId}}`), which updates the default Risk Provider's data. This data is included in the request body:
+
+    ```JSON
+    {
+    "name": "{{providerName}}",
+    "clientId": "{{clientId}}",
+    "action": "enforce_and_log"
+    }
+    ```
+2. Review the response from the call to make sure the Risk Provider now contains the required data. A sample response follows:
+
+    ```JSON
+    {
+    "id": "rkpa9y5jpfe8l4ktr1d6",
+    "name": "Risk Provider Default",
+    "clientId": "0oaaaboyxsbrWdsk81d6",
+    "action": "enforce_and_log",
+    "_links": {
+        "self": {
+            "href": "https://test.oktapreview.com/api/v1/risk/providers/rkpa9y5jpfe8l4ktr1d6",
+            "hints": {
+                "allow": [
+                    "GET",
+                    "PUT"
+                ]
+            }
+        }
+        }
+    }
+    ```
+
+<NextSectionLink/>

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/update-default-provider/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/update-default-provider/index.md
@@ -4,7 +4,7 @@ title: Update default third-party risk provider
 
 The Okta org contains a default risk provider profile, which must be configured for your third-party risk provider by using the risk provider API. On your Okta org, you can have as many as three third-party risk providers available to send risk events to the Okta Risk Engine.
 
-Each third-party risk provider can also be configured to send three action types to the Okta Risk Engine: `none`, `log_only` (default), and `enforce_and_log`. In this example, the action is set to `enforce_and_log`, which uses the third-party risk signal when calculating the risk for a sign-in.
+Each third-party risk provider can also be configured to send three action types to the Okta Risk Engine: `none`, `log_only` (default), and `enforce_and_log`. In this example, the action is set to `enforce_and_log`, which uses the third-party risk event when calculating the risk for a sign-in.
 
 For further detail on the Risk Provider API see the following reference documentation: [Risk Provider API](/docs/reference/api/risk-providers).
 

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/update-default-provider/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/update-default-provider/index.md
@@ -2,18 +2,18 @@
 title: Update default third-party risk provider
 ---
 
-The Okta org contains a default Risk Provider profile, which must be configured for your third-party Risk Provider by using the Risk Provider API. On your Okta org, you can have as many as three third-party Risk Providers available to send risk signals to the Okta Risk Engine.
+The Okta org contains a default risk provider profile, which must be configured for your third-party risk provider by using the risk provider API. On your Okta org, you can have as many as three third-party risk providers available to send risk events to the Okta Risk Engine.
 
 Each third-party risk provider can also be configured to send three action types to the Okta Risk Engine: `none`, `log_only` (default), and `enforce_and_log`. In this example, the action is set to `enforce_and_log`, which uses the third-party risk signal when calculating the risk for a sign-in.
 
 For further detail on the Risk Provider API see the following reference documentation: [Risk Provider API](/docs/reference/api/risk-providers).
 
-In this example, use the following two procedures to set up your third-party Risk Provider:
-- [Retrieve the default Risk Provider](/docs/guides/third-party-risk-integration/update-default-provider/#retrieve-the-default-risk-provider)
-- [Update the Risk Provider ](/docs/guides/third-party-risk-integration/update-default-provider/#update-the-risk-provider)
+In this example, use the following two procedures to set up your third-party risk provider:
+- [Retrieve the default risk provider](/docs/guides/third-party-risk-integration/update-default-provider/#retrieve-the-default-risk-provider)
+- [Update the risk provider ](/docs/guides/third-party-risk-integration/update-default-provider/#update-the-risk-provider)
 
-### Retrieve the default Risk Provider
-This procedure retrieves the default Risk Provider profile and Provider ID.
+### Retrieve the default risk provider
+This procedure retrieves the default risk provider profile and Provider ID.
 
 1. Call the following GET API from the Risk Integration Postman collection: **Admin: API to get all Provider Settings** (`{{url}}/api/v1/risk/providers`).
 
@@ -42,10 +42,10 @@ This procedure retrieves the default Risk Provider profile and Provider ID.
     ```
 3. From the response, copy the `id` value, in this example `rkpa9y5jpfe8l4ktr1d6`, to your Postman environment's `providerId` variable.
 
-### Update the Risk Provider
-This procedure updates the default Risk Provider profile with the service application ID, risk Provider name, and the risk provider action.
+### Update the risk provider
+This procedure updates the default risk provider profile with the service application ID, risk provider name, and the risk provider action.
 
-1. Call the following PUT API from the Risk Integration Postman collection: **Admin: API to Update Provider Settings** (`{{url}}/api/v1/risk/providers/{{providerId}}`), which updates the default Risk Provider's data. This data is included in the request body:
+1. Call the following PUT API from the Risk Integration Postman collection: **Admin: API to Update Provider Settings** (`{{url}}/api/v1/risk/providers/{{providerId}}`), which updates the default risk provider's data. This data is included in the request body:
 
     ```JSON
     {
@@ -55,7 +55,7 @@ This procedure updates the default Risk Provider profile with the service applic
     }
     ```
 
-2. Review the response from the call to make sure the Risk Provider now contains the required data. A sample response follows:
+2. Review the response from the call to make sure the risk provider now contains the required data. A sample response follows:
 
     ```JSON
     {


### PR DESCRIPTION
## Description:
- **What's changed?** New Beta documentation to support Third-Party Risk Integration with Okta. References two new Risk APIs

- **Is this PR related to a Monolith release?** Yes, 2021.02.0

### Resolves:

* [OKTA-345711](https://oktainc.atlassian.net/browse/OKTA-345723)
