### PR TITLE
Fixing sitemap link 

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/config.js
+++ b/packages/@okta/vuepress-site/.vuepress/config.js
@@ -326,14 +326,14 @@ module.exports = {
   plugins: {
     'sitemap': {
       hostname: 'https://developer.okta.com',
-      outFile: 'sitemap.xml',
+      outFile: 'docs-sitemap.xml',
       exclude: [
         '/test_page/'
       ]
-    },
+    }, 
     'robots': {
       host: 'https://developer.okta.com',
-      sitemap: '/sitemap.xml',
+      sitemap: '/docs-sitemap.xml',
       policies: [
         {
           userAgent: '*',

--- a/packages/@okta/vuepress-site/.vuepress/config.js
+++ b/packages/@okta/vuepress-site/.vuepress/config.js
@@ -333,7 +333,7 @@ module.exports = {
     },
     'robots': {
       host: 'https://developer.okta.com',
-      sitemap: '/docs-sitemap.xml',
+      sitemap: '/sitemap_index.xml',
       policies: [
         {
           userAgent: '*',

--- a/packages/@okta/vuepress-site/.vuepress/config.js
+++ b/packages/@okta/vuepress-site/.vuepress/config.js
@@ -330,7 +330,7 @@ module.exports = {
       exclude: [
         '/test_page/'
       ]
-    }, 
+    },
     'robots': {
       host: 'https://developer.okta.com',
       sitemap: '/docs-sitemap.xml',

--- a/packages/@okta/vuepress-site/.vuepress/config.js
+++ b/packages/@okta/vuepress-site/.vuepress/config.js
@@ -326,14 +326,14 @@ module.exports = {
   plugins: {
     'sitemap': {
       hostname: 'https://developer.okta.com',
-      outFile: 'docs-sitemap.xml',
+      outFile: 'sitemap.xml',
       exclude: [
         '/test_page/'
       ]
     },
     'robots': {
       host: 'https://developer.okta.com',
-      sitemap: '/docs-sitemap.xml',
+      sitemap: '/sitemap.xml',
       policies: [
         {
           userAgent: '*',

--- a/packages/@okta/vuepress-site/.vuepress/public/sitemap_index.xml
+++ b/packages/@okta/vuepress-site/.vuepress/public/sitemap_index.xml
@@ -1,0 +1,10 @@
+
+<?xml version="1.0" encoding="UTF-8"?>
+   <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+   <sitemap>
+      <loc>https://developer.okta.com/sitemap.xml</loc>
+   </sitemap>
+   <sitemap>
+      <loc>https://developer.okta.com/docs-sitemap.xml</loc>
+   </sitemap>
+</sitemapindex>

--- a/packages/@okta/vuepress-site/.vuepress/public/sitemap_index.xml
+++ b/packages/@okta/vuepress-site/.vuepress/public/sitemap_index.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
    <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
    <sitemap>

--- a/packages/@okta/vuepress-site/.vuepress/scripts/strip-guide-parts-from-sitemap.js
+++ b/packages/@okta/vuepress-site/.vuepress/scripts/strip-guide-parts-from-sitemap.js
@@ -11,7 +11,7 @@ function isValidUrl(url) {
 };
 
 
-const sitemapFilename = path.join('dist','sitemap.xml');
+const sitemapFilename = path.join('dist','docs-sitemap.xml');
 const rawXml = fs.readFileSync( sitemapFilename, 'utf-8');
 
 parser(rawXml)

--- a/packages/@okta/vuepress-site/.vuepress/scripts/strip-guide-parts-from-sitemap.js
+++ b/packages/@okta/vuepress-site/.vuepress/scripts/strip-guide-parts-from-sitemap.js
@@ -11,7 +11,7 @@ function isValidUrl(url) {
 };
 
 
-const sitemapFilename = path.join('dist','docs-sitemap.xml');
+const sitemapFilename = path.join('dist','sitemap.xml');
 const rawXml = fs.readFileSync( sitemapFilename, 'utf-8');
 
 parser(rawXml)


### PR DESCRIPTION
## Description:
- **What's changed?** 
> Fixing the sitemap link. Previously we were displaying the sitemap under the 'docs-sitemap' alias.

- **Is this PR related to a Monolith release?**
> No

### Resolves:

* [OKTA-362166](https://oktainc.atlassian.net/browse/OKTA-362166)

**Netlify Build

https://6016f373b01495f73debdbe0--reverent-murdock-829d24.netlify.app/sitemap.xml