### PR TITLE
URL encode request parameter

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/users/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/users/index.md
@@ -927,7 +927,7 @@ curl -v -X GET \
 -H "Accept: application/json" \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
-"https://${yourOktaDomain}/api/v1/users/isaac.brock@example.com"
+"https://${yourOktaDomain}/api/v1/users/isaac.brock%40example.com"
 ```
 
 ##### Response Example


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- The docs say when fetching a user by login, you must URL encode the request parameter. The request example shows the parameter NOT URL encoded. A customer reached out to Dev Support and was confused by this.

### Resolves:

N/A