### PR TITLE
OKTA-368631 - Updated beta flags to false so missing Event Types display

### DIFF
--- a/packages/@okta/vuepress-site/data/event-types.json
+++ b/packages/@okta/vuepress-site/data/event-types.json
@@ -17416,7 +17416,7 @@
         "created" : "2020-09-17",
         "release" : "2020.09.4"
       },
-      "beta" : true,
+      "beta" : false,
       "tags" : [ "event-hook-eligible", "mfa" ],
       "mappings" : [ ],
       "schema" : {
@@ -17432,7 +17432,7 @@
         "created" : "2020-09-17",
         "release" : "2020.09.4"
       },
-      "beta" : true,
+      "beta" : false,
       "tags" : [ "event-hook-eligible", "mfa" ],
       "mappings" : [ ],
       "schema" : {


### PR DESCRIPTION
## Description:
- **What's changed?** Updated the beta flags to false in `event-types.json` to display `user.mfa.factor.suspend` and `user.mfa.factor.unsuspend`

- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-368631](https://oktainc.atlassian.net/browse/OKTA-368631)
