### PR TITLE
Update 'Sign Users In' guide to @okta/okta-vue@3.x

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/add-signin-button/vue/login-redirect.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/add-signin-button/vue/login-redirect.md
@@ -23,11 +23,11 @@ export default {
   name: 'home',
   methods: {
     login () {
-      this.$auth.loginRedirect(PATH_TO_PROTECTED_ROUTE)
+      this.$auth.signInWithRedirect({ originalUri: PATH_TO_PROTECTED_ROUTE })
     },
   }
 }
 </script>
 ```
 
-The `loginRedirect()` method lets you specify the path to send the user to after the authentication callback.
+The `signInWithRedirect()` method lets you specify the path to send the user to after the authentication callback.

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/configure-the-sdk/vue/config.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/configure-the-sdk/vue/config.md
@@ -1,23 +1,23 @@
-First, pass the configuration to the Auth handler from the `okta-vue` package.  Use the `router.beforeEach()` call to instruct Vue to check the authorization permissions before rendering a route.
+First, create an [OktaAuth](https://github.com/okta/okta-auth-js) object with your configuration and pass it to the `okta-vue` plugin. You need to use `okta-vue` plugin after `vue-router`.
 
 ```javascript
 // router/index.js
 
 import Vue from 'vue'
-import Auth from '@okta/okta-vue'
+import OktaVue from '@okta/okta-vue'
+import { OktaAuth } from '@okta/okta-auth-js'
 import Router from 'vue-router'
 
-const config = { 
+Vue.use(Router)
+
+const config = {
   // Configuration here
 }
-
-Vue.use(Auth, {...config})
+const oktaAuth = new OktaAuth(config)
 
 // router configuration from previous section here
 
-router.beforeEach(Vue.prototype.$auth.authRedirectGuard()) // Add this
-
-Vue.use(Router)
+Vue.use(OktaVue, { oktaAuth })
 
 export default router
 ```

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/define-callback/vue/define-route.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/define-callback/vue/define-route.md
@@ -24,7 +24,5 @@ const router = new Router({
 
 Vue.use(Router)
 
-router.beforeEach(Vue.prototype.$auth.authRedirectGuard())
-
 export default router
 ```

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/handle-callback/vue/handle-callback.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/handle-callback/vue/handle-callback.md
@@ -1,28 +1,30 @@
-The `handleCallback()` function of the Vue SDK Auth object handles the logic to parse the response that Okta sends back to your application. All you need to do is wire it up to the route you defined:
+The `LoginCallback` component of the Vue SDK Auth object handles the logic to parse the response that Okta sends back to your application. All you need to do is wire it up to the route you defined:
 
 ```javascript
+// router/index.js
+
 import Vue from 'vue'
 import Router from 'vue-router'
-import Auth from '@okta/okta-vue'
+import OktaVue, { LoginCallback } from '@okta/okta-vue'
+import { OktaAuth } from '@okta/okta-auth-js'
+
+Vue.use(Router)
 
 const config = {
   // Configuration here
 }
-
-Vue.use(Auth, {...config})
+const oktaAuth = new OktaAuth(config)
 
 const CALLBACK_PATH = '/login/callback'
 
 const router = new Router({
   mode: 'history',
   routes: [
-    { path: CALLBACK_PATH, component: Auth.handleCallback() },
+    { path: CALLBACK_PATH, component: LoginCallback },
   ]
 })
 
-Vue.use(Router)
-
-router.beforeEach(Vue.prototype.$auth.authRedirectGuard())
+Vue.use(OktaVue, { oktaAuth })
 
 export default router
 ```

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/install-sdk/vue/installsdk.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/install-sdk/vue/installsdk.md
@@ -3,3 +3,9 @@ The Vue SDK is hosted on npm as [@okta/okta-vue](https://www.npmjs.com/package/@
 ```
 npm install @okta/okta-vue
 ```
+
+You will also need the Auth SDK hosted on npm as [@okta/okta-auth-js](https://www.npmjs.com/package/@okta/okta-auth-js).
+
+```
+npm install @okta/okta-auth-js
+```

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/require-authentication/vue/reqauthspecific.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/require-authentication/vue/reqauthspecific.md
@@ -3,28 +3,28 @@ Set the `requiresAuth` property to `true` in the optional `meta` object as part 
 ```javascript
 import Vue from 'vue'
 import Router from 'vue-router'
-import Auth from '@okta/okta-vue'
+import OktaVue, { LoginCallback } from '@okta/okta-vue'
+import { OktaAuth } from '@okta/okta-auth-js'
 import Private from '@/components/Private' // Some component you define
+
+Vue.use(Router)
 
 const config = {
   // Configuration here
 }
-
-Vue.use(Auth, {...config})
+const oktaAuth = new OktaAuth(config)
 
 const CALLBACK_PATH = '/login/callback'
 
 const router = new Router({
   mode: 'history',
   routes: [
-    { path: CALLBACK_PATH, component: Auth.handleCallback() },
+    { path: CALLBACK_PATH, component: LoginCallback },
     { path: '/private', component: Private, meta: { requiresAuth: true } },
   ]
 })
 
-Vue.use(Router)
-
-router.beforeEach(Vue.prototype.$auth.authRedirectGuard())
+Vue.use(OktaVue, { oktaAuth })
 
 export default router
 ```


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
Updated guide [Sign users in to your SPA](https://developer.okta.com/docs/guides/sign-into-spa/vue/define-callback/) to `@okta/okta-vue@3.x`
Affected pages:
https://developer.okta.com/docs/guides/sign-into-spa/vue/define-callback/
https://developer.okta.com/docs/guides/sign-into-spa/vue/configure-the-sdk/
https://developer.okta.com/docs/guides/sign-into-spa/vue/add-signin-button/
https://developer.okta.com/docs/guides/sign-into-spa/vue/handle-callback/
https://developer.okta.com/docs/guides/sign-into-spa/vue/require-authentication/
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->
No

### Resolves:

* [OKTA-358830](https://oktainc.atlassian.net/browse/OKTA-358830)
