### PR TITLE
add /login/sessionCookieRedirect to dynamic scale and workforce license rate limit page

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/rl-additional-limits/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/rl-additional-limits/index.md
@@ -119,6 +119,7 @@ Workforce orgs that are created after January 7, 2021 have increased default rat
 * `/api/v1/sessions`
 * `/login/login.htm`
 * `/login/sso_iwa_auth`
+* `/login/sessionCookieRedirect`
 * `/api/{apiVersion}/radius`
 
 [Authorization](/docs/reference/rl-global-enduser/)

--- a/packages/@okta/vuepress-site/docs/reference/rl-dynamic-scale/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/rl-dynamic-scale/index.md
@@ -15,6 +15,7 @@ If your needs exceed Okta's default rate limits for the base product subscriptio
 * `/api/v1/authn/factors/{factorIdOrFactorType}/verify`
 * `/api/v1/sessions`
 * `/login/login.htm`
+* `/login/sessionCookieRedirect`
 
 **OAuth2 endpoints:**
 


### PR DESCRIPTION
## Description:
- **What's changed?** add `/login/sessionCookieRedirect` to dynamic scale and workforce license rate limit page 
- **Is this PR related to a Monolith release?**  Yes. 2021.02.2

<img width="1108" alt="Screen Shot 2021-02-16 at 5 10 28 PM" src="https://user-images.githubusercontent.com/50559663/108142058-e0cfca80-7079-11eb-897f-483f95aa0b4e.png">
<img width="764" alt="Screen Shot 2021-02-16 at 5 10 56 PM" src="https://user-images.githubusercontent.com/50559663/108142101-f0e7aa00-7079-11eb-9824-13017578bdc9.png">


### Resolves:

* [OKTA-370588](https://oktainc.atlassian.net/browse/OKTA-370588)
