### PR TITLE
OKTA-371941: Performs event type filtering to only include documented event types.

### DIFF
--- a/packages/@okta/vuepress-theme-prose/global-components/EventTypes.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/EventTypes.vue
@@ -39,7 +39,9 @@
       SmartLink: () => import("../components/SmartLink"),
     },
     created() {
-      this.eventTypes = eventTypes.versions[1].eventTypes.filter(eventType => !eventType.beta)
+      this.eventTypes = eventTypes.versions
+        .find(version => version.version == "V2").eventTypes
+        .filter(eventType => !eventType.beta && !eventType.internal)
       this.releases = _.chain(this.eventTypes)
         .map(eventType => eventType.info)
         .map(info => info.release)


### PR DESCRIPTION
## Description:
- **What's changed?** OKTA-371941: Performs event type filtering to only include documented event types.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-371941](https://oktainc.atlassian.net/browse/OKTA-371941)

### Testing

![image](https://user-images.githubusercontent.com/25536705/108727729-e0f71c80-74f6-11eb-89a7-04f35a193de9.png)
![image](https://user-images.githubusercontent.com/25536705/108727817-f3715600-74f6-11eb-8e98-04ba4b12ecc3.png)
