### PR TITLE
Updating the deployment checklist for email pain point

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/production-deployment/deployment-checklist/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/production-deployment/deployment-checklist/index.md
@@ -28,6 +28,7 @@ Ensure your application fits your brand:
 
 ### User authorization and registration
 
+* [Migrate your users in bulk](/docs/guides/migrate-to-okta/bulk-migration-with-credentials/): Use the Okta API to bulk create your users with or without credentials. Make sure to sign into the Admin Console, and check out your settings for Security/General/Security Notification Emails, to configure whether or not you want your newly imported users to receive notification emails.
 * [Configure Multi-Factor Authentication (MFA)](/docs/guides/mfa/ga/set-up-org/): Set up which security factors are used when users sign in.
 * [Set up Self-Service Registration](/docs/guides/set-up-self-service-registration/): Allow users to sign up for an account with an email address.
 * [Enable Social Authentication](/docs/guides/add-an-external-idp/): Allow your users to sign in with their other services.


### PR DESCRIPTION
## Description:
Added a bullet point calling out bulk user migration as a step for the deployment checklist, and added a blurb to ask user to check their email notification settings.

### Resolves:

This was a request from product leadership (Grace W and Arnab):
1. Today, MFA reset emails are set to on by default. 
2. Recently, major customers (Cisco, Pinterest) have run into issues with MFA reset emails being sent to millions of customers as part of an internal migration process and are asking that these be turned off by default. These are generally CIAM use cases. 
3. However, from a workforce use case perspective, there is benefit and value to having these turned on by default as this helps drive education and adoption and 77% of our customers leave this on.

The decision is we will turn off email notifications by default, but it's important regardless of the default on or off, that we should update the docs in case a customer developer does not know that step is worth checking prior to bulk migrating users.
