### PR TITLE
Add CORS Support Icon for /token

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/oidc/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oidc/index.md
@@ -256,7 +256,7 @@ https://www.example.com/#error=invalid_scope&error_description=The+requested+sco
 
 ### /token
 
-<ApiOperation method="post" url="${baseUrl}/v1/token" />
+<ApiOperation method="post" url="${baseUrl}/v1/token" /> <SupportsCors />
 
 This endpoint returns access tokens, ID tokens, and refresh tokens, depending on the request parameters. For [password](/docs/guides/implement-password/), [client credentials](/docs/guides/implement-client-creds/), and [refresh token](/docs/guides/refresh-tokens/) flows, calling `/token` is the only step of the flow. For the [authorization code](/docs/guides/implement-auth-code/) flow, calling `/token` is the second step of the flow.
 


### PR DESCRIPTION
/token is CORS enabled as of 2019 for flows like PKCE. Unless there is something special/different about this endpoint as it relates to CORS, I think we should add the icon for consistency's sake.

<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
