### PR TITLE
OKTA-369713  Update doc to reflect new increases policy v2 limit

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policy-types/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policy-types/index.md
@@ -13,7 +13,7 @@ The Identity Engine Early Adopter Program (EAP) contains many updates to Okta's 
 
 ## Limitations
 
-Okta limits the number of Policies of the new types to 5000 total for Policy type: `Okta:SignOn` and 500 total for Policy type: `Okta:ProfileEnrollment`. Each of those Policies can in turn have a maximum of 100 associated Rules.
+Okta limits the number of Policies of the new types to 5000 total the `Okta:SignOn` Policy type and 500 total for `Okta:ProfileEnrollment` Policy type. Each of those Policies can in turn have a maximum of 100 associated Rules.
 
 ## Policy Operations
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oie-policy-types/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oie-policy-types/index.md
@@ -13,7 +13,7 @@ The Identity Engine Early Adopter Program (EAP) contains many updates to Okta's 
 
 ## Limitations
 
-Okta limits the number of Policies of the new types to 500 total. Each of those Policies can in turn have a maximum of 100 associated Rules.
+Okta limits the number of Policies of the new types to 5000 total for Policy type: `Okta:SignOn` and 500 total for Policy type: `Okta:ProfileEnrollment`. Each of those Policies can in turn have a maximum of 100 associated Rules.
 
 ## Policy Operations
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** 
Earlier all V2 policy types has a limit of 500 total for all policy types. This limit has been revised as,

per org to 5000 for App Sign On policy
and 500 for Profile Enrollment policy.

This information is being updated on developer docs.

- **Is this PR related to a Monolith release?** 
- No

### Resolves:

* [OKTA-369713](https://oktainc.atlassian.net/browse/OKTA-369713)
