### PR TITLE
Clarify behavior when no response is received by the registration hook

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -161,7 +161,7 @@ In the case of the Registration Inline Hook, the `error` object provides a way o
 
 If you do not return any value for that `errorCauses` object, but deny the user's registration attempt via the `commands` object in your response to Okta, the following generic message is displayed to the end user: "Registration cannot be completed at this time".
 
-> **Note:** If you include an error object in your response, no commands will be executed and the registration will fail. This holds true even if the top-level `errorSummary` and the `errorCauses` objects are omitted.
+> **Note:** If you include an error object in your response, or if the request times out without a response, no commands will be executed and the registration will fail. This holds true even if the top-level `errorSummary` and the `errorCauses` objects are omitted.
 
 ## Sample JSON Payload of Request
 


### PR DESCRIPTION
## Description:
- **What's changed?** 
The previous docs left it ambiguous what happened if no response was returned. I think this makes it clearer.
- **Is this PR related to a Monolith release?**
No
