### PR TITLE
Update configmid.md

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/configure-packages/aspnetcore3/configmid.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/configure-packages/aspnetcore3/configmid.md
@@ -1,4 +1,11 @@
-Open your `Startup` class and modify the `ConfigureServices` method to include the Okta middleware configuration. Replace the placeholders with your Okta configuration:
+
+Open your `Startup` class and update your `using` statements to import `Okta.AspNetCore` and other required namespaces:
+
+```csharp
+using Okta.AspNetCore;
+```
+
+Modify the `ConfigureServices` method to include the Okta middleware configuration. Replace the placeholders with your Okta configuration:
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
@@ -14,7 +21,7 @@ public void ConfigureServices(IServiceCollection services)
     .AddOktaMvc(new OktaMvcOptions
     {
         // Replace these values with your Okta configuration
-        OktaDomain = "https://${yourOktaDomain}",
+        OktaDomain = "https://{yourOktaDomain}",
         ClientId = "{clientId}",
         ClientSecret = "{clientSecret}"
     });
@@ -32,7 +39,7 @@ public void ConfigureServices(IServiceCollection services)
     .AddOktaMvc(new OktaMvcOptions
     {
         // Replace these values with your Okta configuration
-        OktaDomain = "https://${yourOktaDomain}",
+        OktaDomain = "https://{yourOktaDomain}",
         ClientId = "{clientId}",
         ClientSecret = "{clientSecret}",
         AuthorizationServerId = "",
@@ -40,7 +47,7 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
-Modify the `Configure` method to include the `app.UseAuthentication()` and `app.UseAuthorization()` lines:
+Finally, modify the `Configure` method to include the `app.UseAuthentication()` and `app.UseAuthorization()` lines:
 
 ```csharp
 public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
@@ -57,12 +64,6 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
             pattern: "{controller=Home}/{action=Index}/{id?}");
     });
 }
-```
-
-Finally, update your `using` statements to import `Okta.AspNetCore` and other required namespaces:
-
-```csharp
-using Okta.AspNetCore;
 ```
 
 The `OktaMvcOptions` class configures the Okta middleware. You can see all of the available options in the **Configuration Reference** section in the [ASP.NET Core SDK readme](https://github.com/okta/okta-aspnet/blob/master/docs/aspnetcore-mvc.md#configuration-reference).


### PR DESCRIPTION
Update documentation on configuring the Okta.AspNetCore package.

## Description:
- **What's changed?**
Update documentation on configuring the Okta.AspNetCore package to start off by adding the ```using``` statement as the first step.  This will provide a better user experience to people going through the steps as it will enable IntelliSense if supported by their IDE.
Also removed the $ symbol in the statements setting the OktaDomain property of OktaMvcOptions.

- **Is this PR related to a Monolith release?**
No