### PR TITLE
Include "matches" operator in Conditional Expressions section of Expression Language reference

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
@@ -277,7 +277,7 @@ The format for conditional expressions is
 * The `OR` operator
 * The `!` operator to designate NOT
 * Standard relational operators including <code>&lt;</code>, <code>&gt;</code>, <code>&lt;=</code>, and <code>&gt;=</code>.
-* The `matches` operator to evaluate a string against a regular expression.
+* The `matches` operator to evaluate a String against a regular expression.
 
 **Note:** Use the double equals sign `==` to check for equality and `!=` for inequality.
 

--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
@@ -267,7 +267,7 @@ The format for conditional expressions is
 
 * Expressions must have valid syntax.
 * Expressions must evaluate to Boolean.
-* Expressions cannot contain an assignment operator, such as =.
+* Expressions cannot contain an assignment operator, such as `=`.
 * User attributes used in expressions can contain only available User or AppUser attributes.
 
 <br>The following functions are supported in conditions.
@@ -277,6 +277,7 @@ The format for conditional expressions is
 * The `OR` operator
 * The `!` operator to designate NOT
 * Standard relational operators including <code>&lt;</code>, <code>&gt;</code>, <code>&lt;=</code>, and <code>&gt;=</code>.
+* The `matches` operator to evaluate a string against a regular expression.
 
 **Note:** Use the double equals sign `==` to check for equality and `!=` for inequality.
 


### PR DESCRIPTION
## Description:
- **What's changed?**
Include a statement noting that the `matches` operator is available to evaluate regular expressions in Conditional Expressions section.
Add missing formatting around `=` operator.

- **Is this PR related to a Monolith release?**
No