### PR TITLE
Remove redundant redirect_uri from example

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/implement-auth-code/use-flow/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-auth-code/use-flow/index.md
@@ -6,7 +6,7 @@ To get an authorization code, your app redirects the user to your [Authorization
 
 ```
 https://${yourOktaDomain}/oauth2/default/v1/authorize?client_id=0oabucvy
-c38HLL1ef0h7&response_type=code&scope=openid&redirect_uri=&redirect_uri=https%3A%2F%2Fexample.com&state=state-296bc9a0-a2a2-4a57-be1a-d0e2fd9bb601'
+c38HLL1ef0h7&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fexample.com&state=state-296bc9a0-a2a2-4a57-be1a-d0e2fd9bb601'
 ```
 
 Note the parameters that are being passed:


### PR DESCRIPTION
Remove extra empty `redirect_uri` query parameter from example authorize URL
