### PR TITLE
Updating config.js by adding root Risk Integration guide url to the d…

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/config.js
+++ b/packages/@okta/vuepress-site/.vuepress/config.js
@@ -317,7 +317,8 @@ module.exports = {
               '/docs/guides/sign-into-web-app-remediation/get-tokens/',
               '/docs/guides/sign-into-web-app-remediation/next-steps/',
               '/docs/reference/api/authenticators-admin/',
-              '/docs/guides/third-party-risk-integration/overview/', //Beta release of Risk APIs and Guide
+              '/docs/guides/third-party-risk-integration/', //Beta release of Risk APIs and Guide
+              '/docs/guides/third-party-risk-integration/overview/',
               '/docs/guides/third-party-risk-integration/create-service-app/',
               '/docs/guides/third-party-risk-integration/update-default-provider/',
               '/docs/guides/third-party-risk-integration/test-integration/',


### PR DESCRIPTION
## Description:
- **What's changed?** Updating the .vuepress/config.js file to include the root URL for the beta Risk Integration Guide in the "disallow" list (excludes guide from Google search)
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-369005](https://oktainc.atlassian.net/browse/OKTA-369005)
