### PR TITLE
Update SAML instructions for dynamic SSO URLs

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/submit-app/submission2-specific/saml2/submit.md
+++ b/packages/@okta/vuepress-site/docs/guides/submit-app/submission2-specific/saml2/submit.md
@@ -6,9 +6,9 @@
 
 * **To configure SAML, can your customers do it by themselves from your app's UI, or do they need to contact your support team?** &mdash; If a customer needs support to configure your app integration, you need to include support contact information in your configuration guide. We recommend that you build a UI that enables self-service configuration to reduce the setup time for your customers.
 
-* **Are tenants deployed on-premises?** &mdash; If tenant data for you application is hosted locally on your customer's systems, select **Yes**. If the tenant data for your application is hosted on your servers, select **No**.
+* **Are tenants deployed on-premises?** &mdash; If tenant data for your application is hosted locally on your customer's systems, select **Yes**. If the tenant data for your application is hosted on your servers, select **No**.
 
-* **Is your app capable of requesting other SSO URLs?** &mdash; Select this option to configure support for multiple ACS URLs where the SAML Response can be sent. Specify an index or URL to uniquely identify each ACS URL endpoint. If an **AuthnRequest** message does not specify an index or URL, the SAML Response is sent to the default ACS URL specified above. Enter the SSO URLs and an index value for any other nodes.
+* **Is your app capable of requesting other SSO URLs?** &mdash; Select this option to configure support for multiple ACS URLs where the SAML Response can be sent. Specify an index or URL to uniquely identify each ACS URL endpoint. If an **AuthnRequest** message does not specify an index or URL, the SAML Response is sent to the default ACS URL specified above. If **Yes**, enter the SSO URLs and an index value for any other nodes. You can specify variables in the SSO URL field to construct non-static URLs. For example, https://`${app.variableName}`.okta.com`.
 
 * **What is the unique SAML identifier for authentication: the subject NameID or a specific SAML attribute?** &mdash; What identifier is used by the integration to perform authentication against your SAML application? If you are using an attribute different than the `NameID` attribute, what is the name of that attribute?
 

--- a/packages/@okta/vuepress-site/docs/guides/submit-app/submission2-specific/saml2/submit.md
+++ b/packages/@okta/vuepress-site/docs/guides/submit-app/submission2-specific/saml2/submit.md
@@ -8,7 +8,7 @@
 
 * **Are tenants deployed on-premises?** &mdash; If tenant data for your application is hosted locally on your customer's systems, select **Yes**. If the tenant data for your application is hosted on your servers, select **No**.
 
-* **Is your app capable of requesting other SSO URLs?** &mdash; Select this option to configure support for multiple ACS URLs where the SAML Response can be sent. Specify an index or URL to uniquely identify each ACS URL endpoint. If an **AuthnRequest** message does not specify an index or URL, the SAML Response is sent to the default ACS URL specified above. If **Yes**, enter the SSO URLs and an index value for any other nodes. You can specify variables in the SSO URL field to construct non-static URLs. For example, https://`${app.variableName}`.okta.com`.
+* **Is your app capable of requesting other SSO URLs?** &mdash; Select this option to configure support for multiple ACS URLs where the SAML Response can be sent. If **Yes**, specify an index or URL to identify each ACS URL endpoint. If an **AuthnRequest** message does not specify an index or URL, the SAML Response is sent to the default ACS URL specified above. Enter the SSO URLs and an index value for any other nodes. You can specify variables in the SSO URL field to construct non-static URLs, for example, `https://${app.variableName}.okta.com`.
 
 * **What is the unique SAML identifier for authentication: the subject NameID or a specific SAML attribute?** &mdash; What identifier is used by the integration to perform authentication against your SAML application? If you are using an attribute different than the `NameID` attribute, what is the name of that attribute?
 
@@ -29,8 +29,8 @@
   * **Construct your dynamic ACS URL by copying the variables above and pasting them where applicable** &mdash; Provide your complete Assertion Consumer Service (ACS) URL endpoint where Okta posts SAML responses for your app integration.
   
     If you're using a per tenant design, include the variable names that you created. For example:
-    * https://`${app.variableName}`.okta.com
-    * https://okta-`${app.variableName}`.com
+    * `https://${app.variableName}.okta.com`
+    * `https://okta-${app.variableName}.com`
 
   * **Construct your dynamic Audience URI by copying the variables above and pasting them where applicable** &mdash; Provide your complete Audience URI. This field, which dictates the audience the SAML Assertion is intended for, can be any data string up to 1024 characters long.
 


### PR DESCRIPTION
## Description:
- **What's changed?** 
Added instruction that SSO URL fields can now accept non-static URL values.
Fixed typo.
- **Is this PR related to a Monolith release?** 
Yes. 2021.04.0

### Resolves:

* [OKTA-380611](https://oktainc.atlassian.net/browse/OKTA-380611)
