### PR TITLE
Updated okta-react code demo

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/add-signin-button/react/login-redirect.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/add-signin-button/react/login-redirect.md
@@ -1,16 +1,16 @@
 Implementing a login button requires that you know IF you should show the button as well as how to implement the button.
 
 The `okta-react` SDK provides you with:
-- an [authState](https://github.com/okta/okta-react#authstate) object that provides information on the state of the current user's authentication
-- an [authService](https://github.com/okta/okta-react#authservice) object that provides methods to read more details about, or to modify, the current authentication
+- an [authState](https://github.com/okta/okta-auth-js#authstatemanager) object that provides information on the state of the current user's authentication
+- an [oktaAuth](https://github.com/okta/okta-auth-js) object that provides methods to read more details about, or to modify, the current authentication
 
-Function-based components can use the `useOktaAuth` [React hook](https://reactjs.org/docs/hooks-intro.html) to access the `authService` or the `authState` objects.
+Function-based components can use the `useOktaAuth` [React hook](https://reactjs.org/docs/hooks-intro.html) to access the `oktaAuth` or the `authState` objects.
 
-Class-based components can use the `withOktaAuth` [higher-order component](https://reactjs.org/docs/higher-order-components.html) to receive the `authService` and `authState` objects as props.
+Class-based components can use the `withOktaAuth` [higher-order component](https://reactjs.org/docs/higher-order-components.html) to receive the `oktaAuth` and `authState` objects as props.
 
 You can use the `authState.isAuthenticated` property to show or hide a button depending on whether the user is signed in.
 
-The `authService.login()` method lets you specify the path you'd like the user to be navigated to after authenticating.
+The `oktaAuth.signInWithRedirect()` method lets you specify the path you'd like the user to be navigated to after authenticating.
 
 Function-based component example:
 
@@ -19,8 +19,8 @@ import { useOktaAuth } from '@okta/okta-react';
 import React from 'react';
 
 const Home = () => {
-  const { authState, authService } = useOktaAuth();
-  const login = () => authService.login('/profile');
+  const { authState, oktaAuth } = useOktaAuth();
+  const login = () => oktaAuth.signInWithRedirect({originalUri: '/profile'});
 
   if( authState.isPending ) {
     return (
@@ -50,7 +50,7 @@ export default withOktaAuth(class Home extends Component {
   }
 
   async login() {
-    this.props.authService.login('/profile');
+    this.props.oktaAuth.signInWithRedirect({originalUri: '/profile'});
   }
 
   render() {

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/use-the-access-token/react/getaccesstoken.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/use-the-access-token/react/getaccesstoken.md
@@ -1,4 +1,4 @@
-Get the access token using the `accessToken` property on the [AuthState](https://github.com/okta/okta-react#authstate) object. Then, use this value to add an `Authorization` header to outgoing requests:
+Get the access token using the `accessToken` property on the [AuthState](https://github.com/okta/okta-auth-js#authstatemanager) object. Then, use this value to add an `Authorization` header to outgoing requests:
 
 ```javascript
 const accessToken = authState.accessToken;

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/user-info/react/getuserinfo.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/user-info/react/getuserinfo.md
@@ -1,8 +1,8 @@
-Your code can get the user's profile using the [getUser()](https://github.com/okta/okta-react#authservicegetuser) method on the [AuthService](https://github.com/okta/okta-react#authservice) object. You should wait until the `authState.isAuthenticated` flag is true.
+Your code can get the user's profile using the [getUserInfo()](https://github.com/okta/okta-auth-js#tokengetuserinfoaccesstokenobject-idtokenobject) method on the [OktaAuth](https://github.com/okta/okta-auth-js) object. You should wait until the `authState.isAuthenticated` flag is true.
 
-For function-based components, `authState` and `authService` are returned by the [useOktaAuth](https://github.com/okta/okta-react#useoktaauth) hook.
+For function-based components, `authState` and `oktaAuth` are returned by the [useOktaAuth](https://github.com/okta/okta-react#useoktaauth) hook.
 
-For class-based components, `authState` and `authService` are passed as props to your component via the [withOktaAuth](https://github.com/okta/okta-react#withoktaauth) higher-order component.
+For class-based components, `authState` and `oktaAuth` are passed as props to your component via the [withOktaAuth](https://github.com/okta/okta-react#withoktaauth) higher-order component.
 
 Function-based component:
 
@@ -11,7 +11,7 @@ import { useOktaAuth } from "@okta/okta-react";
 import React, { useState, useEffect } from "react";
 
 const Home = () => {
-  const { authState, authService } = useOktaAuth();
+  const { authState, oktaAuth } = useOktaAuth();
   const [userInfo, setUserInfo] = useState(null);
 
   useEffect(() => {
@@ -19,11 +19,11 @@ const Home = () => {
       // When user isn't authenticated, forget any user info
       setUserInfo(null);
     } else {
-      authService.getUser().then(info => {
+      oktaAuth.getUserInfo().then(info => {
         setUserInfo(info);
       });
     }
-  }, [authState, authService]); // Update if authState changes
+  }, [authState, oktaAuth]); // Update if authState changes
 
   return (
     <div>
@@ -47,7 +47,7 @@ import React, { Component } from "react";
 
 async function checkUser() {
   if (this.props.authState.isAuthenticated && !this.state.userInfo) {
-    const userInfo = await this.props.authService.getUser();
+    const userInfo = await this.props.oktaAuth.getUserInfo();
     if (this._isMounted) {
       this.setState({ userInfo });
     }

--- a/packages/@okta/vuepress-site/docs/guides/sign-users-out/sign-out-of-okta/react/remotesignout.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-users-out/sign-out-of-okta/react/remotesignout.md
@@ -7,11 +7,11 @@ import { useOktaAuth } from '@okta/okta-react';
 
 // Basic component with logout button
 const Logout = () => { 
-  const { authService } = useOktaAuth();
+  const { oktaAuth } = useOktaAuth();
 
   const logout = async () => {
     // Will redirect to Okta to end the session then redirect back to the configured `postLogoutRedirectUri`
-    await authService.signOut();
+    await oktaAuth.signOut();
   };
 
   return (
@@ -36,7 +36,7 @@ class Logout extends Component {
 
   async logout() {
     // Will redirect to Okta to end the session then redirect back to the configured `postLogoutRedirectUri`
-    await this.props.authService.signOut();
+    await this.props.oktaAuth.signOut();
   }
 
   render() {
@@ -47,7 +47,7 @@ class Logout extends Component {
 });
 
 // withOktaAuth() makes the Okta 
-// - "authService" object available as "this.props.authService"
+// - "oktaAuth" object available as "this.props.oktaAuth"
 Logout = withOktaAuth(Logout);
 export default Logout;
 ```


### PR DESCRIPTION
Update React code demo to use `oktaAuth` instead of `authService` from old okra-react versions

### Resolves:

* [OKTA-374894](https://oktainc.atlassian.net/browse/OKTA-374894)
