### PR TITLE
Okta-380150 Add SSR and SIW requirements for Registration Hook Guide and API Reference

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/registration-inline-hook/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/registration-inline-hook/overview/index.md
@@ -4,6 +4,10 @@ title: Overview
 
 This guide provides example code for an external service to respond to calls from a Registration Inline Hook.
 
+You must enable [self-service registration (SSR)](/docs/guides/set-up-self-service-registration/before-you-begin/) to implement a registration inline hook.
+
+> **Note:** Self-service registration and Registration Inline Hooks only work with the [Okta Sign-In Widget](/code/javascript/okta_sign-in_widget/) version 2.9 or later.
+
 In the following example, the external service code parses requests from Okta and responds with commands that indicate whether the end user's email domain is valid and allowed to register.
 
 At a high-level, the following workflow occurs:

--- a/packages/@okta/vuepress-site/docs/guides/registration-inline-hook/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/registration-inline-hook/overview/index.md
@@ -4,7 +4,7 @@ title: Overview
 
 This guide provides example code for an external service to respond to calls from a Registration Inline Hook.
 
-You must enable [self-service registration (SSR)](/docs/guides/set-up-self-service-registration/before-you-begin/) to implement a registration inline hook.
+You must enable [self-service registration (SSR)](/docs/guides/set-up-self-service-registration/before-you-begin/) to implement a Registration Inline Hook.
 
 > **Note:** Self-service registration and Registration Inline Hooks only work with the [Okta Sign-In Widget](/code/javascript/okta_sign-in_widget/) version 2.9 or later.
 

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -23,12 +23,16 @@ For information on the API for registering external service endpoints with Okta,
 
 For steps to enable this Inline Hook, see below, [Enabling a Registration Inline Hook](#enabling-a-registration-inline-hook-for-self-service-registration).
 
+For an example implementation of this Inline Hook, see [Registration Inline Hook](/docs/guides/registration-inline-hook).
+
 ## About
 
 The Okta Registration Inline Hook allows you to integrate your own custom code into Okta's [Self-Service Registration](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Directory_Self_Service_Registration) flow. The hook is triggered after Okta receives the registration request but before the user is created. Your custom code can:
 
 - Set or override the values that will be populated in attributes of the user's Okta profile
 - Allow or deny the registration attempt, based on your own validation of the information the user has submitted
+
+> **Note:** Self-service registration and Registration Inline Hooks only work with the [Okta Sign-In Widget](/code/javascript/okta_sign-in_widget/) version 2.9 or later.
 
 ## Objects in the Request from Okta
 
@@ -61,7 +65,6 @@ Using the `com.okta.action.update` [command](#supported-commands) in your respon
 ## Objects in Response You Send
 
 The objects that you can return in the JSON payload of your response are an array of one or more `commands`, to be executed by Okta, or an `error` object, to indicate problems with the registration request. These objects are defined as follows:
-
 
 ### commands
 
@@ -209,8 +212,7 @@ If you do not return any value for that `errorCauses` object, but deny the user'
       }
    ]
 }
-```
-```json
+
 {
    "error":{
       "errorSummary":"Errors were found in the user profile",


### PR DESCRIPTION
## Description:
**What's changed?** 
- Added a note in the [Registration Inline Hook API ](https://developer.okta.com/docs/reference/registration-hook/) reference page to highlight SSR must be enabled and used with SIW. Also fixed a broken code block.
- Added same note and info on SSR to [Registration Inline Hook Guide ](https://developer.okta.com/docs/guides/registration-inline-hook/nodejs/overview/)

**Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-380150](https://oktainc.atlassian.net/browse/OKTA-380150)
