### PR TITLE
Improve list apps endpoint's q request parameter docs

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -1538,7 +1538,7 @@ Enumerates apps added to your organization with pagination. A subset of apps can
 | expand    | Traverses the `users` link relationship and optionally embeds the [Application User](#application-user-object) resource   | Query      | String   | FALSE    |         |
 | filter    | Filters apps by `status`, `user.id`, `group.id` or `credentials.signing.kid` expression                          | Query      | String   | FALSE    |         |
 | limit     | Specifies the number of results per page (maximum 200)                                                           | Query      | Number   | FALSE    | 20      |
-| q         | Searches the `name` or `label` property of applications                                                          | Query      | String   | FALSE    |         |
+| q         | Searches the `name` or `label` property of applications using `startsWith` that matches what the string starts with to the query                              | Query      | String   | FALSE    |         |
 
 The results are [paginated](/docs/reference/api-overview/#pagination) according to the `limit` parameter.
 If there are multiple pages of results, the Link header contains a `next` link that should be treated as an opaque value (follow it, don't parse it).


### PR DESCRIPTION
Please see `q` parameter docs of "List users assigned to application" endpoint:
https://github.com/okta/okta-developer-docs/blob/afdc0949909ad575a837fb86343014ca5bdd5bfe/packages/%40okta/vuepress-site/docs/reference/api/apps/index.md#list-users-assigned-to-application

It clearly documents that the q parameter is used with `startsWith` matching instead of exact matching. The type of matching performed is really important to know for API users. `/api/v1/apps` endpoint treats `q` request parameter similarly to `/api/v1/apps/${applicationId}/users` endpoint and uses `startsWith` matching.

[Obvious Fix](https://developer.okta.com/cla/#what-is-considered-an-obvious-fix), CLA submitted 20200804.