### PR TITLE
OKTA-382893 - added cache-control note in key-rotation concept and api/oidc/key endpoint

### DIFF
--- a/packages/@okta/vuepress-site/docs/concepts/key-rotation/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/key-rotation/index.md
@@ -19,7 +19,7 @@ If you are using the Org Authorization Server, configure and perform key rollove
 
 * Okta always publishes keys to the `jwks_uri`.
 
-* To save the network round trip, your app should cache the `jwks_uri` response locally. The [standard HTTP caching headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) are used and should be respected.
+* To save the network round trip, cache the `jwks_uri` response locally with respect to the directives in the [standard HTTP Cache-Control headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control). The cache-control directives are relative to the time of the request. If you make a request as the safe cache period ends, Okta returns the `no-cache` directive to ensure that you don't cache keys which will soon expire.
 
 * You can switch the Authorization Server key rotation mode by updating the Authorization Server's `rotationMode` property. For more information see the API Reference: [Authorization Server Credentials Signing Object](/docs/reference/api/authorization-servers/#credentials-object).
 

--- a/packages/@okta/vuepress-site/docs/concepts/key-rotation/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/key-rotation/index.md
@@ -19,7 +19,7 @@ If you are using the Org Authorization Server, configure and perform key rollove
 
 * Okta always publishes keys to the `jwks_uri`.
 
-* To save the network round trip, cache the `jwks_uri` response locally with respect to the directives in the [standard HTTP Cache-Control headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control). The cache-control directives are relative to the time of the request. If you make a request as the safe cache period ends, Okta returns the `no-cache` directive to ensure that you don't cache keys which will soon expire.
+* To save the network round trip, cache the `jwks_uri` response locally with respect to the directives in the [standard HTTP Cache-Control headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control). The cache-control directives are relative to the time of the request. If you make a request as the safe cache period ends, Okta returns the `no-cache` directive to ensure that you don't cache keys that will soon expire.
 
 * You can switch the Authorization Server key rotation mode by updating the Authorization Server's `rotationMode` property. For more information see the API Reference: [Authorization Server Credentials Signing Object](/docs/reference/api/authorization-servers/#credentials-object).
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oidc/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oidc/index.md
@@ -590,7 +590,7 @@ Okta also recommends caching or persisting these keys to improve performance. If
 
 JWKS properties can be found [here](/docs/reference/api/authorization-servers/#key-properties).
 
-> **Note:** Okta returns [standard HTTP Cache-Control headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) for applicable JWKS endpoints. Ensure you respect the cache header directives, as they are updated based on the time of request.
+> **Note:** Okta returns [standard HTTP Cache-Control headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) for applicable JWKS endpoints. Ensure that you respect the cache header directives, as they are updated based on the time of the request.
 
 #### Response example
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oidc/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oidc/index.md
@@ -590,6 +590,8 @@ Okta also recommends caching or persisting these keys to improve performance. If
 
 JWKS properties can be found [here](/docs/reference/api/authorization-servers/#key-properties).
 
+> **Note:** Okta returns [standard HTTP Cache-Control headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) for applicable JWKS endpoints. Ensure you respect the cache header directives, as they are updated based on the time of request.
+
 #### Response example
 
 ```http


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** OKTA-382893 : added cache-control note in key-rotation concept and api/oidc/key endpoint
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-382893](https://oktainc.atlassian.net/browse/OKTA-382893)
