### PR TITLE
Update Third-Party Admin Api Doc

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/iam-roles/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/iam-roles/index.md
@@ -1450,7 +1450,7 @@ HTTP/1.1 204 No Content
 
 You can grant third-party admin status by using an optional query parameter on the Administrator Roles API called `disableNotifications`.
 
-You're able to grant third-party admin status when adding a new admin, or you could update its status alone by passing just the request parameter.
+You're able to grant third-party admin status when adding a new admin, or you could update their status alone by passing just the request parameter.
 
 When this setting is enabled, the admins won't receive any of the default Okta administrator emails. These admins also won't have access to contact Okta Support and open support cases on behalf of your org.
 

--- a/packages/@okta/vuepress-site/docs/reference/api/iam-roles/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/iam-roles/index.md
@@ -1440,11 +1440,17 @@ HTTP/1.1 204 No Content
 
 ## Role assignment operations
 
-### Grant third-party admin status
+#### Grant third-party admin status to a User
 
 <ApiOperation method="post" url="/api/v1/users/${userId}/roles?disableNotifications=true" />
 
-You can grant third-party admin status when you add a new admin using the API. You can do this by using an optional query parameter with the Administrator Roles API called `disableNotifications`.
+#### Grant third-party admin status to a Group
+
+<ApiOperation method="post" url="/api/v1/groups/${groupId}/roles?disableNotifications=true" />
+
+You can grant third-party admin status by using an optional query parameter on the Administrator Roles API called `disableNotifications`.
+
+You're able to grant third-party admin status when adding a new admin, or you could update its status alone by passing just the request parameter.
 
 When this setting is enabled, the admins won't receive any of the default Okta administrator emails. These admins also won't have access to contact Okta Support and open support cases on behalf of your org.
 

--- a/packages/@okta/vuepress-site/docs/reference/api/roles/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/roles/index.md
@@ -16,10 +16,17 @@ Explore the Administrator Roles API:  [![Run in Postman](https://run.pstmn.io/bu
 
 ## Role assignment operations
 
-### Grant third-party admin status
+#### Grant third-party admin status to a User
+
 <ApiOperation method="post" url="/api/v1/users/${userId}/roles?disableNotifications=true" />
 
-You can grant third-party admin status when you are adding a new admin using the API. You can do this by using an optional query parameter on the Administrator Roles API called `disableNotifications`.
+#### Grant third-party admin status to a Group
+
+<ApiOperation method="post" url="/api/v1/groups/${groupId}/roles?disableNotifications=true" />
+
+You can grant third-party admin status by using an optional query parameter on the Administrator Roles API called `disableNotifications`.
+
+You're able to grant third-party admin status when adding a new admin, or you could update its status alone by passing just the request parameter.
 
 When this setting is enabled, the admins will not receive any of the default Okta administrator emails. These admins will also not have access to contact Okta Support and open support cases on behalf of your org.
 

--- a/packages/@okta/vuepress-site/docs/reference/api/roles/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/roles/index.md
@@ -26,7 +26,7 @@ Explore the Administrator Roles API:  [![Run in Postman](https://run.pstmn.io/bu
 
 You can grant third-party admin status by using an optional query parameter on the Administrator Roles API called `disableNotifications`.
 
-You're able to grant third-party admin status when adding a new admin, or you could update its status alone by passing just the request parameter.
+You're able to grant third-party admin status when adding a new admin, or you could update their status alone by passing just the request parameter.
 
 When this setting is enabled, the admins will not receive any of the default Okta administrator emails. These admins will also not have access to contact Okta Support and open support cases on behalf of your org.
 


### PR DESCRIPTION
## Description:

**What's changed?**

- Updated third-party admin status to be more flexible. You can update third-party status without the need of adding an admin/role, you're able to update the third-party status alone.
- Also added missing groups endpoint which covers granting third-party admin.

**Is this PR related to a Monolith release?**

- 2021.05.0

### Resolves:

* [OKTA-381780](https://oktainc.atlassian.net/browse/OKTA-381780)
