### PR TITLE
Update saml inline hook doc to add SessionNotOnOrAfter support

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/saml-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/saml-hook/index.md
@@ -344,7 +344,7 @@ Okta supports URI claims with SAML assertion hooks. When you need to replace or 
 
 ### SessionNotOnOrAfter support
 
-If you want to add `SessionNotOnOrAfter` attribute to the `<saml:AuthnStatement>` in SAML assertion, use `add` op with the path `/authentication/sessionLifetime` and session lifetime in seconds. Refer to example [here](/docs/reference/saml-hook/#sample-listing-of-json-payload-of-response). Okta will calculate `SessionNotOnOrAfter` by adding `/authentication/sessionLifetime` value to `issueInstant` and return it in SAML assertion.
+In some scenarios, your service provider may require the `SessionNotOnOrAfter` attribute for the `<saml:AuthnStatement>` in the SAML assertion, which sets the provider session time correctly. Use `add` op with the path `/authentication/sessionLifetime` and a value for session lifetime in seconds to add this attribute. See the [Sample listing of JSON payload response](/docs/reference/saml-hook/#sample-listing-of-json-payload-of-response) for an example. Okta calculates `SessionNotOnOrAfter` by adding `/authentication/sessionLifetime` value to the `issueInstant` attribute and returns it in the SAML assertion.
 
 ## Sample listing of JSON payload of response
 

--- a/packages/@okta/vuepress-site/docs/reference/saml-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/saml-hook/index.md
@@ -334,13 +334,17 @@ The `value` object is where you specify the specific operation to perform. It is
 
 Specify the location within the assertion where you want to apply your operation using a slash-delimited path, which follows JSON Patch conventions.
 
-When you perform an `add` op to add a new attribute statement, always begin with `/claims/` and follow that with the name of the new attribute that you are adding.
+When you perform an `add` op to add a new attribute statement, begin with `/claims/` and follow that with the name of the new attribute that you are adding.
 
 When you modify an existing assertions statement, begin the path with `/subject/`, `/authentication/`, `/conditions/`, or `/claims/`, depending on which part of the assertion you want to modify. You then drill down within the child elements using slash-delimited element names, for example, `/claims/array/attributeValues/1/value`. (The `/1/` in the path indicates the index of the array.)
 
 ### URI claims
 
 Okta supports URI claims with SAML assertion hooks. When you need to replace or add a URI claim, you must encode the claim name within the command per the [JavaScript Object Notation (JSON) Pointer](https://tools.ietf.org/html/rfc6901) specification. Specifically, this replaces `~` with `~0` and  `/` with `~1`.
+
+### SessionNotOnOrAfter support
+
+If you want to add `SessionNotOnOrAfter` attribute to the `<saml:AuthnStatement>` in SAML assertion, use `add` op with the path `/authentication/sessionLifetime` and session lifetime in seconds. Refer to example [here](/docs/reference/saml-hook/#sample-listing-of-json-payload-of-response). Okta will calculate `SessionNotOnOrAfter` by adding `/authentication/sessionLifetime` value to `issueInstant` and return it in SAML assertion.
 
 ## Sample listing of JSON payload of response
 
@@ -378,6 +382,11 @@ Okta supports URI claims with SAML assertion hooks. When you need to replace or 
               }
             ]
           }
+        },
+        {
+          "op": "add",
+          "path": "/authentication/sessionLifetime",
+          "value": 300
         }
       ]
     },


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- Update SAML inline hook doc to add `SessionNotOnOrAfter` support. Okta now allows clients to add `sessionLifetime` using inline hook command which will calculate `SessionNotOnOrAfter` value and return it in SAML assertion response. 
More details: [OKTA-353804](https://oktainc.atlassian.net/browse/OKTA-353804)
<!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
- **Is this PR related to a Monolith release?** Yes. Monthly Release: 2021.05.0 , Date: 4/30/2021

### Resolves:

* [OKTA-380909](https://oktainc.atlassian.net/browse/OKTA-380909)
