### PR TITLE
Add note on optional Authorization header

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
@@ -617,6 +617,7 @@ Authenticates a user via a [trusted application](#trusted-application) or proxy 
 
 * Specifying your own `deviceToken` is a highly privileged operation limited to trusted web applications and requires making authentication requests with a valid *API token*. If an API token is not provided, the `deviceToken` is ignored.
 * The **public IP address** of your [trusted application](#trusted-application) must be [allow listed as a gateway IP address](/docs/reference/api-overview/#ip-address) to forward the user agent's original IP address with the `X-Forwarded-For` HTTP header.
+* The ```Authorization: SSWS ${api_token}``` header is optional, in case of a SPA (Single Page app) this header can be omitted. 
 
 ##### Request example for activation token
 


### PR DESCRIPTION
Tested by Frank Benus (CIAM Specialist at Okta)

<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** 
Added a bullitpoint in the note for primary auth-n with an activation token. The api key is optional and in case of a SPA very confusing.

- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:
