### PR TITLE
Remove EA labels from group search API documentation

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
@@ -179,7 +179,7 @@ Enumerates Groups in your organization with pagination. A subset of Groups can b
 | limit     | Specifies the number of Group results in a page                                            | Query     | Number   | FALSE    | 10000   |
 | q         | Finds a group that matches the `name` property                                               | Query     | String   | FALSE    |         |
 | expand        | If specified, it causes additional metadata to be included in the response. Possible values are `stats` and/or `app`.                                             | Query     | String   | FALSE    |         |
-| search <ApiLifecycle access="ea" /> | Searches for groups with a supported [filtering](/docs/reference/api-overview/#filtering) expression for all [attributes](#group-attributes) except for `_embedded`, `_links`, and `objectClass`  | Query     | String   | FALSE    |         |
+| search | Searches for groups with a supported [filtering](/docs/reference/api-overview/#filtering) expression for all [attributes](#group-attributes) except for `_embedded`, `_links`, and `objectClass`  | Query     | String   | FALSE    |         |
 
 > **Notes:** The `after` cursor should be treated as an opaque value and obtained through the next link relation. See [Pagination](/docs/reference/api-overview/#pagination).<br><br>
 Search currently performs a `startsWith` match but it should be considered an implementation detail and may change without notice in the future.
@@ -724,8 +724,6 @@ curl -v -X GET \
 ```
 
 #### List Groups with Search
-
-<ApiLifecycle access="ea" />
 
 Searches for groups based on the properties specified in the search parameter
 


### PR DESCRIPTION
## Description:
- **What's changed?** `EXTENSIBLE_GROUP_SEARCH_API` is GA (almost) everywhere in production (and should be by the end of the week). Our API documentation has "EA" labels next to this functionality. Now that we are GA, the "EA" labels should be removed. This pull request removes the "EA" labels that were added in https://github.com/okta/okta-developer-docs/pull/1459. I manually tested that the documentation changes look good when built locally.
- **Is this PR related to a Monolith release?** Not a monolith release, but we should hold off until the rollout is complete near the end of the week.

### Resolves:

* [OKTA-342026](https://oktainc.atlassian.net/browse/OKTA-342026)

### Reviewers:

- @chenningzhang-okta
- @okta/ud-core 