### PR TITLE
add okta.domain.manage and okta.domain.read to supported scopes page

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta/scopes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta/scopes/index.md
@@ -17,6 +17,8 @@ The following table shows the scopes that are currently available:
 | `okta.clients.manage`    | Allows the app to manage all OAuth/OIDC clients and to create new clients| [Dynamic Client Registration API](/docs/reference/api/oauth-clients/)|
 | `okta.clients.read`      | Allows the app to read information for all OAuth/OIDC clients           | [Dynamic Client Registration API](/docs/reference/api/oauth-clients/)|
 | `okta.clients.register`  | Allows the app to register (create) new OAuth/OIDC clients (but not read information about existing clients)| [Dynamic Client Registration API](/docs/reference/api/oauth-clients/#register-new-client) |
+| `okta.domain.manage`  | Allows the app to create and manage Domains in your Okta organization| [Domain API](/docs/reference/api/domains/) |
+| `okta.domain.read`  | Allows the app to read information about Domains in your Okta organization| [Domain API](/docs/reference/api/domains/) |
 | `okta.eventHooks.manage` | Allows the app to create and manage Event Hooks in your Okta organization| [Event Hooks API](/docs/reference/api/event-hooks/)|
 | `okta.eventHooks.read`   | Allows the app to read information about Event Hooks in your Okta organization| [Event Hooks API](/docs/reference/api/event-hooks/)|
 | `okta.factors.manage`    | Allows the app to manage all admin operations for org factors (for example, activate, deactive, read)| [Factors Administration Operations](/docs/reference/api/factor-admin/#factors-administration-operations)|

--- a/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta/scopes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta/scopes/index.md
@@ -18,7 +18,7 @@ The following table shows the scopes that are currently available:
 | `okta.clients.read`      | Allows the app to read information for all OAuth/OIDC clients           | [Dynamic Client Registration API](/docs/reference/api/oauth-clients/)|
 | `okta.clients.register`  | Allows the app to register (create) new OAuth/OIDC clients (but not read information about existing clients)| [Dynamic Client Registration API](/docs/reference/api/oauth-clients/#register-new-client) |
 | `okta.domain.manage`  | Allows the app to create and manage Domains in your Okta organization| [Domains API](/docs/reference/api/domains/) |
-| `okta.domain.read`  | Allows the app to read information about Domains in your Okta organization| [Domain API](/docs/reference/api/domains/) |
+| `okta.domain.read`  | Allows the app to read information about Domains in your Okta organization| [Domains API](/docs/reference/api/domains/) |
 | `okta.eventHooks.manage` | Allows the app to create and manage Event Hooks in your Okta organization| [Event Hooks API](/docs/reference/api/event-hooks/)|
 | `okta.eventHooks.read`   | Allows the app to read information about Event Hooks in your Okta organization| [Event Hooks API](/docs/reference/api/event-hooks/)|
 | `okta.factors.manage`    | Allows the app to manage all admin operations for org factors (for example, activate, deactive, read)| [Factors Administration Operations](/docs/reference/api/factor-admin/#factors-administration-operations)|

--- a/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta/scopes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta/scopes/index.md
@@ -17,7 +17,7 @@ The following table shows the scopes that are currently available:
 | `okta.clients.manage`    | Allows the app to manage all OAuth/OIDC clients and to create new clients| [Dynamic Client Registration API](/docs/reference/api/oauth-clients/)|
 | `okta.clients.read`      | Allows the app to read information for all OAuth/OIDC clients           | [Dynamic Client Registration API](/docs/reference/api/oauth-clients/)|
 | `okta.clients.register`  | Allows the app to register (create) new OAuth/OIDC clients (but not read information about existing clients)| [Dynamic Client Registration API](/docs/reference/api/oauth-clients/#register-new-client) |
-| `okta.domain.manage`  | Allows the app to create and manage Domains in your Okta organization| [Domain API](/docs/reference/api/domains/) |
+| `okta.domain.manage`  | Allows the app to create and manage Domains in your Okta organization| [Domains API](/docs/reference/api/domains/) |
 | `okta.domain.read`  | Allows the app to read information about Domains in your Okta organization| [Domain API](/docs/reference/api/domains/) |
 | `okta.eventHooks.manage` | Allows the app to create and manage Event Hooks in your Okta organization| [Event Hooks API](/docs/reference/api/event-hooks/)|
 | `okta.eventHooks.read`   | Allows the app to read information about Event Hooks in your Okta organization| [Event Hooks API](/docs/reference/api/event-hooks/)|


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Added okta.domain.manage and okta.domain.read to supported oauth2 scopes page
- **Is this PR related to a Monolith release?** Yes, 2021.05.0

### Resolves:

* [OKTA-381286](https://oktainc.atlassian.net/browse/OKTA-381286)
