### PR TITLE
Improve users api related resources request parameters docs

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/users/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/users/index.md
@@ -2250,7 +2250,7 @@ Users that don't have a password must complete the flow by completing [Reset Pas
 
 | Parameter | Description                                                                | Param Type | DataType | Required |
 | --------- | -------------------------------------------------------------------------- | ---------- | -------- | -------- |
-| id        | `id` of user                                                               | URL        | String   | TRUE     |
+| id        | `id`, `login`, or *login shortname* (as long as it is unambiguous) of user                                                               | URL        | String   | TRUE     |
 | sendEmail | Sends an activation email to the user if `true`. Default value is `false`. | Query      | Boolean  | FALSE    |
 
 ##### Response Parameters

--- a/packages/@okta/vuepress-site/docs/reference/api/users/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/users/index.md
@@ -2044,7 +2044,7 @@ Fetches appLinks for all direct or indirect (via group membership) assigned appl
 
 | Parameter | Description  | Param Type | DataType | Required |
 | --------- | ------------ | ---------- | -------- | -------- |
-| id        | `id`, `login`, or *login shortname* (as long as it is unambiguous) of user | URL        | String   | TRUE     |
+| id        | `id`, `login`, or login shortname (as long as it is unambiguous) of user | URL        | String   | TRUE     |
 
 ##### Response Parameters
 
@@ -2130,7 +2130,7 @@ Fetches the groups of which the user is a member
 
 | Parameter | Description  | Param Type | DataType | Required |
 | --------- | ------------ | ---------- | -------- | -------- |
-| id        | `id`, `login`, or *login shortname* (as long as it is unambiguous) of user | URL        | String   | TRUE     |
+| id        | `id`, `login`, or login shortname (as long as it is unambiguous) of user | URL        | String   | TRUE     |
 
 ##### Response Parameters
 
@@ -2250,7 +2250,7 @@ Users that don't have a password must complete the flow by completing [Reset Pas
 
 | Parameter | Description                                                                | Param Type | DataType | Required |
 | --------- | -------------------------------------------------------------------------- | ---------- | -------- | -------- |
-| id        | `id`, `login`, or *login shortname* (as long as it is unambiguous) of user                                                               | URL        | String   | TRUE     |
+| id        | `id`, `login`, or login shortname (as long as it is unambiguous) of user                                                               | URL        | String   | TRUE     |
 | sendEmail | Sends an activation email to the user if `true`. Default value is `false`. | Query      | Boolean  | FALSE    |
 
 ##### Response Parameters

--- a/packages/@okta/vuepress-site/docs/reference/api/users/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/users/index.md
@@ -2044,7 +2044,7 @@ Fetches appLinks for all direct or indirect (via group membership) assigned appl
 
 | Parameter | Description  | Param Type | DataType | Required |
 | --------- | ------------ | ---------- | -------- | -------- |
-| id        | `id` of user | URL        | String   | TRUE     |
+| id        | `id`, `login`, or *login shortname* (as long as it is unambiguous) of user | URL        | String   | TRUE     |
 
 ##### Response Parameters
 
@@ -2130,7 +2130,7 @@ Fetches the groups of which the user is a member
 
 | Parameter | Description  | Param Type | DataType | Required |
 | --------- | ------------ | ---------- | -------- | -------- |
-| id        | `id` of user | URL        | String   | TRUE     |
+| id        | `id`, `login`, or *login shortname* (as long as it is unambiguous) of user | URL        | String   | TRUE     |
 
 ##### Response Parameters
 


### PR DESCRIPTION
Just like "Get User" (https://github.com/okta/okta-developer-docs/blob/31deb2594c5fbaf4d60de1ddf96ee707af18f680/packages/%40okta/vuepress-site/docs/reference/api/users/index.md#get-user-with-login) accepts `login` and *login shortname* similarly these three endpoints that I changed also accept `login` and *login shortname*.


[Obvious Fix](https://developer.okta.com/cla/#what-is-considered-an-obvious-fix), CLA submitted on 20200804.

Please squash commits when merging.
