### PR TITLE
[FIX] Incorrect Android artifacts resolves #2133

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app/configure-packages/android/installsdk.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app/configure-packages/android/installsdk.md
@@ -3,7 +3,7 @@ Use the [Okta OIDC](https://github.com/okta/okta-oidc-android) library available
 To install it, add the following to your `build.gradle`:
 
 ```groovy
-implementation 'com.okta.oidc.android:okta-oidc-androidx:1.0.18'
+implementation 'com.okta.android:oidc-androidx:1.0.18'
 ```
 
 For projects that don't yet use AndroidX:
@@ -17,5 +17,5 @@ repositories {
 ```
 
 ```groovy
-implementation 'com.okta.oidc.android:okta-oidc-android:1.0.16'
+implementation 'com.okta.android:oidc-android:1.0.18'
 ```

--- a/packages/@okta/vuepress-site/docs/guides/unlock-mobile-app-with-biometrics/configure-packages/android/installsdk.md
+++ b/packages/@okta/vuepress-site/docs/guides/unlock-mobile-app-with-biometrics/configure-packages/android/installsdk.md
@@ -3,10 +3,10 @@
 To install the library, add the following to your `build.gradle`:
 
 ```groovy
-implementation 'com.okta.oidc.android:okta-oidc-androidx:1.0.18'
+implementation 'com.okta.android:oidc-androidx:1.0.18'
 ```
 
 For projects that don't yet use AndroidX:
 
 ```groovy
-implementation 'com.okta.oidc.android:okta-oidc-android:1.0.16'
+implementation 'com.okta.android:oidc-android:1.0.18'


### PR DESCRIPTION


## Description:

Corrected references to ```com.okta.oidc.android:okta-oidc-androidx``` & ```com.okta.oidc.android:okta-oidc-android```. The correct artifacts are ```com.okta.android:oidc-androidx``` & ```com.okta.android:oidc-android``` respectively.


