### PR TITLE
add doc for apps api GA change

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -6572,7 +6572,7 @@ Specifies the template used to generate a user's username when the application i
 | userSuffix | suffix for built-in mapping expressions | String                           | TRUE     | NULL              |           |            |            |
 | pushStatus | push username on update                 | `PUSH`, `DONT_PUSH`              | TRUE     | `DONT_PUSH` for `CUSTOM` type |           |            |            |
 
-> **Note:** You must use the `CUSTOM` type when defining your own expression that is not built-in. `pushStatus` is only effective for `CUSTOM` type.
+> **Note:** You must use the `CUSTOM` type when defining your own expression that is not built-in. The `pushStatus` parameter is effective only for the `CUSTOM` type.
 
 ```json
 {

--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -6570,8 +6570,9 @@ Specifies the template used to generate a user's username when the application i
 | template   | mapping expression for username         | String                           | TRUE     | `${source.login}` |           | 1024       |            |
 | type       | type of mapping expression              | `NONE`,  `BUILT_IN`, or `CUSTOM` | FALSE    | BUILT_IN          |           |            |            |
 | userSuffix | suffix for built-in mapping expressions | String                           | TRUE     | NULL              |           |            |            |
+| pushStatus | push username on update                 | `PUSH`, `DONT_PUSH`              | TRUE     | `DONT_PUSH` for `CUSTOM` type |           |            |            |
 
-> **Note:** You must use the `CUSTOM` type when defining your own expression that is not built-in.
+> **Note:** You must use the `CUSTOM` type when defining your own expression that is not built-in. `pushStatus` is only effective for `CUSTOM` type.
 
 ```json
 {


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
-   adding `pushStatus` attribute to /api/v1/apps API
```
    "credentials": {
        "scheme": "EDIT_USERNAME_AND_PASSWORD",
        "userNameTemplate": {
            "template": "user.login",
            "type": "CUSTOM",
            "pushStatus": "PUSH".  // the added attribute 
        },
        "revealPassword": true,
        "signing": {}
    },
```
- **Is this PR related to a Monolith release?** Yes, must be released along with GA of changes. Release: 2021.7.0

### Resolves:

* OKTA-396834
