### PR TITLE
Fix Outdated Reference for Vue Sign In Widget Guide

### DIFF
--- a/packages/@okta/vuepress-site/code/vue/okta_vue_sign-in_widget/index.md
+++ b/packages/@okta/vuepress-site/code/vue/okta_vue_sign-in_widget/index.md
@@ -23,7 +23,7 @@ This guide will walk you through integrating authentication into a Vue app with 
 - [Support](#support)
 
 
-> This guide is for `@okta/okta-signin-widget` v5.2.0, `@okta/okta-vue` v3.0.0 and `okta-auth-js` v4.5.0.
+> This guide is for `@okta/okta-signin-widget` v5.2.0, `@okta/okta-vue` v3.0.0 and `@okta/okta-auth-js` v4.5.0.
 
 ## Prerequisites
 

--- a/packages/@okta/vuepress-site/code/vue/okta_vue_sign-in_widget/index.md
+++ b/packages/@okta/vuepress-site/code/vue/okta_vue_sign-in_widget/index.md
@@ -292,7 +292,7 @@ This example is using Vue Router. Replace the code in `src/router/index.js` with
 ```js
 import Vue from 'vue'
 import VueRouter from 'vue-router'
-import Auth from '@okta/okta-vue'
+import Auth, { LoginCallback } from '@okta/okta-vue'
 import { OktaAuth } from '@okta/okta-auth-js'
 import HomeComponent from '@/components/Home'
 import LoginComponent from '@/components/Login'
@@ -321,7 +321,7 @@ const router = new VueRouter({
     },
     {
       path: '/login/callback',
-      component: Auth.handleCallback()
+      component: LoginCallback
     },
     {
       path: '/profile',


### PR DESCRIPTION
## Description:
- **What's changed?**
   - Update `Auth.HandleCallback` -> `LoginCallback`
        - The guide references using the `Auth.HandleCallback()` method for the component, which differs from the [v3.0.0 documentation](https://github.com/okta/okta-vue/tree/3.0#use-the-logincallback-component). This causes an error in real-time.
   - Specify  org name of `okta-auth-js` by `@okta/okta-auth-js`

- **Is this PR related to a Monolith release?** No

### Resolves:
* No existing Jira ticket
