### PR TITLE
OKTA-398045: add array reference operator to developer doc

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
@@ -247,9 +247,10 @@ The functions above are often used in tandem to check whether a user has an AD o
 | Common Actions                                                                              | Example                                     |
 | ----------------                                                                            | --------                                    |
 | Refer to a `String` constant                                                                | `'Hello world'`                             |
-| Refer to a `Integer` constant                                                               | `1234`                                      |
+| Refer to an `Integer` constant                                                              | `1234`                                      |
 | Refer to a `Number` constant                                                                | `3.141`                                     |
 | Refer to a `Boolean` constant                                                               | `true`                                      |
+| Refer to an `Array` element                                                                 | `{1, 2, 3}[0]` or `user.arrayProperty[0]`   |
 | Concatenate two strings                                                                     | `user.firstName + user.lastName`            |
 | Concatenate two strings with space                                                          | `user.firstName + " " + user.lastName`      |
 | Ternary operator example:<br>If group code is 123, assign value of Sales, else assign Other | `user.groupCode == 123 ? 'Sales' : 'Other'` |


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** array referencing added to doc (i.e. the `[]` operator)
- **Is this PR related to a Monolith release?** 2021.05.03

### Resolves:

* [OKTA-398045](https://oktainc.atlassian.net/browse/OKTA-398045)
