### PR TITLE
Fixed issue with missing breadcrumbs "Show content" label in reference page

### DIFF
--- a/packages/@okta/vuepress-theme-prose/components/Breadcrumb.vue
+++ b/packages/@okta/vuepress-theme-prose/components/Breadcrumb.vue
@@ -9,7 +9,7 @@
           <path d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"/>
         </svg>
       </li>
-      <li class="crumb-show-contents" @click="toggleTreeNav" v-if="enableShowHide">{{showHideContents}}</li>
+      <li class="crumb-show-contents" @click="toggleTreeNav" >{{showHideContents}}</li>
     </ol>
   </div>
 </div>
@@ -20,12 +20,6 @@
     name: "Breadcrumb",
     inject: ['appContext'],
     computed: {
-      enableShowHide() {
-        if(this.$page.path == '/docs/reference/') {
-          return false;
-        }
-        return true;
-      },
       showHideContents() {
         if(this.appContext.isTreeNavMobileOpen) {
           return 'Hide Contents';


### PR DESCRIPTION

## Description:
- **What's changed?**  "Show Content" is present on /reference/ page now
- **Is this PR related to a Monolith release?** No

![image](https://user-images.githubusercontent.com/68992536/119652293-8ee3d100-be2e-11eb-9812-c1e968fb6e89.png)


### Resolves:

* [OKTA-369871](https://oktainc.atlassian.net/browse/OKTA-369871)
