### PR TITLE
Makes `snippet` on `StackSelector` optional, adds `StackSnippet` component

### DIFF
--- a/packages/@okta/vuepress-theme-prose/global-components/StackSelector.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/StackSelector.vue
@@ -130,6 +130,10 @@
   };
 </script>
 <style scoped lang="scss">
+  .stack-selector {
+    margin-bottom: 1.5rem;
+  }
+
   .no-stack-content {
     border: 1px solid #d66;
     padding: 10px;

--- a/packages/@okta/vuepress-theme-prose/global-components/StackSelector.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/StackSelector.vue
@@ -129,6 +129,11 @@
     border: 1px solid #d66;
     padding: 10px;
   }
+  .no-selector {
+    & /deep/ ol[start] {
+      margin-top: -0.75rem;
+    }
+  }
   .display-inline {
     display: inline;
 

--- a/packages/@okta/vuepress-theme-prose/global-components/StackSelector.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/StackSelector.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="{ 'stack-selector': !noSelector, 'no-selector': noSelector, 'display-inline': inline }" v-if="options.length">
+  <div :class="{ 'stack-selector': !noSelector, 'no-selector': noSelector, 'no-snippet': !snippet, 'display-inline': inline }" v-if="options.length">
     <div class="selector-control" v-if="!noSelector">
       <span class="instructions-label">
         Instructions for
@@ -137,6 +137,11 @@
   .no-selector {
     & /deep/ ol[start] {
       margin-top: -0.75rem;
+    }
+  }
+  .no-snippet {
+    .selector-control {
+      border-bottom: 0;
     }
   }
   .display-inline {

--- a/packages/@okta/vuepress-theme-prose/global-components/StackSelector.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/StackSelector.vue
@@ -20,7 +20,7 @@
       </v-select>
       </nav>
     </div>
-    <aside class="stack-content">
+    <aside class="stack-content" v-if="snippet">
       <Content v-if="snippetComponentKey" :pageKey="snippetComponentKey" />
     </aside>
   </div>
@@ -36,7 +36,7 @@
     props: {
       snippet: {
         type: String,
-        required: true,
+        required: false,
       },
       noSelector: {
         type: Boolean,
@@ -94,7 +94,15 @@
         return this.guide.sectionByName[this.sectionName];
       },
       options() {
-        return this.section?.snippetByName?.[this.snippet]?.frameworks ?? [];
+        const snippetByName = this.section?.snippetByName;
+
+        if (typeof snippetByName !== 'object') {
+          return [];
+        }
+
+        const frameworksData = Object.values(snippetByName)[0]?.frameworks ?? [];
+
+        return frameworksData;
       },
       snippetComponentKey() { 
         const option = this.options.find( option => option.framework === this.framework );

--- a/packages/@okta/vuepress-theme-prose/global-components/StackSelector.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/StackSelector.vue
@@ -47,14 +47,14 @@
         default: false,
       },
     },
-    data() { 
-      return { 
+    data() {
+      return {
         offsetFromViewport: null,
         hasFocus: false,
       };
     },
-    methods: { 
-      handleScroll() { 
+    methods: {
+      handleScroll() {
         // beforeUpdated was somehow AFTER the viewport offsets were calculated for new content
         // thus we need to save this from before they swap tabs within the StackSelector
         this.offsetFromViewport = this.$el.getBoundingClientRect().top;
@@ -76,11 +76,11 @@
         window.removeEventListener('scroll', this.handleScroll);
       }
     },
-    computed: { 
+    computed: {
       guideName() {
         return guideFromPath( this.$route.path ).guideName;
       },
-      framework() { 
+      framework() {
         // Default to first available framework
         return guideFromPath( this.$route.path ).framework || this.options[0].name;
       },
@@ -90,14 +90,11 @@
       guide() {
          return getGuidesInfo({pages: this.$site.pages}).byName[this.guideName];
       },
-      section() { 
+      section() {
         return this.guide.sectionByName[this.sectionName];
       },
-      options() { 
-        return (this.section &&  // Eagerly awaiting the ?. operator 
-          this.section.snippetByName && 
-          this.section.snippetByName[this.snippet] && 
-          this.section.snippetByName[this.snippet].frameworks) || []; 
+      options() {
+        return this.section?.snippetByName?.[this.snippet]?.frameworks ?? [];
       },
       snippetComponentKey() { 
         const option = this.options.find( option => option.framework === this.framework );
@@ -112,7 +109,7 @@
           }
       }
     },
-    updated() { 
+    updated() {
       // If we are the Stack Selector that was focused (clicked on), 
       // scroll that we stay in the same position relative to the viewport
       if(this.hasFocus && this.offsetFromViewport ) { 
@@ -125,7 +122,7 @@
   };
 </script>
 <style scoped lang="scss">
-  .no-stack-content { 
+  .no-stack-content {
     border: 1px solid #d66;
     padding: 10px;
   }

--- a/packages/@okta/vuepress-theme-prose/global-components/StackSelector.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/StackSelector.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="stack-selector" v-if="options.length">
-    <div class="selector-control">
+  <div :class="{ 'stack-selector': !noSelector, 'no-selector': noSelector, 'display-inline': inline }" v-if="options.length">
+    <div class="selector-control" v-if="!noSelector">
       <span class="instructions-label">
         Instructions for
       </span>
@@ -33,7 +33,20 @@
   import { getGuidesInfo, guideFromPath } from '../util/guides';
   export default {
     name: 'StackSelector',
-    props: [ 'snippet' ],
+    props: {
+      snippet: {
+        type: String,
+        required: true,
+      },
+      noSelector: {
+        type: Boolean,
+        default: false,
+      },
+      inline: {
+        type: Boolean,
+        default: false,
+      },
+    },
     data() { 
       return { 
         offsetFromViewport: null,
@@ -115,5 +128,16 @@
   .no-stack-content { 
     border: 1px solid #d66;
     padding: 10px;
+  }
+  .display-inline {
+    display: inline;
+
+    .stack-content {
+      display: inline;
+
+      & > div, & /deep/ p {
+        display: inline;
+      }
+    }
   }
 </style>

--- a/packages/@okta/vuepress-theme-prose/global-components/StackSelector.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/StackSelector.vue
@@ -113,7 +113,7 @@
           return this.options.find(option => option.framework === this.framework)
         },
         set: function (selectedOption) {
-          // no-op for silencing computed property assignemnt(by vue-select) warning
+          // no-op for silencing computed property assignment(by vue-select) warning
         }
       }
     },

--- a/packages/@okta/vuepress-theme-prose/global-components/StackSelector.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/StackSelector.vue
@@ -109,18 +109,18 @@
         return (option ? option.componentKey : '');
       },
       selectedOption: {
-          get: function() {
-            return this.options.find(option => option.framework === this.framework)
-          },
-          set: function (selectedOption) {
-            // no-op for silencing computed property assignemnt(by vue-select) warning
-          }
+        get: function() {
+          return this.options.find(option => option.framework === this.framework)
+        },
+        set: function (selectedOption) {
+          // no-op for silencing computed property assignemnt(by vue-select) warning
+        }
       }
     },
     updated() {
       // If we are the Stack Selector that was focused (clicked on), 
       // scroll that we stay in the same position relative to the viewport
-      if(this.hasFocus && this.offsetFromViewport ) { 
+      if(!this.noSelector && this.hasFocus && this.offsetFromViewport ) { 
         this.$nextTick(() => { // postponed to allow child components to rerender
           window.scroll(0, this.$el.offsetTop - this.offsetFromViewport );
           this.hasFocus = false;

--- a/packages/@okta/vuepress-theme-prose/global-components/StackSnippet.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/StackSnippet.vue
@@ -1,0 +1,19 @@
+<template>
+  <StackSelector noSelector :snippet="snippet" :inline="inline" />
+</template>
+
+<script>
+  export default {
+    name: 'StackSnippet',
+    props: {
+      snippet: {
+        type: String,
+        required: true,
+      },
+      inline: {
+        type: Boolean,
+        default: false,
+      },
+    },
+  };
+</script>


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
`StackSelector` can now be rendered without passing `snippet` to show it without any content:
```vue
  <StackSelector />
```
![image](https://user-images.githubusercontent.com/72248639/119732376-14bf4680-be46-11eb-8f24-fee77b1b2f51.png)


Added new component `StackSnippet`, which displays only a snippet of code/instructions without the selector:
```vue
  // display block-level snippet
  <StackSnippet snippet="snippetName" />

  // display inline snippet
  <StackSnippet snippet="snippetName" inline />
```
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-397896](https://oktainc.atlassian.net/browse/OKTA-397896)
