### PR TITLE
clarify that the UTC Epoch time is in seconds

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/rl-best-practices/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/rl-best-practices/index.md
@@ -17,7 +17,7 @@ For org-wide rate limits, the three headers show the limit that is being enforce
 
 * `X-Rate-Limit-Limit` - the rate limit ceiling that is applicable for the current request.
 * `X-Rate-Limit-Remaining` - the number of requests left for the current rate-limit window.
-* `X-Rate-Limit-Reset` - the time at which the rate limit resets, specified in UTC epoch time in seconds.
+* `X-Rate-Limit-Reset` - the time at which the rate limit resets, specified in UTC epoch time (in seconds).
 
 For example:
 

--- a/packages/@okta/vuepress-site/docs/reference/rl-best-practices/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/rl-best-practices/index.md
@@ -17,7 +17,7 @@ For org-wide rate limits, the three headers show the limit that is being enforce
 
 * `X-Rate-Limit-Limit` - the rate limit ceiling that is applicable for the current request.
 * `X-Rate-Limit-Remaining` - the number of requests left for the current rate-limit window.
-* `X-Rate-Limit-Reset` - the time at which the rate limit resets, specified in UTC epoch time.
+* `X-Rate-Limit-Reset` - the time at which the rate limit resets, specified in UTC epoch time in seconds.
 
 For example:
 


### PR DESCRIPTION
## Description:
In many systems (like Unix, Java, etc) Epoch timestamps are in Millies, this one is in seconds but the doc doesn't say that explicitly (if you look at the example it's clearly seconds). This just clarifies that.



