### PR TITLE
Minor improvements & nits

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/implement-auth-code-pkce/exchange-code-token/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-auth-code-pkce/exchange-code-token/index.md
@@ -21,6 +21,7 @@ Note the parameters that are being passed:
 - `redirect_uri` must match the URI that was used to get the authorization code.
 - `code` is the authorization code that you got from the `/authorize` endpoint.
 - `code_verifier` is the PKCE code verifier that your app generated at the beginning of this flow.
+- `client_id`
 
 See the [OIDC & OAuth 2.0 API reference](/docs/reference/api/oidc/#token) for more information on these parameters.
 

--- a/packages/@okta/vuepress-site/docs/guides/implement-auth-code-pkce/exchange-code-token/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-auth-code-pkce/exchange-code-token/index.md
@@ -21,7 +21,7 @@ Note the parameters that are being passed:
 - `redirect_uri` must match the URI that was used to get the authorization code.
 - `code` is the authorization code that you got from the `/authorize` endpoint.
 - `code_verifier` is the PKCE code verifier that your app generated at the beginning of this flow.
-- `client_id` identifies your client, and must match the value preregistered in Okta.    
+- `client_id` identifies your client and must match the value preregistered in Okta.    
 
 See the [OIDC & OAuth 2.0 API reference](/docs/reference/api/oidc/#token) for more information on these parameters.
 

--- a/packages/@okta/vuepress-site/docs/guides/implement-auth-code-pkce/exchange-code-token/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-auth-code-pkce/exchange-code-token/index.md
@@ -21,7 +21,7 @@ Note the parameters that are being passed:
 - `redirect_uri` must match the URI that was used to get the authorization code.
 - `code` is the authorization code that you got from the `/authorize` endpoint.
 - `code_verifier` is the PKCE code verifier that your app generated at the beginning of this flow.
-- `client_id`
+- `client_id` identifies your client, and must match the value preregistered in Okta.    
 
 See the [OIDC & OAuth 2.0 API reference](/docs/reference/api/oidc/#token) for more information on these parameters.
 

--- a/packages/@okta/vuepress-site/docs/guides/implement-auth-code-pkce/exchange-code-token/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-auth-code-pkce/exchange-code-token/index.md
@@ -27,7 +27,7 @@ See the [OIDC & OAuth 2.0 API reference](/docs/reference/api/oidc/#token) for mo
 
 If the code is still valid, and the code verifier matches, your application receives back access and ID tokens:
 
-```
+```json
 {
     "access_token": "eyJhb[...]Hozw",
     "expires_in": 3600,

--- a/packages/@okta/vuepress-site/docs/guides/implement-auth-code-pkce/use-flow/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-auth-code-pkce/use-flow/index.md
@@ -13,7 +13,7 @@ You need to add code in your native app to create the code verifier and code cha
 
 The PKCE generator code creates output like this:
 
-```
+```json
 {
   "code_verifier":"M25iVXpKU3puUjFaYWg3T1NDTDQtcW1ROUY5YXlwalNoc0hhakxifmZHag",
   "code_challenge":"qjrzSW9gMiUgpUvqgEPE4_-8swvyCtfOVvg55o5S_es"

--- a/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta-serviceapp/create-sign-jwt/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta-serviceapp/create-sign-jwt/index.md
@@ -29,12 +29,12 @@ You can use the following [JWT claims](/docs/reference/api/oidc/#token-claims-fo
     **Payload example**
 
 ```json
-    {
+{
     "aud": "https://{yourOktaDomain}/oauth2/v1/token",
     "iss": "0oar95zt9zIpYuz6A0h7",
     "sub": "0oar95zt9zIpYuz6A0h7",
     "exp": "1614664267"
-    }
+}
 ```
 
 2. In the **Signing Key** box, paste the public and private key that you generated in the <GuideLink link="../create-publicprivate-keypair">Create a public/private key pair</GuideLink> step.

--- a/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta-serviceapp/get-access-token/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-oauth-for-okta-serviceapp/get-access-token/index.md
@@ -17,7 +17,7 @@ Include the following parameters:
 The following is an example request for an access token (the JWT is truncated for brevity).
 
 ```bash
-    curl --location --request POST 'https://{yourOktaDomain}/oauth2/v1/token' \
+curl --location --request POST 'https://{yourOktaDomain}/oauth2/v1/token' \
     --header 'Accept: application/json' \
     --header 'Content-Type: application/x-www-form-urlencoded' \
     --data-urlencode 'grant_type=client_credentials' \

--- a/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
@@ -37,7 +37,7 @@ Trusted applications are backend applications that act as authentication broker 
 2. For more advanced use cases, learn [the Okta API basics](/code/rest/).
 3. Explore the Authentication API:
 
-    [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/41c71ad6815e708b504a))
+    [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/41c71ad6815e708b504a)
 
 ## Authentication operations
 

--- a/packages/@okta/vuepress-site/docs/reference/api/oidc/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oidc/index.md
@@ -665,7 +665,7 @@ You must include an access token (returned from the [authorization endpoint](#au
 #### Request example
 
 ```bash
-curl -v -X POST \
+curl -X GET \
 -H "Authorization: Bearer ${access_token}" \
 "https://{baseUrl}/userinfo"
 ```


### PR DESCRIPTION
## Description:

While implementing an auth flow I came across a few issues in the docs. This PR is a mix of fixes & nits.

- `/userinfo` is listed as a `GET` but the example given is a `POST`—I've updated it to `GET`
- There was a visible trailing `)` on one page
- The `/token` endpoint has a hard requirement for a `client_id`, but the page does not list that as a param.
- Minor syntax cleanup