### PR TITLE
Moving note snippet above ordered list, to correct numerics

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/add-an-external-idp/configure-idp-in-okta/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/add-an-external-idp/configure-idp-in-okta/index.md
@@ -3,9 +3,9 @@ title: Create an Identity Provider in Okta
 ---
 To connect your org to the Identity Provider, add and configure that Identity Provider in Okta.
 
-1. In the Admin Console, go to **Security** > **Identity Providers**.
-
 > **Note:** See the [Identity Providers API](/docs/reference/api/idps/#add-identity-provider) for request and response examples of creating an Identity Provider in Okta using the API.
+
+1. In the Admin Console, go to **Security** > **Identity Providers**.
 
 1. Select **Add Identity Provider** and then select the appropriate Identity Provider.
 


### PR DESCRIPTION
## Description:

Fixes an issue where a snippet split ordered list items, causing the numerics to reset.

<img width="571" alt="Screenshot_6_9_21__10_50_AM" src="https://user-images.githubusercontent.com/52420/121387877-a0d67100-c910-11eb-85c3-51968aea00de.png">

By moving the snippet above the list it will allow the numerics to show the expected values.