### PR TITLE
Renamed headings and fixed linking to avoid page autoscroll on top

### DIFF
--- a/packages/@okta/vuepress-site/code/angular/okta_angular_sign-in_widget/index.md
+++ b/packages/@okta/vuepress-site/code/angular/okta_angular_sign-in_widget/index.md
@@ -12,7 +12,7 @@ This guide will walk you through integrating authentication into an Angular appl
 - [Create an Angular App](#create-an-angular-app)
 - [Install Dependencies](#install-dependencies)
 - [Create Routes](#create-routes)
-  - [`/`](#)
+  - [`/`](#index-page)
   - [`/protected`](#protected)
   - [`/login`](#login)
   - [Connect the Routes](#connect-the-routes)
@@ -80,7 +80,7 @@ Some routes require authentication in order to render. Defining these protected 
 * `/protected`: A protected route that can only be accessed by an authenticated user.
 * `/login`: A custom sign-in page to handle signing users into your app.
 
-### `/`
+### `/ - index page`
 
 First, update `src/app/app.component.html` to provide the Login logic:
 

--- a/packages/@okta/vuepress-site/code/react/okta_react_sign-in_widget/index.md
+++ b/packages/@okta/vuepress-site/code/react/okta_react_sign-in_widget/index.md
@@ -14,7 +14,7 @@ This guide will walk you through integrating authentication into a React app wit
 - [Config](#config)
 - [Create a Widget Wrapper](#create-a-widget-wrapper)
 - [Create Routes](#create-routes)
-  - [`/`](#)
+  - [`/`](#index-page)
   - [`/protected`](#protected)
   - [`/login`](#login)
   - [`/login/callback`](#logincallback)
@@ -140,7 +140,7 @@ Some routes require authentication in order to render. Defining those routes is 
 * `/login`: Show the sign-in page.
 * `/login/callback`: A route to parse tokens after a redirect.
 
-### `/`
+### `/ - index page`
 
 First, create `src/Home.js` to provide links to navigate our app:
 

--- a/packages/@okta/vuepress-site/code/vue/okta_vue_sign-in_widget/index.md
+++ b/packages/@okta/vuepress-site/code/vue/okta_vue_sign-in_widget/index.md
@@ -13,7 +13,7 @@ This guide will walk you through integrating authentication into a Vue app with 
 - [Install Dependencies](#install-dependencies)
 - [Create a Widget Wrapper](#create-a-widget-wrapper)
 - [Create Routes](#create-routes)
-  - [`/`](#)
+  - [`/`](#index-page)
   - [`/profile`](#profile)
   - [`/login`](#login)
   - [`/login/callback`](#logincallback)
@@ -128,7 +128,7 @@ Some routes require authentication in order to render. Defining those routes is 
 * `/login`: Show the sign-in page.
 * `/login/callback`: A route to parse tokens after a redirect.
 
-### `/`
+### `/ - index page`
 
 First, update `src/App.vue` to provide links to navigate your app:
 


### PR DESCRIPTION

## Description:
- Name of  all `/` links in "Create Routes" section of pages which include `_sign-in_widget/` info is changed to `/ - index page`
![image](https://user-images.githubusercontent.com/68992536/121678315-b8079100-cabf-11eb-9f80-dbc4f9da8f8b.png)
![image](https://user-images.githubusercontent.com/68992536/121678364-c48be980-cabf-11eb-8209-63c5775a9636.png)
- Links in upper part of pages where adjusted to new routes

### Resolves:
* [OKTA-397842](https://oktainc.atlassian.net/browse/OKTA-397842)
