### PR TITLE
Remove 404 jcenter link

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app/configure-packages/android/installsdk.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app/configure-packages/android/installsdk.md
@@ -1,4 +1,4 @@
-Use the [Okta OIDC](https://github.com/okta/okta-oidc-android) library available through [JCenter](https://bintray.com/okta/com.okta.android/okta-oidc-android).
+Use the [Okta OIDC](https://github.com/okta/okta-oidc-android).
 
 To install it, add the following to your `build.gradle`:
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app/configure-packages/android/installsdk.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app/configure-packages/android/installsdk.md
@@ -1,4 +1,4 @@
-Use the [Okta OIDC](https://github.com/okta/okta-oidc-android).
+Use the [Okta OIDC library](https://github.com/okta/okta-oidc-android).
 
 To install it, add the following to your `build.gradle`:
 


### PR DESCRIPTION
## Description:
- **What's changed?** Jcenter has shutdown. The link redirects to a 404 page.
- **Is this PR related to a Monolith release?** no

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
