### PR TITLE
Update event property for duplicate hooks

### DIFF
--- a/packages/@okta/vuepress-site/docs/concepts/event-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/event-hooks/index.md
@@ -57,7 +57,7 @@ Information is encapsulated in the JSON payload in the `data.events` object. The
 
 The content of each array element is an object of the [LogEvent](/docs/reference/api/system-log/#example-logevent-object) type. This is the same object that the [System Log API](/docs/reference/api/system-log/) defines for System Log events. See the documentation there for information on the object and its sub-objects.
 
-Delivery of events is best effort. Events are delivered at least once. Delivery may be delayed by network conditions. In some cases, multiple requests may arrive at the same time after a delay, or events may arrive out of order. To establish ordering, you can use the time stamp contained in the `data.events.published` property of each event. To detect duplicated delivery, you can compare the `data.events.uuid` value of incoming events against the values for events previously received.
+Delivery of events is best effort. Events are delivered at least once. Delivery may be delayed by network conditions. In some cases, multiple requests may arrive at the same time after a delay, or events may arrive out of order. To establish ordering, you can use the time stamp contained in the `data.events.published` property of each event. To detect duplicated delivery, you can compare the `eventId` value of incoming events against the values for events previously received.
 
 No guarantee of maximum delay between event occurrence and delivery is currently specified.
 


### PR DESCRIPTION
## Description:
- **What's changed?** Minor change to the Event Hooks Concept. Removing the event property `data.events.uuid` and replacing with `eventId`.
- **Is this PR related to a Monolith release?** No
### Resolves:

* n/a
