### PR TITLE
Switched links to refer to appropriate object

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -713,8 +713,8 @@ The People Condition identifies Users and Groups that are used together. For Pol
 
 | Parameter | Description          | Data Type                                         | Required |
 | ---       | ---                  | ---                                               | ---      |
-| groups    | The Groups condition | [User Condition object](#user-condition-object)   | Yes      |
-| users     | The Users condition  | [Group Condition object](#group-condition-object) | Yes      |
+| groups    | The Groups condition | [Group Condition object](#group-condition-object) | Yes      |
+| users     | The Users condition  | [User Condition object](#user-condition-object) | Yes      |
 
 ##### User Condition object
 


### PR DESCRIPTION
## Description:
- **What's changed?** Fixed two links on the People Condition object of the [Policy API](https://developer.okta.com/docs/reference/api/policy/) reference.
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* [OKTA-407204](https://oktainc.atlassian.net/browse/OKTA-407204)
