### PR TITLE
Move the Dev Blog link to the top level of the menu bar

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/config.js
+++ b/packages/@okta/vuepress-site/.vuepress/config.js
@@ -192,7 +192,6 @@ module.exports = ctx => ({
       { text: 'Community',
         children: [
           { text: 'Forum', link: 'https://devforum.okta.com' },
-          { text: 'Blog', link: 'https://developer.okta.com/blog/' },
           { text: 'Toolkit', link: 'https://toolkit.okta.com/' },
           { text: 'Developer Day', link: 'https://www.okta.com/developerday/' },
           { type: 'divider' },
@@ -205,6 +204,7 @@ module.exports = ctx => ({
           }
         ]
       },
+      { text: 'Developer Blog', link: '/blog/' },
       { text: 'Pricing', link: '/pricing/' },
     ],
     primary_right_nav: [

--- a/packages/@okta/vuepress-site/.vuepress/config.js
+++ b/packages/@okta/vuepress-site/.vuepress/config.js
@@ -204,7 +204,7 @@ module.exports = ctx => ({
           }
         ]
       },
-      { text: 'Developer Blog', link: '/blog/' },
+      { text: 'Blog', link: '/blog/' },
       { text: 'Pricing', link: '/pricing/' },
     ],
     primary_right_nav: [


### PR DESCRIPTION
NOTE: `primary_left_nav` is actually used for the top nav (and hamburger nav)

### Resolves:

* [BD-635](https://oktainc.atlassian.net/browse/BD-635)
