### PR TITLE
Remove group profiles EA banner.

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
@@ -1868,8 +1868,6 @@ Profile for any Group that is not imported from Active Directory. Specifies the 
 ```
 ##### Custom Profile Properties
 
-<ApiLifecycle access="ea" />
-
 You can extend Group Profiles with custom properties, but you must first add the properties to the Group Profile schema before they can be referenced. You can use the Profile Editor in the administrator UI or the [Schemas API](/docs/reference/api/schemas/) to manage schema extensions.
 
 Custom properties may contain HTML tags. It is the client's responsibility to escape or encode this data before displaying it. Use [best-practices](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html) to prevent cross-site scripting.

--- a/packages/@okta/vuepress-site/docs/reference/api/schemas/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/schemas/index.md
@@ -1039,8 +1039,6 @@ curl -v -X POST \
 
 ## Group Schema operations
 
-<ApiLifecycle access="ea" />
-
 The [User Types](/docs/reference/api/user-types) feature doesn't extend to groups. All groups use the same [Group Schema](#group-schema-object). Unlike User Schema operations, Group Schema operations all specify `default` and don't accept a Schema ID.
 
 ### Get Group Schema
@@ -2133,8 +2131,6 @@ Specific property types support a subset of [JSON Schema validations](https://to
 | `array`       | [JSON Array](https://tools.ietf.org/html/rfc7159#section-5)                                                                         |                             |
 
 ## Group Schema object
-
-<ApiLifecycle access="ea" />
 
 The [Group object](/docs/reference/api/groups/#group-object) schema is defined using [JSON Schema Draft 4](https://tools.ietf.org/html/draft-zyp-json-schema-04).
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Remove the EA banner for group profiles since the feature is going GA in preview in the 2021.07.0 release. According to https://github.com/okta/okta-developer-docs/pull/1947, we only added these three EA banners when we added docs for group profiles.
- **Is this PR related to a Monolith release?** 2021.07.0

### Resolves:

* [OKTA-409916](https://oktainc.atlassian.net/browse/OKTA-409916)

@donwoods-okta @daytonwilliams-okta @okta/ud-core 