### PR TITLE
GA "Test Custom Email Templates"

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/email-customization/customize-email-templates/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/email-customization/customize-email-templates/index.md
@@ -30,8 +30,6 @@ Email templates use common and unique [Expression Language (EL) variables](https
 
 ### Test Custom Email Templates
 
-> **Note:** This is an <ApiLifecycle access="ea" /> feature.
-
 You can send yourself a test email to see how a custom email template looks and functions. This can help you validate macro attributes and translations in the customized template as well as see how the template renders in different email environments. This eliminates the need to create a real end-to-end workflow to test customization. The test email is sent to the primary email address of the admin that initiates the test email.
 
 1. Click the email icon to the right of the email template that you have customized. The Send test email dialog box appears and lists who the email is sent to and from what sender the email is coming from.


### PR DESCRIPTION
Removing the EA flag, it is GA in prod for 2021.07.0

## Description:
- **What's changed?** 
- SEND_TEST_EMAIL is now GA in production, so I removed the "EA" badge in this guide. 

- **Is this PR related to a Monolith release?** <!-- If so, which one? -->
- Yes, 2021.07.0, which hit production cells today July 13, 2021

### Resolves:

* https://oktainc.atlassian.net/browse/OKTA-383818
