### PR TITLE
Fixed incomplete blog link in header

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/config.js
+++ b/packages/@okta/vuepress-site/.vuepress/config.js
@@ -130,7 +130,7 @@ module.exports = ctx => ({
         ]
       },
       { text: 'Pricing', link: 'https://www.okta.com/pricing/#customer-identity-products' },
-      { text: 'Blog', link: '/blog/' },
+      { text: 'Blog', link: 'https://developer.okta.com/blog/' },
       { text: 'Support', link: 'https://www.okta.com/contact/',
         children: [
           { text: 'Okta Developer Forum', link: 'https://devforum.okta.com/' },


### PR DESCRIPTION
## Description:
- **What's changed?** 
- added full blog link https://developer.okta.com/blog/ vs /blog/

- **Is this PR related to a Monolith release?** 
- No

### Resolves:

* https://oktainc.atlassian.net/browse/BD-635
