### PR TITLE
adding brands api guide updates

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/custom-error-pages/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-error-pages/overview/index.md
@@ -18,7 +18,7 @@ You can add any HTML, CSS, or JavaScript you want to the page.
 
 ## Use the Brands API
 
-The [Brands API](/docs/reference/api/brands/) is a more recent feature (currently in Early Access) that allows you to set icons, images, and colors across your Okta-hosted sign-in widget, error pages, email templates, and End-User Dashboard all at once, without needing to set a customized Okta URL domain. To find out more about this feature and how to use it, see [Customize your Okta experience with the Brands API](/docs/guides/customize-themes).
+The [Brands API](/docs/reference/api/brands/) is a feature (currently in Early Access) that allows you to set icons, images, and colors across your Okta-hosted Sign-In Widget, error pages, email templates, and Okta End-User Dashboard all at once, without needing to set a customized Okta URL domain. To find out more about this feature and how to use it, see [Customize your Okta experience with the Brands API](/docs/guides/customize-themes).
 
 ## Before you begin
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-error-pages/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-error-pages/overview/index.md
@@ -16,9 +16,13 @@ The error page appears when a critical error occurs or an application is misconf
 
 You can add any HTML, CSS, or JavaScript you want to the page.
 
+## Use the Brands API
+
+The [Brands API](/docs/reference/api/brands/) is a more recent feature (currently in Early Access) that allows you to set icons, images, and colors across your Okta-hosted sign-in widget, error pages, email templates, and End-User Dashboard all at once, without needing to set a customized Okta URL domain. To find out more about this feature and how to use it, see [Customize your Okta experience with the Brands API](/docs/guides/customize-themes).
+
 ## Before you begin
 
-Before you can get started customizing error pages, you must have already [customized your Okta URL domain](/docs/guides/custom-url-domain/).
+Before you can get started customizing error pages, you must have already [customized your Okta URL domain](/docs/guides/custom-url-domain/), unless you are using the Brands API as mentioned above.
 
 A custom error page appears only when an application connects to Okta using your custom domain. Otherwise, the default Okta error page appears.
 

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -12,7 +12,7 @@ This article explains how to use the Brands API to rapidly customize the theme o
 
 Okta provides you with a lot of power to authenticate your users, and using the [Okta-hosted Sign-In Widget](/docs/concepts/hosted-vs-embedded/#okta-hosted-widget) gets you up and running quickly, without having to write much custom code or host the sign-in functionality yourself. However, the trade off is that your [customization options](/docs/guides/style-the-widget/before-you-begin/) are more limited, and potentially tricky to administer (with the existing functionality you tend to need to set colors, icons, and so on, in multiple places).
 
-The [Brands API](/docs/reference/api/brands/) allows you to set all of the following items across your Okta-hosted sign-in widget, error pages, email templates, and End-User Dashboard all at once:
+The [Brands API](/docs/reference/api/brands/) allows you to set all of the following items across your Okta-hosted Sign-In Widget, error pages, email templates, and Okta End-User Dashboard all at once:
 
 * Primary color
 * Secondary color

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -28,7 +28,7 @@ It is up to you how you make requests to the API to update your branding. In thi
 
 1. [Create an API token](/docs/guides/create-an-api-token/overview/) to use when accessing the API.
 1. [Download](https://www.postman.com/downloads/) and install Postman.
-1. Once Postman is installed, import the Okta environment and add your Okta domain and API token to Postman, as explained in [Use Postman with the Okta REST APIs > Set up your environment](/code/rest/#set-up-your-environment).
+1. After you install Postman, import the Okta environment and add your Okta domain and API token to Postman, as explained in [Use Postman with the Okta REST APIs > Set up your environment](/code/rest/#set-up-your-environment).
 1. Click the following button to add the Brands collection to postman, which will allow you to test the API calls described below.
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/1d58ab8a3909dd6a3cfb)

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -55,7 +55,7 @@ This returns an array of [brand response objects](/docs/reference/api/brands/#br
 
 You can also return a specific brand by running the **Get brand** request. Before you run the request, you'll need to set the `brandId` variable in Postman, which is used in the request, as seen below.
 
-  > **Tip:** The easiest way to set a variable in Postman is to highlight the value you want to assign to the variable (for example you can find the ID of a specific brand in the brand response object returned by `GET /api/v1/brands`), right/Ctrl + click on the value, and select **Set: _your-environment-name_ > _your-variable-name_**.
+  > **Tip:** The easiest way to set a variable in Postman is to highlight the value that you want to assign to the variable (for example, you can find the ID of a specific brand in the brand response object returned by `GET /api/v1/brands`), right/Ctrl + click on the value, and select **Set: _your-environment-name_ > _your-variable-name_**.
 
 <ApiOperation method="get" url="/api/v1/brands/{brandId}" />
 

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -121,7 +121,7 @@ A successful request will result in an updated [Theme response object](/docs/ref
 
 ### Update and delete theme logos and images
 
-You can upload a logo, favicon, and background image to be used in your theme (on your email templates, your End-User Dashboard, etc.) with the following requests (**Upload logo**, **Upload favicon**, and **Upload background image** in Postman):
+You can upload a logo, favicon, and background image for use in your theme (on your email templates, your Okta End-User Dashboard, and so on) with the following requests (**Upload logo**, **Upload favicon**, and **Upload background image** in Postman):
 
 <ApiOperation method="post" url="/api/v1/brands/{brandId}/themes/{themeId}/logo" />
 <ApiOperation method="post" url="/api/v1/brands/{brandId}/themes/{themeId}/favicon" />

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -22,7 +22,7 @@ The [Brands API](/docs/reference/api/brands/) allows you to set all of the follo
 
 ## Before you begin
 
-You need to make sure you have an [Okta organization](/docs/guides/quickstart/cli/create-org/) set up to test this functionality, and you need to request access to the Brands API from [Okta support](https://support.okta.com/help).
+You need to make sure that you have an [Okta organization](/docs/guides/quickstart/cli/create-org/) set up to test this functionality, and you need to request access to the Brands API from [Okta support](https://support.okta.com/help).
 
 It is up to you how you make requests to the API to update your branding; we will be demonstrating the required API calls using a Postman collection to demonstrate them in a language/platform neutral way. To run the API calls:
 

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -100,7 +100,7 @@ You can update your theme colors and the settings that dictate where your assets
 
 <ApiOperation method="put" url="/api/v1/brands/{brandId}/themes/{themeId}" />
 
-The request body needs to contain a JSON object along these lines:
+The request body needs to contain a JSON object:
 
 ``` json
 {

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -133,7 +133,7 @@ The request body needs to be form data with a file property that contains a file
 * Favicons must be in PNG or ICO format and must be in 1:1 ratio with a maximum dimension of 512 x 512 px.
 * Background images must be a PNG, JPG, or GIF file, and be less than 2MB in size.
 
-A successful response will result in a JSON object containing the `url` of the uploaded image, e.g.:
+A successful response results in a JSON object that contains the `url` of the uploaded image, such as:
 
 ``` json
 {

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -6,7 +6,7 @@ layout: Guides
 
 <ApiLifecycle access="ea" />
 
-This article explains how to use the Brands API to rapidly customize the theme of your Okta org, including colors, icons, and background images in your Okta-hosted sign-in widget, error pages, email templates, and End-User Dashboard.
+This article explains how to use the Brands API to rapidly customize the theme of your Okta org, including colors, icons, and background images in your Okta-hosted Sign-In Widget, error pages, email templates, and Okta End-User Dashboard.
 
 ## Overview
 

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -90,7 +90,7 @@ Once you've set the `themeId` variable to a specific theme ID, you can return a 
 
 This returns a [theme response object](/docs/reference/api/brands/#theme-response-object) that contains all the details of your theme, including logo, favicon, colors, and background image.
 
-## Updating your theme
+## Update your theme
 
 In this section we'll look at how we can update all of the different facets of your theme.
 

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -10,7 +10,7 @@ This article explains how to use the Brands API to rapidly customize the theme o
 
 ## Overview
 
-Okta provides you with a lot of power to authenticate your users, and using the [Okta-hosted sign-in Widget](/docs/concepts/hosted-vs-embedded/#okta-hosted-widget) you get up and running quickly, without having to write much custom code or host the sign-in functionality yourself. However, the trade off is that your [customization options](/docs/guides/style-the-widget/before-you-begin/) are more limited, and potentially tricky to administer (with the existing functionality you tend to need to set colors, icons, etc. in multiple places).
+Okta provides you with a lot of power to authenticate your users, and using the [Okta-hosted Sign-In Widget](/docs/concepts/hosted-vs-embedded/#okta-hosted-widget) gets you up and running quickly, without having to write much custom code or host the sign-in functionality yourself. However, the trade off is that your [customization options](/docs/guides/style-the-widget/before-you-begin/) are more limited, and potentially tricky to administer (with the existing functionality you tend to need to set colors, icons, and so on, in multiple places).
 
 The [Brands API](/docs/reference/api/brands/) allows you to set all of the following items across your Okta-hosted sign-in widget, error pages, email templates, and End-User Dashboard all at once:
 

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -43,7 +43,7 @@ So for example, if you make changes to the sign-in page code using the editor re
 
 At the top level, Your Okta organization contains a brand, which contains a default theme. The default brand is applied to your organization's subdomain/[custom domain](https://developer.okta.com/docs/guides/custom-url-domain/overview/) if you have specified one.
 
-  > **Note:** At the time of writing each org can only contain one brand and one theme, however we are working on a plan to allow multiple themes and multiple brands per org, so stay tuned!
+  > **Note:** Currently, each org can contain only one brand and one theme. However, we are working on a plan to allow multiple themes and multiple brands per org, so stay tuned!
 
 ### Get brands
 

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -67,7 +67,7 @@ You can also update brand information with the following request (**Update brand
 
 <ApiOperation method="put" url="/api/v1/brands/{brandId}" />
 
-This request needs to contain a [brand object](/docs/reference/api/brands/#brand-object) in the body, which contains updates to privacy policy information:
+This request needs to contain a [brand object](/docs/reference/api/brands/#brand-object) in the body that contains updates to privacy policy information:
 
 ``` json
 {

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -117,7 +117,7 @@ The request body needs to contain a JSON object:
 
   > **Note:** To see your custom colors and image assets being used on your Okta org, you need to set the `...Variant` properties to non-`OKTA_DEFAULT` values when you update your theme. See [Variant definition](/docs/reference/api/brands/#variant-definition) for explanations of the available variant values.
 
-A successful request will result in an updated [Theme response object](/docs/reference/api/brands/#theme-response-object).
+A successful request results in an updated [Theme response object](/docs/reference/api/brands/#theme-response-object).
 
 ### Update and delete theme logos and images
 

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -29,7 +29,7 @@ It is up to you how you make requests to the API to update your branding. In thi
 1. [Create an API token](/docs/guides/create-an-api-token/overview/) to use when accessing the API.
 1. [Download](https://www.postman.com/downloads/) and install Postman.
 1. After you install Postman, import the Okta environment and add your Okta domain and API token to Postman, as explained in [Use Postman with the Okta REST APIs > Set up your environment](/code/rest/#set-up-your-environment).
-1. Click the following button to add the Brands collection to postman, which will allow you to test the API calls described below.
+1. Click **Run in Postman** to add the Brands collection to Postman, which allows you to test the API calls that are described below.
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/1d58ab8a3909dd6a3cfb)
 

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -88,7 +88,7 @@ Once you've set the `themeId` variable to a specific theme ID, you can return a 
 
 <ApiOperation method="get" url="/api/v1/brands/{brandId}/themes/{themeId}" />
 
-This will return a [theme response object](/docs/reference/api/brands/#theme-response-object), which contains all the details of your theme, including logo, favicon, colors, and background image.
+This returns a [theme response object](/docs/reference/api/brands/#theme-response-object) that contains all the details of your theme, including logo, favicon, colors, and background image.
 
 ## Updating your theme
 

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -1,0 +1,155 @@
+---
+title: Customize your Okta experience with the Brands API
+excerpt: How to use the Brands API to rapidly customize the theme of your Okta org
+layout: Guides
+---
+
+<ApiLifecycle access="ea" />
+
+This article explains how to use the Brands API to rapidly customize the theme of your Okta org, including colors, icons, and background images in your Okta-hosted sign-in widget, error pages, email templates, and End-User Dashboard.
+
+## Overview
+
+Okta provides you with a lot of power to authenticate your users, and using the [Okta-hosted sign-in Widget](/docs/concepts/hosted-vs-embedded/#okta-hosted-widget) you get up and running quickly, without having to write much custom code or host the sign-in functionality yourself. However, the trade off is that your [customization options](/docs/guides/style-the-widget/before-you-begin/) are more limited, and potentially tricky to administer (with the existing functionality you tend to need to set colors, icons, etc. in multiple places).
+
+The [Brands API](/docs/reference/api/brands/) allows you to set all of the following items across your Okta-hosted sign-in widget, error pages, email templates, and End-User Dashboard all at once:
+
+* Primary color
+* Secondary color
+* Logo
+* Favicon
+* Background image
+
+## Before you begin
+
+You need to make sure you have an [Okta organization](/docs/guides/quickstart/cli/create-org/) set up to test this functionality, and you need to request access to the Brands API from [Okta support](https://support.okta.com/help).
+
+It is up to you how you make requests to the API to update your branding; we will be demonstrating the required API calls using a Postman collection to demonstrate them in a language/platform neutral way. To run the API calls:
+
+1. [Create an API token](/docs/guides/create-an-api-token/overview/) to use when accessing the API.
+1. [Download](https://www.postman.com/downloads/) and Install Postman.
+1. Once Postman is installed, import the Okta environment and add your Okta domain and API token to Postman, as explained in [Use Postman with the Okta REST APIs > Set up your environment](/code/rest/#set-up-your-environment).
+1. Click the following button to add the Brands collection to postman, which will allow you to test the API calls described below.
+
+[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/1d58ab8a3909dd6a3cfb)
+
+## Important: overriding themes in the code template editors
+
+You can customize individual parts of your Okta org experience using the various code editors we've made available in the Okta Admin UI (for example **Settings** > **Customizations** > **Custom Sign-in** to customize the Okta-hosted sign-in page. Please note that when you use the Brands API, your custom brand settings will not apply to the places where you've customized the theme settings.
+
+So for example, if you make changes to the sign-in page code using the editor referenced above and change the background image or logo setting, your customizations will override the Brands API settings. To get your Brands API settings back, you will have to reset the code editors to the default code again.
+
+## Top-level overview: Brands and themes
+
+At the top level, Your Okta organization contains a brand, which contains a default theme. The default brand is applied to your organization's subdomain/[custom domain](https://developer.okta.com/docs/guides/custom-url-domain/overview/) if you have specified one.
+
+  > **Note:** At the time of writing each org can only contain one brand and one theme, however we are working on a plan to allow multiple themes and multiple brands per org, so stay tuned!
+
+### Get brands
+
+You can return the brands with the following request (**Get brands** in Postman):
+
+<ApiOperation method="get" url="/api/v1/brands" />
+
+This returns an array of [brand response objects](/docs/reference/api/brands/#brand-response-object). You can try this in Postman by running the Get brands request.
+
+You can also return a specific brand by running the **Get brand** request. Before you run the request, you'll need to set the `brandId` variable in Postman, which is used in the request, as seen below.
+
+  > **Tip:** The easiest way to set a variable in Postman is to highlight the value you want to assign to the variable (for example you can find the ID of a specific brand in the brand response object returned by `GET /api/v1/brands`), right/Ctrl + click on the value, and select **Set: _your-environment-name_ > _your-variable-name_**.
+
+<ApiOperation method="get" url="/api/v1/brands/{brandId}" />
+
+This returns a single brand response object.
+
+### Get brands
+
+You can also update brand information with the following request (**Update brand** in Postman):
+
+<ApiOperation method="put" url="/api/v1/brands/{brandId}" />
+
+This request needs to contain a [brand object](/docs/reference/api/brands/#brand-object) in the body, which contains updates to privacy policy information:
+
+``` json
+{
+  "agreeToCustomPrivacyPolicy": true,
+  "customPrivacyPolicyUrl": "https://www.someHost.com/privacy-policy"
+}
+```
+
+### Get themes
+
+You can return the themes contained in a brand with the following request (**Get themes** in postman):
+
+<ApiOperation method="put" url="/api/v1/brands/{brandId}/themes" />
+
+This returns an array of [theme response objects](/docs/reference/api/brands/#theme-response-object).
+
+Once you've set the `themeId` variable to a specific theme ID, you can return a specific theme response object using the following request (**Get theme** in Postman):
+
+<ApiOperation method="get" url="/api/v1/brands/{brandId}/themes/{themeId}" />
+
+This will return a [theme response object](/docs/reference/api/brands/#theme-response-object), which contains all the details of your theme, including logo, favicon, colors, and background image.
+
+## Updating your theme
+
+In this section we'll look at how we can update all of the different facets of your theme.
+
+### Update theme colors and asset placement
+
+You can update your theme colors and the settings that dictate where your assets will be used with the following request (**Update theme** in Postman):
+
+<ApiOperation method="put" url="/api/v1/brands/{brandId}/themes/{themeId}" />
+
+The request body needs to contain a JSON object along these lines:
+
+``` json
+{
+  "primaryColorHex": "#1662dd",
+  "secondaryColorHex": "#ebebed",
+  "signInPageTouchPointVariant": "BACKGROUND_IMAGE",
+  "endUserDashboardTouchPointVariant": "FULL_THEME",
+  "errorPageTouchPointVariant": "BACKGROUND_IMAGE",
+  "emailTemplateTouchPointVariant": "FULL_THEME"
+}
+```
+
+  > **Note:** The different properties are explained in the [Theme object reference](/docs/reference/api/brands/#theme-object).
+
+  > **Note:** To see your custom colors and image assets being used on your Okta org, you need to set the `...Variant` properties to non-`OKTA_DEFAULT` values when you update your theme. See [Variant Definition](/docs/reference/api/brands/#variant-definition) for explanations of the available variant values.
+
+A successful request will result in an updated [Theme response object](/docs/reference/api/brands/#theme-response-object).
+
+### Update and delete theme logos and images
+
+You can upload a logo, favicon, and background image to be used in your theme (on your email templates, your End-User Dashboard, etc.) with the following requests (**Upload logo**, **Upload favicon**, and **Upload background image** in Postman):
+
+<ApiOperation method="post" url="/api/v1/brands/{brandId}/themes/{themeId}/logo" />
+<ApiOperation method="post" url="/api/v1/brands/{brandId}/themes/{themeId}/favicon" />
+<ApiOperation method="post" url="/api/v1/brands/{brandId}/themes/{themeId}/background-image" />
+
+The request body needs to be form-data, with a file property containing a file to upload. Guidelines are as follows:
+
+* Logos must be in PNG, JPG, or GIF format and less than 1 MB in size. The file dimensions should be less than 3840 x 2160 px. For best results use landscape orientation, a transparent background, and a minimum size of 420px by 120px to prevent upscaling.
+* Favicons must be in PNG or ICO format and must be in 1:1 ratio with a maximum dimension of 512 x 512 px.
+* Background images must be a PNG, JPG, or GIF file, and be less than 2MB in size.
+
+A successful response will result in a JSON object containing the `url` of the uploaded image, e.g.:
+
+``` json
+{
+  "url": "https://${yourOktaDomain}/assets/img/logos/okta-logo.47066819ac7db5c13f4c431b2687cef6.png"
+}
+```
+
+You can also delete these assets using the following requests (**Delete logo**, **Delete favicon**, and **Delete background image** in Postman):
+
+<ApiOperation method="delete" url="/api/v1/brands/{brandId}/themes/{themeId}/logo" />
+<ApiOperation method="delete" url="/api/v1/brands/{brandId}/themes/{themeId}/favicon" />
+<ApiOperation method="delete" url="/api/v1/brands/{brandId}/themes/{themeId}/background-image" />
+
+## See also
+
+* [Brands API reference](/docs/reference/api/brands/)
+* [Customize the Okta-hosted error pages](/docs/guides/custom-error-pages/overview/)
+* [Customize email notifications and email domains](/docs/guides/email-customization/before-you-begin/)
+* [Style the Okta-hosted Sign-In Widget](/docs/guides/style-the-widget/style-okta-hosted/)

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -37,7 +37,7 @@ It is up to you how you make requests to the API to update your branding. In thi
 
 You can customize individual parts of your Okta org experience using the various code editors we've made available in the Okta Admin Console (for example, **Settings** > **Customizations** > **Custom Sign-in** to customize the Okta-hosted sign-in page). Note that when you use the Brands API, your custom brand settings won't apply to the places where you've customized the theme settings.
 
-So for example, if you make changes to the sign-in page code using the editor referenced above and change the background image or logo setting, your customizations will override the Brands API settings. To get your Brands API settings back, you will have to reset the code editors to the default code again.
+So for example, if you make changes to the sign-in page code using the editor referenced above and change the background image or logo setting, your customizations override the Brands API settings. To get your Brands API settings back, reset the code editors to the default code again.
 
 ## Top-level overview: Brands and themes
 

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -27,7 +27,7 @@ You need to make sure that you have an [Okta organization](/docs/guides/quicksta
 It is up to you how you make requests to the API to update your branding. In this guide, we are demonstrating the required API calls using a Postman collection to demonstrate them in a language/platform neutral way. To run the API calls:
 
 1. [Create an API token](/docs/guides/create-an-api-token/overview/) to use when accessing the API.
-1. [Download](https://www.postman.com/downloads/) and Install Postman.
+1. [Download](https://www.postman.com/downloads/) and install Postman.
 1. Once Postman is installed, import the Okta environment and add your Okta domain and API token to Postman, as explained in [Use Postman with the Okta REST APIs > Set up your environment](/code/rest/#set-up-your-environment).
 1. Click the following button to add the Brands collection to postman, which will allow you to test the API calls described below.
 

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -127,7 +127,7 @@ You can upload a logo, favicon, and background image for use in your theme (on y
 <ApiOperation method="post" url="/api/v1/brands/{brandId}/themes/{themeId}/favicon" />
 <ApiOperation method="post" url="/api/v1/brands/{brandId}/themes/{themeId}/background-image" />
 
-The request body needs to be form-data, with a file property containing a file to upload. Guidelines are as follows:
+The request body needs to be form data with a file property that contains a file to upload. Guidelines are as follows:
 
 * Logos must be in PNG, JPG, or GIF format and less than 1 MB in size. The file dimensions should be less than 3840 x 2160 px. For best results use landscape orientation, a transparent background, and a minimum size of 420px by 120px to prevent upscaling.
 * Favicons must be in PNG or ICO format and must be in 1:1 ratio with a maximum dimension of 512 x 512 px.

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -24,7 +24,7 @@ The [Brands API](/docs/reference/api/brands/) allows you to set all of the follo
 
 You need to make sure that you have an [Okta organization](/docs/guides/quickstart/cli/create-org/) set up to test this functionality, and you need to request access to the Brands API from [Okta support](https://support.okta.com/help).
 
-It is up to you how you make requests to the API to update your branding; we will be demonstrating the required API calls using a Postman collection to demonstrate them in a language/platform neutral way. To run the API calls:
+It is up to you how you make requests to the API to update your branding. In this guide, we are demonstrating the required API calls using a Postman collection to demonstrate them in a language/platform neutral way. To run the API calls:
 
 1. [Create an API token](/docs/guides/create-an-api-token/overview/) to use when accessing the API.
 1. [Download](https://www.postman.com/downloads/) and Install Postman.

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -92,7 +92,7 @@ This returns a [theme response object](/docs/reference/api/brands/#theme-respons
 
 ## Update your theme
 
-In this section we'll look at how we can update all of the different facets of your theme.
+In this section we look at how we can update all of the different facets of your theme.
 
 ### Update theme colors and asset placement
 

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -35,7 +35,7 @@ It is up to you how you make requests to the API to update your branding. In thi
 
 ## Important: overriding themes in the code template editors
 
-You can customize individual parts of your Okta org experience using the various code editors we've made available in the Okta Admin UI (for example **Settings** > **Customizations** > **Custom Sign-in** to customize the Okta-hosted sign-in page. Please note that when you use the Brands API, your custom brand settings will not apply to the places where you've customized the theme settings.
+You can customize individual parts of your Okta org experience using the various code editors we've made available in the Okta Admin Console (for example, **Settings** > **Customizations** > **Custom Sign-in** to customize the Okta-hosted sign-in page). Note that when you use the Brands API, your custom brand settings won't apply to the places where you've customized the theme settings.
 
 So for example, if you make changes to the sign-in page code using the editor referenced above and change the background image or logo setting, your customizations will override the Brands API settings. To get your Brands API settings back, you will have to reset the code editors to the default code again.
 

--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -115,7 +115,7 @@ The request body needs to contain a JSON object:
 
   > **Note:** The different properties are explained in the [Theme object reference](/docs/reference/api/brands/#theme-object).
 
-  > **Note:** To see your custom colors and image assets being used on your Okta org, you need to set the `...Variant` properties to non-`OKTA_DEFAULT` values when you update your theme. See [Variant Definition](/docs/reference/api/brands/#variant-definition) for explanations of the available variant values.
+  > **Note:** To see your custom colors and image assets being used on your Okta org, you need to set the `...Variant` properties to non-`OKTA_DEFAULT` values when you update your theme. See [Variant definition](/docs/reference/api/brands/#variant-definition) for explanations of the available variant values.
 
 A successful request will result in an updated [Theme response object](/docs/reference/api/brands/#theme-response-object).
 

--- a/packages/@okta/vuepress-site/docs/guides/email-customization/before-you-begin/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/email-customization/before-you-begin/index.md
@@ -10,7 +10,7 @@ Email notifications are based on templates that are generated automatically and 
 
 ## Use the Brands API
 
-The [Brands API](/docs/reference/api/brands/) is a more recent feature (currently in Early Access) that allows you to set icons, images, and colors across your Okta-hosted sign-in widget, error pages, email templates, and End-User Dashboard all at once, without needing to set a customized Okta URL domain. To find out more about this feature and how to use it, see [Customize your Okta experience with the Brands API](/docs/guides/customize-themes).
+The [Brands API](/docs/reference/api/brands/) is a feature (currently in Early Access) that allows you to set icons, images, and colors across your Okta-hosted Sign-In Widget, error pages, email templates, and Okta End-User Dashboard all at once, without needing to set a customized Okta URL domain. To find out more about this feature and how to use it, see [Customize your Okta experience with the Brands API](/docs/guides/customize-themes).
 
 ## Caveats
 

--- a/packages/@okta/vuepress-site/docs/guides/email-customization/before-you-begin/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/email-customization/before-you-begin/index.md
@@ -8,6 +8,10 @@ You can customize and style the default email notifications that Okta sends to e
 
 Email notifications are based on templates that are generated automatically and sent to end users according to your settings. Okta email templates contain text for account activation, password reset, and account unlock scenarios and are available in each Okta-supported language. You can use the default email templates as is, or you can edit the email template text to send end users custom Okta-generated email messages.
 
+## Use the Brands API
+
+The [Brands API](/docs/reference/api/brands/) is a more recent feature (currently in Early Access) that allows you to set icons, images, and colors across your Okta-hosted sign-in widget, error pages, email templates, and End-User Dashboard all at once, without needing to set a customized Okta URL domain. To find out more about this feature and how to use it, see [Customize your Okta experience with the Brands API](/docs/guides/customize-themes).
+
 ## Caveats
 
 * Email templates must be under 64 KB. This is approximately 65,000 single-byte characters for all text, HTML, and CSS characters in the template. UTF-8 characters can be as large as 4 bytes each, so fewer characters are accepted.

--- a/packages/@okta/vuepress-site/docs/guides/style-the-widget/style-okta-hosted/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/style-the-widget/style-okta-hosted/index.md
@@ -41,7 +41,7 @@ If you are familiar with using HTML and want to change the page layout, colors, 
 
 ### Use the Brands API
 
-The [Brands API](/docs/reference/api/brands/) is a more recent feature (currently in Early Access) that allows you to set icons, images, and colors across your Okta-hosted sign-in widget, error pages, email templates, and End-User Dashboard all at once, without needing to set a customized Okta URL domain. To find out more about this feature and how to use it, see [Customize your Okta experience with the Brands API](/docs/guides/customize-themes).
+The [Brands API](/docs/reference/api/brands/) is a feature (currently in Early Access) that allows you to set icons, images, and colors across your Okta-hosted sign-in widget, error pages, email templates, and End-User Dashboard all at once, without needing to set a customized Okta URL domain. To find out more about this feature and how to use it, see [Customize your Okta experience with the Brands API](/docs/guides/customize-themes).
 
 ### Bypass the Custom Sign-In Page
 

--- a/packages/@okta/vuepress-site/docs/guides/style-the-widget/style-okta-hosted/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/style-the-widget/style-okta-hosted/index.md
@@ -4,7 +4,7 @@ title: Style the Okta-hosted Sign-In Widget
 
 You can add any HTML, CSS, or JavaScript to the sign-in page and also customize the sign-in page <GuideLink link="../customization-examples/#per-application-customization">per application</GuideLink> and with multiple brands. This page covers what you can change when you are using the Okta-hosted Sign-In Widget, how to use the macros and request context, and also how to bypass the custom sign-in page.
 
-> **Note:** Before you can get started customizing the Okta-hosted sign-in page, you must have already customized your [Okta URL domain](/docs/guides/custom-url-domain/).
+> **Note:** Before you can get started customizing the Okta-hosted sign-in page, you must have already customized your [Okta URL domain](/docs/guides/custom-url-domain/), unless you are using the [Brands API](/docs/guides/customize-themes) as mentioned below.
 
 ### Edit the sign-in page
 
@@ -38,6 +38,10 @@ If you are familiar with using HTML and want to change the page layout, colors, 
 4. Click **Save and Publish** when you finish.
 
 > **Note:** See the <GuideLink link="../customization-examples">Customization examples</GuideLink> section for examples that you can alter and use on your hosted sign-in page.
+
+### Use the Brands API
+
+The [Brands API](/docs/reference/api/brands/) is a more recent feature (currently in Early Access) that allows you to set icons, images, and colors across your Okta-hosted sign-in widget, error pages, email templates, and End-User Dashboard all at once, without needing to set a customized Okta URL domain. To find out more about this feature and how to use it, see [Customize your Okta experience with the Brands API](/docs/guides/customize-themes).
 
 ### Bypass the Custom Sign-In Page
 

--- a/packages/@okta/vuepress-theme-prose/const/navbar.const.js
+++ b/packages/@okta/vuepress-theme-prose/const/navbar.const.js
@@ -302,6 +302,10 @@ export const guides = [
           {
             title: "Customize email notifications and email domains",
             guideName: "email-customization"
+          },
+          {
+            title: "Customize themes",
+            path: "/docs/guides/customize-themes/"
           }
         ]
       },


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->

As per https://oktainc.atlassian.net/browse/OKTA-413691, we wanted to add to our guide content to explain how to use the new Brands API to update your okta org theme (colors, icon, etc.)

I chose to add a single guide that explains all of what the Brands API can do, and then link to it from all the places where knowing about it would be useful (e.g. the guide to updating email templates, error pages, etc.)

- **Is this PR related to a Monolith release?** Yes. 2021.08.0<!-- If so, which one? -->

### Resolves:

* [OKTA-413691](https://oktainc.atlassian.net/browse/OKTA-413691)
