### PR TITLE
Update API Design Principles - Link header section

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api-overview/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api-overview/index.md
@@ -183,22 +183,18 @@ Pagination links are included in the [Link header](http://tools.ietf.org/html/rf
 
 ``` http
 HTTP/1.1 200 OK
-Link: <https://${yourOktaDomain}/api/v1/users?after=00ubfjQEMYBLRUWIEDKK>; rel="next",
-  <https://${yourOktaDomain}/api/v1/users?after=00ub4tTFYKXCCZJSGFKM>; rel="self"
+link: <https://${yourOktaDomain}/api/v1/logs?limit=20>; rel="self"
+link: <https://${yourOktaDomain}/api/v1/logs?limit=20&after=1627500044869_1>; rel="next"
 ```
 
 The possible `rel` values are:
 
 | Link relation type | Description                                              |
 | ------------------ | ------------                                             |
-| `next`             | Specifies the URL of the immediate next page of results |
 | `self`             | Specifies the URL of the current page of results         |
+| `next`             | Specifies the URL of the immediate next page of results |
 
-When you first make an API call and get a cursor-paged list of objects, the end of the list is the point at which you don't receive another `next` link value with the response. This holds true for all but two cases:
-
-1. [Events API](/docs/reference/api/events): The `next` link always exists, since the [Events API](/docs/reference/api/events/) is like a stream of data with a cursor.
-
-2. [System Log API](/docs/reference/api/system-log/): The `next` link always exists in polling queries in the [System Log API](/docs/reference/api/system-log/). A polling query is defined as an `ASCENDING` query with an empty or absent `until` parameter. Like in the [Events API](/docs/reference/api/events/), the polling query is a stream of data.
+When you first make an API call and get a cursor-paged list of objects, the end of the list is the point at which you don't receive another `next` link value with the response. This holds true for all cases, except for the [System Log API](/docs/reference/api/system-log/), where the `next` link always exists in [System Log](/docs/reference/api/system-log/#list-events) polling queries. A polling query is defined as an `ASCENDING` query with an empty or absent `until` parameter, providing a stream of data.
 
 ## Filter
 


### PR DESCRIPTION
## Description:
- **What's changed?** Updated Link header section of the "API Design Principles" page to have 2 separate link header lines and removed references to the Events API.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-406097](https://oktainc.atlassian.net/browse/OKTA-406097)
