### PR TITLE
Mark the risk providers, risk events API as EA

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/config.js
+++ b/packages/@okta/vuepress-site/.vuepress/config.js
@@ -307,13 +307,13 @@ module.exports = ctx => ({
           userAgent: '*',
           crawlDelay: 10,
           disallow: [
-              '/docs/guides/third-party-risk-integration/', //Beta release of Risk APIs and Guide
-              '/docs/guides/third-party-risk-integration/overview/',
-              '/docs/guides/third-party-risk-integration/create-service-app/',
-              '/docs/guides/third-party-risk-integration/update-default-provider/',
-              '/docs/guides/third-party-risk-integration/test-integration/',
-              '/docs/reference/api/risk-providers/',
-              '/docs/reference/api/risk-events/',
+              //'/docs/guides/third-party-risk-integration/', //EA release of Risk APIs and Guide 2021.08.0
+              //'/docs/guides/third-party-risk-integration/overview/',
+              //'/docs/guides/third-party-risk-integration/create-service-app/',
+              //'/docs/guides/third-party-risk-integration/update-default-provider/',
+              //'/docs/guides/third-party-risk-integration/test-integration/',
+              //'/docs/reference/api/risk-providers/',
+              //'/docs/reference/api/risk-events/',
               '/docs/reference/api/iam-roles/',
               '/docs/concepts/role-assignment/',
               '/docs/guides/migrate-to-oie/',

--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/overview/index.md
@@ -2,7 +2,7 @@
 title: Third-party risk provider integration overview
 ---
 
-<ApiLifecycle access="beta" />
+<ApiLifecycle access="ea" />
 
 The Okta Risk Engine evaluates authentication attempts by reviewing the risk score of the sign-in based on context and historical data. Using Okta Risk APIs, third-party risk providers can integrate with the Okta Risk Engine using a standard Okta service application. The third-party risk provider can send risk events, which can be used when calculating the authentication risk based on the risk policy configured in the Okta org. The risk events are additionally logged as part of the System Log.
 

--- a/packages/@okta/vuepress-site/docs/reference/api/risk-events/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/risk-events/index.md
@@ -1,11 +1,10 @@
 ---
 title: Risk Events
-category: beta
 ---
 
 # Risk Events API
 
-<ApiLifecycle access="beta" />
+<ApiLifecycle access="ea" />
 
 The Okta Risk Events API provides the ability for third-party Risk Providers to send Risk Events to Okta.
 

--- a/packages/@okta/vuepress-site/docs/reference/api/risk-providers/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/risk-providers/index.md
@@ -1,11 +1,10 @@
 ---
 title: Risk Providers
-category: beta
 ---
 
 # Risk Providers API
 
-<ApiLifecycle access="beta" />
+<ApiLifecycle access="ea" />
 
 The Okta Risk Providers API provides the ability to manage the Risk Providers within Okta.
 

--- a/packages/@okta/vuepress-theme-prose/const/navbar.const.js
+++ b/packages/@okta/vuepress-theme-prose/const/navbar.const.js
@@ -341,6 +341,10 @@ export const guides = [
           {
             title: "Configure an access policy",
             guideName: "configure-access-policy"
+          },
+          {
+            title: "Integrate Third-Party Risk",
+            guideName: "third-party-risk-integration"
           }
         ]
       },
@@ -644,6 +648,8 @@ export const reference = [
           { title: "MyAccount", path: "/docs/reference/api/myaccount/" },
           { title: "Org", path: "/docs/reference/api/org/" },
           { title: "Policy", path: "/docs/reference/api/policy/" },
+          { title: "Risk Events", path: "/docs/reference/api/risk-events/" },
+          { title: "Risk Providers", path: "/docs/reference/api/risk-providers/" },
           { title: "Schemas", path: "/docs/reference/api/schemas/" },
           { title: "Sessions", path: "/docs/reference/api/sessions/" },
           { title: "System Log", path: "/docs/reference/api/system-log/" },


### PR DESCRIPTION
Related to OKTA-415576


## Description:
- **What's changed?**  -- Marking an API as Early Access.
- **Is this PR related to a Monolith release?** Yes, 2021.08.0 (the feature flag is going EA in that release).

### Resolves:

* [OKTA-415576](https://oktainc.atlassian.net/browse/OKTA-415576)
