### PR TITLE
[OKTA-418015] Fix "Go Samples on GitHub" link in go/create-app.md

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/protect-your-api/before-you-begin/go/create-app.md
+++ b/packages/@okta/vuepress-site/docs/guides/protect-your-api/before-you-begin/go/create-app.md
@@ -1,3 +1,3 @@
 The [Golang getting started guide](https://golang.org/doc/install) teaches you how to get started with Golang and create your first app.
 
-Or, if you want to skip this guide and just download a working sample app, download our [Go Samples on GitHub](https://github.com/okta/samples-golang/tree/develop/resource-server).
+Or, if you want to skip this guide and just download a working sample app, download our [Go Samples on GitHub](https://github.com/okta/samples-golang/tree/master/resource-server).


### PR DESCRIPTION
## Description:
From https://developer.okta.com/docs/guides/protect-your-api/go/before-you-begin/, looks like https://github.com/okta/samples-golang/tree/develop/resource-server doesn't exist, proposing changing to https://github.com/okta/samples-golang/tree/master/resource-server.

### Resolves:

* [OKTA-418015](https://oktainc.atlassian.net/browse/OKTA-418015)
