### PR TITLE
typo

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
@@ -62,7 +62,7 @@ In addition to referencing user attributes, you can also reference App propertie
 
 | Syntax           | Definitions                                                             | Examples     |
 | --------         | ----------                                                              | ------------ |
-| `org.$attribute` | `org` reference to Okta org<br>`$attribute` the attribute variable name | org.name<br>org.subdomain   |
+| `org.$attribute` | `org` reference to Okta org<br>`$attribute` the attribute variable name | org.name<br>org.subDomain   |
 
 ## Referencing Session Properties
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- Typo in EL doc where `subdomain` should be `subDomain`

### Resolves:

* [OKTA-420106](https://oktainc.atlassian.net/browse/OKTA-420106)
