### PR TITLE
Add missing status property to Authenticators doc

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/authenticators-admin/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/authenticators-admin/index.md
@@ -534,6 +534,7 @@ The Authenticator object defines the following properties:
 | `created`     | String (ISO-8601)                                               | Timestamp when the Authenticator was created                                   |
 | `id`          | String                                                          | A unique identifier for the Authenticator                                                |
 | `key`         | String                                                          | A human-readable string that identifies the Authenticator                                |
+| `status`      | `ACTIVE`,`INACTIVE`                                             | Status of the Authenticator                                |
 | `lastUpdated` | String (ISO-8601)                                               | Timestamp when the Authenticator was last modified                             |
 | `name`        | String                                                          | Display name of this Authenticator                                             |
 | `type`        | String (Enum)                                                   | The type of Authenticator. Values include: `password`, `security_question`, `phone`, `email`, and `security_key`.                            |


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
Added missing property `status` to `Authenticator` documentation [here](https://developer.okta.com/docs/reference/api/authenticators-admin/).
