### PR TITLE
Update index.md

### DIFF
--- a/packages/@okta/vuepress-site/code/javascript/okta_sign-in_widget/index.md
+++ b/packages/@okta/vuepress-site/code/javascript/okta_sign-in_widget/index.md
@@ -53,8 +53,6 @@ import '@okta/okta-signin-widget/dist/css/okta-sign-in.min.css';
 
 Because the Widget will be making cross-origin requests, you need to enable Cross Origin Access (CORS) by adding your application's URL to your Okta org's Trusted Origins (in **API** > **Trusted Origins**). More information about this can be found on the [Enable CORS](/docs/guides/enable-cors/) page.
 
-> If you are using the Widget to sign users in to your own application, then you can skip this step. When you create an Application in Okta, you need to specify a `redirectURI`, and the Okta Admin Console automatically adds it as a CORS URL.
-
 ## Usage
 
 Once you have installed the Widget and enabled CORS, you can start using it.


### PR DESCRIPTION
## Description:
- **What's changed?** Removed the line implying you no longer need to configure a Trusted Origin if you add a "Login redirect URI" to an application in the admin console. This was only true in the Developer console and now you MUST add the domain to Trusted Origins for the widget to work no matter what.
- **Is this PR related to a Monolith release?** No