### PR TITLE
Modify Developer docs to change RL of api/v1/orgs from 50 to 25

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/rl-previous/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/rl-previous/index.md
@@ -52,7 +52,7 @@ Extensions to the base URLs listed below are included in the specified limit, un
 | Get a user by user ID or login (combined) | `/api/v1/users/{id}` or `/api/v1/users/{login}`  only                   | 2000                          |
 | Get my user                               | `/api/v1/users/me`                                                      | 1000                          |
 | Update or delete a user by ID             | `/api/v1/users/{id}` only                                               | 600                           |
-| Create an org (ISVs only)                 | `/api/v1/orgs`                                                          | 50                            |
+| Create an org (ISVs only)                 | `/api/v1/orgs`                                                          | 25                            |
 | All other actions                         | `/api/v1/`                                                              | 1000                          |
 
 ## Concurrent rate limits (legacy orgs)


### PR DESCRIPTION
Docs for : OKTA:406663

<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- Modified Rate Limit of api/v1/orgs endpoint form 50 to 25
- Changes part of 2021.09.0 release

### Resolves:

* [OKTA-422919 ](https://oktainc.atlassian.net/browse/OKTA-422919 )
