### PR TITLE
Minor updates to Hook API Reference pages

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/password-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/password-hook/index.md
@@ -31,7 +31,7 @@ The Password Import Inline Hook is triggered when the end user tries to sign in 
 
 If your service returns a response that indicates that the password is valid, Okta sets the password for the user and won't normally need to call your service again. However, if the Okta service is in read-only mode, it might not be possible to set the password. Okta then needs to call your service again the next time the end user attempts to signs in. See [Password Inline Hook and Okta Service Mode](#password-inline-hook-and-okta-service-mode) and [Removing Password from Existing User Store](#removing-password-from-existing-user-store) for details.
 
->**Note:** If a response to the Password Import Inline Hook request is not received from your external service within 3 seconds, a timeout occurs. In this scenario, the Okta process flow stops and the user can't sign in. The password is not imported and the Inline Hook is called the next time the end user attempts to sign in.
+>**Note:** Password policies do not apply to the Password Import Inline Hook. That is, if your external service validates the password, the password imports even if it does not meet the Okta [password policy](/docs/reference/api/policy/#password-policy) requirements.
 
 ## Objects in the request from Okta
 
@@ -103,7 +103,7 @@ If the default action sent by Okta in the `action.credential` property of the re
 
 ## Timeout behavior
 
-If the external service times out after receiving an Okta request, the end-user can't sign in, and the password is not imported.
+If a response to the Password Import Inline Hook request is not received from your external service within 3 seconds, a timeout occurs. In this scenario, the Okta process flow stops and the user can't sign in. The password is not imported and the Inline Hook is called the next time the end user attempts to sign in.
 
 ## Sample JSON payload of request
 

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -19,9 +19,9 @@ For a general introduction to Okta Inline Hooks, see [Inline Hooks](/docs/concep
 
 For information on the API for registering external service endpoints with Okta, see [Inline Hooks Management API](/docs/reference/api/inline-hooks/).
 
-For steps to enable this Inline Hook, see below, [Enabling a Registration Inline Hook](#enabling-a-registration-inline-hook-for-profile-enrollment). <ApiLifecycle access="ie" /><br>
+For steps to enable this Inline Hook, see below, [Enabling a Registration Inline Hook](#enable-a-registration-inline-hook-for-profile-enrollment-in-okta-identity-engine). <ApiLifecycle access="ie" /><br>
 
-For steps to enable this Inline Hook in Okta classic, see below, [Enabling a Registration Inline Hook in Okta Classic](#enabling-a-registration-inline-hook-for-self-service-registration-in-okta-classic).
+For steps to enable this Inline Hook in Okta classic, see below, [Enabling a Registration Inline Hook in Okta Classic](#enable-a-registration-inline-hook-for-self-service-registration-in-okta-classic)
 
 For an example implementation of this Inline Hook, see [Registration Inline Hook](/docs/guides/registration-inline-hook).
 


### PR DESCRIPTION

## Description:
- **What's changed?** Fixed broken anchors on the Registration Inline Hook API reference page (top-level to both enabling procedures); updated the Password Import Inline Hook API reference to include a new note that state password policies are not applied (also moved an existing note to the Timeout Behavior heading.
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* [OKTA-410177](https://oktainc.atlassian.net/browse/OKTA-410177)
