### PR TITLE
OKTA-425097 Proper engine naming

### DIFF
--- a/packages/@okta/vuepress-site/code/oie/index.md
+++ b/packages/@okta/vuepress-site/code/oie/index.md
@@ -9,17 +9,17 @@ title: Okta Identity Engine SDKs & Samples
 
 ## What's new
 
-[Okta Identity Engine](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie) introduces new identity management capabilities with greater flexibility and customization. To take advantage of these new features and for a better development experience, use the Okta Identity Engine SDKs to manage authentication in your apps. These new SDKs are recommended for orgs using Okta Identity Engine.
+[Okta Identity Engine](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie) introduces new identity management capabilities with greater flexibility and customization. To take advantage of these new features and for a better development experience, use the Identity Engine SDKs to manage authentication in your apps. These new SDKs are recommended for orgs using the Identity Engine.
 
-Experiment with sample apps that showcase Okta Identity Engine using the following [authentication approaches](/docs/concepts/redirect-vs-embedded/):
+Experiment with sample apps that showcase the Identity Engine using the following [authentication approaches](/docs/concepts/redirect-vs-embedded/):
 
 * **Redirect**: These sample apps demonstrate how to redirect users to an Okta-hosted sign-in page, and then receive users redirected back from Okta after users sign in. This approach is recommended for most developers, as it is easier to build and maintain.
 
 * **Embedded**: These sample apps demonstrate how to embed the Okta Sign-In Widget in an app as a package dependency.
 
-Learn how to implement each approach with these Okta Identity Engine SDKs and sample apps in the [Redirect authentication guide](/docs/guides/sampleapp-oie-redirectauth/), [Embedded authentication with SDK guide](/docs/guides/oie-embedded-sdk-overview/), and [Embedded authentication with Sign-In Widget guide](/docs/guides/oie-embedded-widget-overview/).
+Learn how to implement each approach with these Identity Engine SDKs and sample apps in the [Redirect authentication guide](/docs/guides/sampleapp-oie-redirectauth/), [Embedded authentication with SDK guide](/docs/guides/oie-embedded-sdk-overview/), and [Embedded authentication with Sign-In Widget guide](/docs/guides/oie-embedded-widget-overview/).
 
-Orgs using Okta Identity Engine can also continue to use current SDKs and tools. You can find those SDKs for your stack from the [Languages & SDKs overview](/code/).
+Orgs using the Identity Engine can also continue to use current SDKs and tools. You can find those SDKs for your stack from the [Languages & SDKs overview](/code/).
 
 ## Repository
 
@@ -27,13 +27,13 @@ Orgs using Okta Identity Engine can also continue to use current SDKs and tools.
 
 ##### Android
 
-* [Java Okta Identity Engine SDK](https://github.com/okta/okta-idx-java)
+* [Identity Engine Java SDK](https://github.com/okta/okta-idx-java)
 * [Android embedded authentication with SDK sample app](https://github.com/okta/okta-idx-android)
 * [Android redirect authentication sample app](https://github.com/okta/samples-android) &mdash; see [Browser Sign In](https://github.com/okta/samples-android/tree/master/browser-sign-in) for redirect configuration
 
 ##### iOS
 
-* [Swift Okta Identity Engine SDK](https://github.com/okta/okta-idx-swift)
+* [Identity Engine Swift SDK](https://github.com/okta/okta-idx-swift)
 * [iOS embedded authentication with SDK sample app](https://github.com/okta/okta-idx-swift/tree/master/Samples/EmbeddedAuthWithSDKs)
 * [iOS redirect authentication sample app](https://github.com/okta/samples-ios) &mdash; see [Browser Sign In](https://github.com/okta/samples-ios/tree/master/browser-sign-in) for redirect configuration
 
@@ -49,7 +49,7 @@ Orgs using Okta Identity Engine can also continue to use current SDKs and tools.
 
 #### JavaScript
 
-* [Okta JavaScript SDK](https://github.com/okta/okta-auth-js) &mdash; see the [Okta Identity Engine README](https://github.com/okta/okta-auth-js/blob/master/docs/idx.md) for Okta Identity Engine specific instructions
+* [Okta JavaScript SDK](https://github.com/okta/okta-auth-js) &mdash; see the [Identity Engine README](https://github.com/okta/okta-auth-js/blob/master/docs/idx.md) for Identity Engine specific instructions
 * [Okta Sign-In Widget](/code/javascript/okta_sign-in_widget/)
 
 ##### React
@@ -64,7 +64,7 @@ Orgs using Okta Identity Engine can also continue to use current SDKs and tools.
 
 ##### .NET
 
-* [.NET Okta Identity Engine SDK](https://github.com/okta/okta-idx-dotnet)
+* [Identity Engine .NET SDK](https://github.com/okta/okta-idx-dotnet)
 * [ASP.NET embedded authentication with SDK sample app](https://github.com/okta/okta-idx-dotnet/tree/master/samples/samples-aspnet/embedded-auth-with-sdk)
 * [ASP.NET embedded Sign-In Widget sample app](https://github.com/okta/okta-idx-dotnet/tree/master/samples/samples-aspnet/embedded-sign-in-widget)
 * [ASP.NET redirect authentication sample app](https://github.com/okta/samples-aspnet) &mdash;  see [Okta-Hosted Login](https://github.com/okta/samples-aspnet/tree/master/okta-hosted-login) for redirect configuration
@@ -74,21 +74,21 @@ Orgs using Okta Identity Engine can also continue to use current SDKs and tools.
 
 ##### Express JS
 
-* [Okta JavaScript SDK](https://github.com/okta/okta-auth-js) &mdash; see the [Okta Identity Engine README](https://github.com/okta/okta-auth-js/blob/master/docs/idx.md) for Okta Identity Engine specific instructions
+* [Okta JavaScript SDK](https://github.com/okta/okta-auth-js) &mdash; see the [Identity Engine README](https://github.com/okta/okta-auth-js/blob/master/docs/idx.md) for Identity Engine specific instructions
 * [Express JS embedded authentication with SDK sample app](https://github.com/okta/okta-auth-js/tree/master/samples/generated/express-embedded-auth-with-sdk)
 * [Express JS embedded Sign-In Widget sample app](https://github.com/okta/okta-auth-js/tree/master/samples/generated/express-embedded-sign-in-widget)
 * [Express JS redirect authentication sample app](https://github.com/okta/samples-nodejs-express-4) &mdash; see [Okta-Hosted Login](https://github.com/okta/samples-nodejs-express-4/tree/master/okta-hosted-login) for redirect configuration
 
 ##### Go
 
-* [Golang Okta Identity Engine SDK](https://github.com/okta/okta-idx-golang)
+* [Identity Engine Golang SDK](https://github.com/okta/okta-idx-golang)
 * [Golang embedded authentication with SDK sample app](https://github.com/okta/samples-golang/tree/master/identity-engine/embedded-auth-with-sdk)
 * [Golang embedded Sign-In Widget sample app](https://github.com/okta/samples-golang/tree/master/identity-engine/embedded-sign-in-widget)
 * [Golang redirect authentication sample app](https://github.com/okta/samples-golang) &mdash; see [Okta-Hosted Login](https://github.com/okta/samples-golang/tree/master/okta-hosted-login) for redirect configuration
 
 ##### Java
 
-* [Java Okta Identity Engine SDK](https://github.com/okta/okta-idx-java)
+* [Identity Engine Java SDK](https://github.com/okta/okta-idx-java)
 * [Java embedded authentication with SDK sample app](https://github.com/okta/okta-idx-java/tree/master/samples/embedded-auth-with-sdk)
 * [Spring embedded Sign-In Widget sample app](https://github.com/okta/okta-idx-java/tree/master/samples/embedded-sign-in-widget)
 * [Spring redirect authentication sample app](https://github.com/okta/samples-java-spring) &mdash; see [Okta-Hosted Login](https://github.com/okta/samples-java-spring/tree/master/okta-hosted-login) for redirect configuration

--- a/packages/@okta/vuepress-site/code/oie/index.md
+++ b/packages/@okta/vuepress-site/code/oie/index.md
@@ -9,9 +9,9 @@ title: Okta Identity Engine SDKs & Samples
 
 ## What's new
 
-[Okta Identity Engine](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie) introduces new identity management capabilities with greater flexibility and customization. To take advantage of these new features and for a better development experience, use Identity Engine SDKs to manage authentication in your apps. These new SDKs are recommended for orgs using Identity Engine.
+[Okta Identity Engine](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie) introduces new identity management capabilities with greater flexibility and customization. To take advantage of these new features and for a better development experience, use the Identity Engine SDKs to manage authentication in your apps. These new SDKs are recommended for orgs using the Identity Engine.
 
-Experiment with sample apps that showcase Identity Engine using the following [authentication approaches](/docs/concepts/redirect-vs-embedded/):
+Experiment with sample apps that showcase the Identity Engine using the following [authentication approaches](/docs/concepts/redirect-vs-embedded/):
 
 * **Redirect**: These sample apps demonstrate how to redirect users to an Okta-hosted sign-in page, and then receive users redirected back from Okta after users sign in. This approach is recommended for most developers, as it is easier to build and maintain.
 
@@ -19,7 +19,7 @@ Experiment with sample apps that showcase Identity Engine using the following [a
 
 Learn how to implement each approach with these Identity Engine SDKs and sample apps in the [Redirect authentication guide](/docs/guides/sampleapp-oie-redirectauth/), [Embedded authentication with SDK guide](/docs/guides/oie-embedded-sdk-overview/), and [Embedded authentication with Sign-In Widget guide](/docs/guides/oie-embedded-widget-overview/).
 
-Orgs using Identity Engine can also continue to use current SDKs and tools. You can find those SDKs for your stack from the [Languages & SDKs overview](/code/).
+Orgs using the Identity Engine can also continue to use current SDKs and tools. You can find those SDKs for your stack from the [Languages & SDKs overview](/code/).
 
 ## Repository
 

--- a/packages/@okta/vuepress-site/code/oie/index.md
+++ b/packages/@okta/vuepress-site/code/oie/index.md
@@ -9,9 +9,9 @@ title: Okta Identity Engine SDKs & Samples
 
 ## What's new
 
-[Okta Identity Engine](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie) introduces new identity management capabilities with greater flexibility and customization. To take advantage of these new features and for a better development experience, use the Identity Engine SDKs to manage authentication in your apps. These new SDKs are recommended for orgs using the Identity Engine.
+[Okta Identity Engine](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie) introduces new identity management capabilities with greater flexibility and customization. To take advantage of these new features and for a better development experience, use Identity Engine SDKs to manage authentication in your apps. These new SDKs are recommended for orgs using Identity Engine.
 
-Experiment with sample apps that showcase the Identity Engine using the following [authentication approaches](/docs/concepts/redirect-vs-embedded/):
+Experiment with sample apps that showcase Identity Engine using the following [authentication approaches](/docs/concepts/redirect-vs-embedded/):
 
 * **Redirect**: These sample apps demonstrate how to redirect users to an Okta-hosted sign-in page, and then receive users redirected back from Okta after users sign in. This approach is recommended for most developers, as it is easier to build and maintain.
 
@@ -19,7 +19,7 @@ Experiment with sample apps that showcase the Identity Engine using the followin
 
 Learn how to implement each approach with these Identity Engine SDKs and sample apps in the [Redirect authentication guide](/docs/guides/sampleapp-oie-redirectauth/), [Embedded authentication with SDK guide](/docs/guides/oie-embedded-sdk-overview/), and [Embedded authentication with Sign-In Widget guide](/docs/guides/oie-embedded-widget-overview/).
 
-Orgs using the Identity Engine can also continue to use current SDKs and tools. You can find those SDKs for your stack from the [Languages & SDKs overview](/code/).
+Orgs using Identity Engine can also continue to use current SDKs and tools. You can find those SDKs for your stack from the [Languages & SDKs overview](/code/).
 
 ## Repository
 

--- a/packages/@okta/vuepress-site/code/oie/index.md
+++ b/packages/@okta/vuepress-site/code/oie/index.md
@@ -19,7 +19,7 @@ Experiment with sample apps that showcase the Identity Engine using the followin
 
 Learn how to implement each approach with these Identity Engine SDKs and sample apps in the [Redirect authentication guide](/docs/guides/sampleapp-oie-redirectauth/), [Embedded authentication with SDK guide](/docs/guides/oie-embedded-sdk-overview/), and [Embedded authentication with Sign-In Widget guide](/docs/guides/oie-embedded-widget-overview/).
 
-Orgs using the Identity Engine can also continue to use current SDKs and tools. You can find those SDKs for your stack from the [Languages & SDKs overview](/code/).
+Orgs that use the Identity Engine can also continue to use current SDKs and tools. You can find those SDKs for your stack from the [Languages & SDKs overview](/code/).
 
 ## Repository
 

--- a/packages/@okta/vuepress-site/docs/concepts/redirect-vs-embedded/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/redirect-vs-embedded/index.md
@@ -15,11 +15,11 @@ When you develop applications that require the customer to sign-in and then to a
 - **Redirect authentication**: A user sign-in flow that grants authentication control to Okta by redirecting to an Okta hosted sign-in page using open protocols like OAuth 2.0 and SAML.
 - **Embedded authentication**: A user sign-in flow where the application retains authentication control, without redirection to Okta, using a client-hosted Sign-In Widget, Okta Identity Engine SDKs, or directly with Okta proprietary Identity Engine authentication APIs.
 
-Identity Engine supports both these deployment and authentication models, and uses authentication protocols to communicate with Identity Server, the entity that acts as the logical location for all identity-related services and resources.
+The Identity Engine supports both these deployment and authentication models, and uses authentication protocols to communicate with Identity Server, the entity that acts as the logical location for all identity-related services and resources.
 
 ## Redirect authentication
 
-Redirect authentication is the process of delegating authentication to your Okta org and externalizes this process from the client application. The user or system is redirected to Okta for credential verification by Identity Engine and is then provided authenticated access to the client application and other Service Providers.
+Redirect authentication is the process of delegating authentication to your Okta org and externalizes this process from the client application. The user or system is redirected to Okta for credential verification by the Identity Engine and is then provided authenticated access to the client application and other Service Providers.
 
 When a user signs in to the client application, they are redirected to Okta using a protocol like SAML or OpenId Connect (OIDC). After the user signs in (based on policies that are configured in Okta), Okta redirects the user back to your application. The hosted Okta Sign-in Widget can also be customized, including the domain, to match your application's brand.
 
@@ -63,7 +63,7 @@ Deploy the redirect authentication model in the following use-cases:
 
 ## Embedded authentication
 
-Embedded authentication is the process of authenticating user credentials directly at the client application site using proprietary Okta authentication SDKs and APIs. No redirection to Okta is required. The client application's code determines the methods and processes necessary to authenticate, and uses Identity Engine SDK to validate the credentials. Client applications create their own application sessions and require explicit support for SSO to other external Service Providers.
+Embedded authentication is the process of authenticating user credentials directly at the client application site using proprietary Okta authentication SDKs and APIs. No redirection to Okta is required. The client application's code determines the methods and processes necessary to authenticate, and uses the Identity Engine SDK to validate the credentials. Client applications create their own application sessions and require explicit support for SSO to other external Service Providers.
 
 With embedded authentication, the client application obtains and validates the user's credentials by API calls to Okta, generally through the customer-hosted Sign-In Widget. Based on the organization’s requirements, the client application then creates a session for user access. The client application may also exchange tokens with a Security Token Service (STS) to provide SSO access to other Service Providers (CRM, IT, HR, and so on). Using this deployment model, the client’s sign-in page can render native user experiences and use native platform APIs.
 

--- a/packages/@okta/vuepress-site/docs/concepts/redirect-vs-embedded/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/redirect-vs-embedded/index.md
@@ -63,7 +63,7 @@ Deploy the redirect authentication model in the following use-cases:
 
 ## Embedded authentication
 
-Embedded authentication is the process of authenticating user credentials directly at the client application site using proprietary Okta authentication SDKs and APIs. No redirection to Okta is required. The client application's code determines the methods and processes necessary to authenticate, and uses the Identity Engine SDK to validate the credentials. Client applications create their own application sessions and require explicit support for SSO to other external Service Providers.
+Embedded authentication is the process of authenticating user credentials directly at the client application site by using proprietary Okta authentication SDKs and APIs. No redirection to Okta is required. The client application's code determines the methods and processes necessary to authenticate, and uses the Identity Engine SDK to validate the credentials. Client applications create their own application sessions and require explicit support for SSO to other external Service Providers.
 
 With embedded authentication, the client application obtains and validates the user's credentials by API calls to Okta, generally through the customer-hosted Sign-In Widget. Based on the organization’s requirements, the client application then creates a session for user access. The client application may also exchange tokens with a Security Token Service (STS) to provide SSO access to other Service Providers (CRM, IT, HR, and so on). Using this deployment model, the client’s sign-in page can render native user experiences and use native platform APIs.
 

--- a/packages/@okta/vuepress-site/docs/concepts/redirect-vs-embedded/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/redirect-vs-embedded/index.md
@@ -13,13 +13,13 @@ meta:
 When you develop applications that require the customer to sign-in and then to authentication, the user authentication deployment model is a critical design consideration that can broadly be divided into two approaches:
 
 - **Redirect authentication**: A user sign-in flow that grants authentication control to Okta by redirecting to an Okta hosted sign-in page using open protocols like OAuth 2.0 and SAML.
-- **Embedded authentication**: A user sign-in flow where the application retains authentication control, without redirection to Okta, using a client-hosted Sign-In Widget, Identity Engine SDKs, or directly with Okta's proprietary Identity Engine authentication APIs.
+- **Embedded authentication**: A user sign-in flow where the application retains authentication control, without redirection to Okta, using a client-hosted Sign-In Widget, Okta Identity Engine SDKs, or directly with Okta proprietary Identity Engine authentication APIs.
 
-Identity Engine supports both these deployment and authentication models, and uses authentication protocols to communicate with the Identity Server, the entity that acts as the logical location for all identity-related services and resources.
+The Identity Engine supports both these deployment and authentication models, and uses authentication protocols to communicate with the Identity Server, the entity that acts as the logical location for all identity-related services and resources.
 
 ## Redirect authentication
 
-Redirect authentication is the process of delegating authentication to your Okta org and externalizes this process from the client application. The user or system is redirected to Okta for credential verification by the Okta Identity Engine and is then provided authenticated access to the client application and other Service Providers.
+Redirect authentication is the process of delegating authentication to your Okta org and externalizes this process from the client application. The user or system is redirected to Okta for credential verification by the Identity Engine and is then provided authenticated access to the client application and other Service Providers.
 
 When a user signs in to the client application, they are redirected to Okta using a protocol like SAML or OpenId Connect (OIDC). After the user signs in (based on policies that are configured in Okta), Okta redirects the user back to your application. The hosted Okta Sign-in Widget can also be customized, including the domain, to match your application's brand.
 
@@ -63,7 +63,7 @@ Deploy the redirect authentication model in the following use-cases:
 
 ## Embedded authentication
 
-Embedded authentication is the process of authenticating user credentials directly at the client application site using proprietary Okta authentication SDKs and APIs. No redirection to Okta is required. The client application's code determines the methods and processes necessary to authenticate, and uses Okta’s Identity Engine SDK to validate the credentials. Client applications create their own application sessions and require explicit support for SSO to other external Service Providers.
+Embedded authentication is the process of authenticating user credentials directly at the client application site using proprietary Okta authentication SDKs and APIs. No redirection to Okta is required. The client application's code determines the methods and processes necessary to authenticate, and uses the Identity Engine SDK to validate the credentials. Client applications create their own application sessions and require explicit support for SSO to other external Service Providers.
 
 With embedded authentication, the client application obtains and validates the user's credentials by API calls to Okta, generally through the customer-hosted Sign-In Widget. Based on the organization’s requirements, the client application then creates a session for user access. The client application may also exchange tokens with a Security Token Service (STS) to provide SSO access to other Service Providers (CRM, IT, HR, and so on). Using this deployment model, the client’s sign-in page can render native user experiences and use native platform APIs.
 

--- a/packages/@okta/vuepress-site/docs/concepts/redirect-vs-embedded/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/redirect-vs-embedded/index.md
@@ -15,11 +15,11 @@ When you develop applications that require the customer to sign-in and then to a
 - **Redirect authentication**: A user sign-in flow that grants authentication control to Okta by redirecting to an Okta hosted sign-in page using open protocols like OAuth 2.0 and SAML.
 - **Embedded authentication**: A user sign-in flow where the application retains authentication control, without redirection to Okta, using a client-hosted Sign-In Widget, Okta Identity Engine SDKs, or directly with Okta proprietary Identity Engine authentication APIs.
 
-The Identity Engine supports both these deployment and authentication models, and uses authentication protocols to communicate with the Identity Server, the entity that acts as the logical location for all identity-related services and resources.
+Identity Engine supports both these deployment and authentication models, and uses authentication protocols to communicate with Identity Server, the entity that acts as the logical location for all identity-related services and resources.
 
 ## Redirect authentication
 
-Redirect authentication is the process of delegating authentication to your Okta org and externalizes this process from the client application. The user or system is redirected to Okta for credential verification by the Identity Engine and is then provided authenticated access to the client application and other Service Providers.
+Redirect authentication is the process of delegating authentication to your Okta org and externalizes this process from the client application. The user or system is redirected to Okta for credential verification by Identity Engine and is then provided authenticated access to the client application and other Service Providers.
 
 When a user signs in to the client application, they are redirected to Okta using a protocol like SAML or OpenId Connect (OIDC). After the user signs in (based on policies that are configured in Okta), Okta redirects the user back to your application. The hosted Okta Sign-in Widget can also be customized, including the domain, to match your application's brand.
 
@@ -63,7 +63,7 @@ Deploy the redirect authentication model in the following use-cases:
 
 ## Embedded authentication
 
-Embedded authentication is the process of authenticating user credentials directly at the client application site using proprietary Okta authentication SDKs and APIs. No redirection to Okta is required. The client application's code determines the methods and processes necessary to authenticate, and uses the Identity Engine SDK to validate the credentials. Client applications create their own application sessions and require explicit support for SSO to other external Service Providers.
+Embedded authentication is the process of authenticating user credentials directly at the client application site using proprietary Okta authentication SDKs and APIs. No redirection to Okta is required. The client application's code determines the methods and processes necessary to authenticate, and uses Identity Engine SDK to validate the credentials. Client applications create their own application sessions and require explicit support for SSO to other external Service Providers.
 
 With embedded authentication, the client application obtains and validates the user's credentials by API calls to Okta, generally through the customer-hosted Sign-In Widget. Based on the organization’s requirements, the client application then creates a session for user access. The client application may also exchange tokens with a Security Token Service (STS) to provide SSO access to other Service Providers (CRM, IT, HR, and so on). Using this deployment model, the client’s sign-in page can render native user experiences and use native platform APIs.
 

--- a/packages/@okta/vuepress-site/docs/guides/device-authorization-grant/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/device-authorization-grant/main/index.md
@@ -10,7 +10,7 @@ layout: Guides
 
 The Device Authorization feature is an OAuth 2.0 grant type. It allows users to sign in to input-constrained devices, such as smart TVs, digital picture frames, and printers, as well as devices with no browser. Device Authorization enables you to use a secondary device, such as a laptop or mobile phone, to complete sign-in to applications that run on such devices.
 
-The Device Authorization feature is available for both Okta Classic and Okta Identity Engine orgs.
+The Device Authorization feature is available for both Okta Classic Engine and Okta Identity Engine orgs.
 
 If you need help or have an issue, post a question on the [Okta Developer Forum](https://devforum.okta.com).
 

--- a/packages/@okta/vuepress-site/docs/guides/ie-limitations/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/ie-limitations/index.md
@@ -6,22 +6,22 @@ excerpt: Okta Identity Engine introduces a lot of changes to the Okta platform. 
 <ApiLifecycle access="ie" /><br>
 <ApiLifecycle access="Limited GA" />
 
-Okta Identity Engine introduces a lot of changes to the Okta platform. Some of these changes result in a lack of support for previously available features. Additionally, some of these changes result in Identity Engine features not supported for use with Okta Classic Engine APIs.
+Okta Identity Engine introduces a lot of changes to the Okta platform. Some of these changes result in a lack of support for previously available features. Additionally, some of these changes result in the Identity Engine features not supported for use with Okta Classic Engine APIs.
 
-> **Note:** This doc is designed for people who are familiar with the Classic Engine. If you are new to Okta and Identity Engine, see [Get started](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie) with Identity Engine.
+> **Note:** This doc is designed for people who are familiar with the Classic Engine. If you are new to Okta and the Identity Engine, see [Get started](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie) with the Identity Engine.
 
-Are you an admin? See Identity Engine [Limitations](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-oie-limitations) doc for admins.
+Are you an admin? See the Identity Engine [Limitations](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-oie-limitations) doc for admins.
 
-### Classic Engine features not supported in Identity Engine
+### Classic Engine features not supported in the Identity Engine
 
 #### Event Type availability for Event Hooks
 
-**What Changed:** The following Event Types aren't available in Identity Engine because Device Trust isn't currently supported:
+**What Changed:** The following Event Types aren't available in the Identity Engine because Device Trust isn't currently supported:
 
 * `user.authentication.authenticate`
 * `user.credential.enroll`
 
-The following Event Types are available only in Identity Engine and can't be used by Classic Engine customers:
+The following Event Types are available only in the Identity Engine and can't be used by Classic Engine customers:
 
 * `device.enrollment.create`
 * `user.mfa.factor.suspend`
@@ -35,7 +35,7 @@ The following Event Types are available only in Identity Engine and can't be use
 
 #### Help Support number
 
-**What Changed:** In Identity Engine, if the user is unable to use an Authenticator, the Help Support number is no longer provided. The only support available is the Authenticator list page that provides alternative ways for the user to authenticate.
+**What Changed:** In the Identity Engine, if the user is unable to use an Authenticator, the Help Support number is no longer provided. The only support available is the Authenticator list page that provides alternative ways for the user to authenticate.
 
 ***
 
@@ -49,9 +49,9 @@ The following Event Types are available only in Identity Engine and can't be use
 
 #### Sessions APIs
 
-**What Changed:** Some Sessions APIs aren't supported in Identity Engine. However, your existing application could continue to work as long as session management and application interactions are fully contained within the `v1/sessions` APIs.
+**What Changed:** Some Sessions APIs aren't supported in the Identity Engine. However, your existing application could continue to work as long as session management and application interactions are fully contained within the `v1/sessions` APIs.
 
-**Further Information:** APIs not supported on Identity Engine sessions:
+**Further Information:** APIs not supported on the Identity Engine sessions:
 
 * `GET /api/v1/sessions/${sessionId}`
 * `POST /api/v1/sessions/${sessionId}/lifecycle/refresh`
@@ -103,7 +103,7 @@ The following Event Types are available only in Identity Engine and can't be use
 
 #### Sign-In Widget customization - Registration Inline Hooks
 
-**What Changed:** Existing Registration Inline Hooks may experience compatibility issues after migrating to Identity Engine due to changes in the Okta Registration Inline Hook request. Your application may require code updates to consume the new request format properly.
+**What Changed:** Existing Registration Inline Hooks may experience compatibility issues after migrating to the Identity Engine due to changes in the Okta Registration Inline Hook request. Your application may require code updates to consume the new request format properly.
 
 In the Admin Console, the enablement of a Registration Inline Hook has changed from the former Self-Service Registration page (**Self-service Directory** > **Self-Service Registration**) to the Profile Enrollment Rules page (**Security** > **Profile Enrollment**). The creation of the Registration Inline Hook remains the same and can be completed in the Admin Console or by Inline Hook Management APIs.
 
@@ -113,7 +113,7 @@ In the Admin Console, the enablement of a Registration Inline Hook has changed f
 
 #### Sign-In Widget customization - Security image
 
-**What Changed:** The ability for end users to specify a security image when they first register for an account isn't supported with Identity Engine. Additionally, existing users who may have already registered a security image, won't see that image when they sign in.
+**What Changed:** The ability for end users to specify a security image when they first register for an account isn't supported with the Identity Engine. Additionally, existing users who may have already registered a security image, won't see that image when they sign in.
 
 ***
 
@@ -125,7 +125,7 @@ In the Admin Console, the enablement of a Registration Inline Hook has changed f
 
 ***
 
-### Identity Engine features not supported with Classic Engine APIs
+### Identity Engine features not supported with the Classic Engine APIs
 
 #### Factor API enrollment limitations
 
@@ -145,6 +145,6 @@ See the [SDK uses cases](/docs/guides/oie-embedded-sdk-use-cases/-/oie-embedded-
 
 #### Password recovery limitations with the /authn API
 
-Developers who use the `/api/v1/authn` APIs to build custom password reset and account unlock experiences can't use the new recovery options in Identity Engine. Specifically, if developers set a password policy rule to require Okta Verify Push for recovery or configure **Any enrolled authenticator used for MFA/SSO** for additional verification, end users who use the Classic Engine Authentication APIs are denied recovery.
+Developers who use the `/api/v1/authn` APIs to build custom password reset and account unlock experiences can't use the new recovery options in the Identity Engine. Specifically, if developers set a password policy rule to require Okta Verify Push for recovery or configure **Any enrolled authenticator used for MFA/SSO** for additional verification, end users who use the Classic Engine Authentication APIs are denied recovery.
 
 **Further information:** [Recovery operations](https://developer.okta.com/docs/reference/api/authn/#recovery-operations) section of the Authentication API.

--- a/packages/@okta/vuepress-site/docs/guides/ie-limitations/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/ie-limitations/index.md
@@ -1,27 +1,27 @@
 ---
 title: Okta Identity Engine Limitations
-excerpt: The Okta Identity Engine introduces a lot of changes to the Okta platform. Some of these changes result in a lack of support for previously available features.
+excerpt: Okta Identity Engine introduces a lot of changes to the Okta platform. Some of these changes result in a lack of support for previously available features.
 ---
 
 <ApiLifecycle access="ie" /><br>
 <ApiLifecycle access="Limited GA" />
 
-The Okta Identity Engine introduces a lot of changes to the Okta platform. Some of these changes result in a lack of support for previously available features. Additionally, some of these changes result in Okta Identity Engine features not supported for use with Okta Classic Engine APIs.
+Okta Identity Engine introduces a lot of changes to the Okta platform. Some of these changes result in a lack of support for previously available features. Additionally, some of these changes result in the Identity Engine features not supported for use with Okta Classic Engine APIs.
 
-> **Note:** This doc is designed for people who are familiar with Classic Engine. If you are new to Okta and Okta Identity Engine, see [Get started](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie) with Okta Identity Engine.
+> **Note:** This doc is designed for people who are familiar with the Classic Engine. If you are new to Okta and the Identity Engine, see [Get started](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie) with the Identity Engine.
 
-Are you an admin? See the Okta Identity Engine [Limitations](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-oie-limitations) doc for admins.
+Are you an admin? See the Identity Engine [Limitations](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-oie-limitations) doc for admins.
 
-### Classic Engine features not supported in Okta Identity Engine
+### Classic Engine features not supported in the Identity Engine
 
 #### Event Type availability for Event Hooks
 
-**What Changed:** The following Event Types aren't available in the Okta Identity Engine because Device Trust isn't currently supported:
+**What Changed:** The following Event Types aren't available in the Identity Engine because Device Trust isn't currently supported:
 
 * `user.authentication.authenticate`
 * `user.credential.enroll`
 
-The following Event Types are available only in the Okta Identity Engine and can't be used by Classic Engine customers:
+The following Event Types are available only in the Identity Engine and can't be used by Classic Engine customers:
 
 * `device.enrollment.create`
 * `user.mfa.factor.suspend`
@@ -35,7 +35,7 @@ The following Event Types are available only in the Okta Identity Engine and can
 
 #### Help Support number
 
-**What Changed:** In Okta Identity Engine, if the user is unable to use an Authenticator, the Help Support number is no longer provided. The only support available is the Authenticator list page that provides alternative ways for the user to authenticate.
+**What Changed:** In the Identity Engine, if the user is unable to use an Authenticator, the Help Support number is no longer provided. The only support available is the Authenticator list page that provides alternative ways for the user to authenticate.
 
 ***
 
@@ -49,9 +49,9 @@ The following Event Types are available only in the Okta Identity Engine and can
 
 #### Sessions APIs
 
-**What Changed:** Some Sessions APIs aren't supported in Okta Identity Engine. However, your existing application could continue to work as long as session management and application interactions are fully contained within the `v1/sessions` APIs.
+**What Changed:** Some Sessions APIs aren't supported in the Identity Engine. However, your existing application could continue to work as long as session management and application interactions are fully contained within the `v1/sessions` APIs.
 
-**Further Information:** APIs not supported on Okta Identity Engine sessions:
+**Further Information:** APIs not supported on the Identity Engine sessions:
 
 * `GET /api/v1/sessions/${sessionId}`
 * `POST /api/v1/sessions/${sessionId}/lifecycle/refresh`
@@ -125,11 +125,11 @@ In the Admin Console, the enablement of a Registration Inline Hook has changed f
 
 ***
 
-### Okta Identity Engine features not supported with Classic Engine APIs
+### Identity Engine features not supported with Classic Engine APIs
 
 #### Factor API enrollment limitations
 
-The following Okta Identity Engine features aren't supported using the Factor APIs.
+The following Identity Engine features aren't supported using the Factor APIs.
 
 * Enroll in multiple Okta Verify factors using the [Factors API](/docs/reference/api/factors/#enroll-okta-verify-totp-factor). You can only use the Factors API to enroll the first Okta Verify factor.
 * Okta Verify authenticator settings aren't enforced when enrolling using the Factors API:
@@ -145,6 +145,6 @@ See the [SDK uses cases](/docs/guides/oie-embedded-sdk-use-cases/-/oie-embedded-
 
 #### Password recovery limitations with the /authn API
 
-Developers who use the `/api/v1/authn` APIs to build custom password reset and account unlock experiences can't use the new recovery options in Okta Identity Engine. Specifically, if developers set a password policy rule to require Okta Verify Push for recovery or configure **Any enrolled authenticator used for MFA/SSO** for additional verification, end users who use the Classic Engine Authentication APIs are denied recovery.
+Developers who use the `/api/v1/authn` APIs to build custom password reset and account unlock experiences can't use the new recovery options in the Identity Engine. Specifically, if developers set a password policy rule to require Okta Verify Push for recovery or configure **Any enrolled authenticator used for MFA/SSO** for additional verification, end users who use the Classic Engine Authentication APIs are denied recovery.
 
 **Further information:** [Recovery operations](https://developer.okta.com/docs/reference/api/authn/#recovery-operations) section of the Authentication API.

--- a/packages/@okta/vuepress-site/docs/guides/ie-limitations/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/ie-limitations/index.md
@@ -6,22 +6,22 @@ excerpt: Okta Identity Engine introduces a lot of changes to the Okta platform. 
 <ApiLifecycle access="ie" /><br>
 <ApiLifecycle access="Limited GA" />
 
-Okta Identity Engine introduces a lot of changes to the Okta platform. Some of these changes result in a lack of support for previously available features. Additionally, some of these changes result in the Identity Engine features not supported for use with Okta Classic Engine APIs.
+Okta Identity Engine introduces a lot of changes to the Okta platform. Some of these changes result in a lack of support for previously available features. Additionally, some of these changes result in Identity Engine features not supported for use with Okta Classic Engine APIs.
 
-> **Note:** This doc is designed for people who are familiar with the Classic Engine. If you are new to Okta and the Identity Engine, see [Get started](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie) with the Identity Engine.
+> **Note:** This doc is designed for people who are familiar with the Classic Engine. If you are new to Okta and Identity Engine, see [Get started](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie) with Identity Engine.
 
-Are you an admin? See the Identity Engine [Limitations](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-oie-limitations) doc for admins.
+Are you an admin? See Identity Engine [Limitations](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-oie-limitations) doc for admins.
 
-### Classic Engine features not supported in the Identity Engine
+### Classic Engine features not supported in Identity Engine
 
 #### Event Type availability for Event Hooks
 
-**What Changed:** The following Event Types aren't available in the Identity Engine because Device Trust isn't currently supported:
+**What Changed:** The following Event Types aren't available in Identity Engine because Device Trust isn't currently supported:
 
 * `user.authentication.authenticate`
 * `user.credential.enroll`
 
-The following Event Types are available only in the Identity Engine and can't be used by Classic Engine customers:
+The following Event Types are available only in Identity Engine and can't be used by Classic Engine customers:
 
 * `device.enrollment.create`
 * `user.mfa.factor.suspend`
@@ -35,7 +35,7 @@ The following Event Types are available only in the Identity Engine and can't be
 
 #### Help Support number
 
-**What Changed:** In the Identity Engine, if the user is unable to use an Authenticator, the Help Support number is no longer provided. The only support available is the Authenticator list page that provides alternative ways for the user to authenticate.
+**What Changed:** In Identity Engine, if the user is unable to use an Authenticator, the Help Support number is no longer provided. The only support available is the Authenticator list page that provides alternative ways for the user to authenticate.
 
 ***
 
@@ -49,9 +49,9 @@ The following Event Types are available only in the Identity Engine and can't be
 
 #### Sessions APIs
 
-**What Changed:** Some Sessions APIs aren't supported in the Identity Engine. However, your existing application could continue to work as long as session management and application interactions are fully contained within the `v1/sessions` APIs.
+**What Changed:** Some Sessions APIs aren't supported in Identity Engine. However, your existing application could continue to work as long as session management and application interactions are fully contained within the `v1/sessions` APIs.
 
-**Further Information:** APIs not supported on the Identity Engine sessions:
+**Further Information:** APIs not supported on Identity Engine sessions:
 
 * `GET /api/v1/sessions/${sessionId}`
 * `POST /api/v1/sessions/${sessionId}/lifecycle/refresh`
@@ -103,7 +103,7 @@ The following Event Types are available only in the Identity Engine and can't be
 
 #### Sign-In Widget customization - Registration Inline Hooks
 
-**What Changed:** Existing Registration Inline Hooks may experience compatibility issues after migrating to Okta Identity Engine due to changes in the Okta Registration Inline Hook request. Your application may require code updates to consume the new request format properly.
+**What Changed:** Existing Registration Inline Hooks may experience compatibility issues after migrating to Identity Engine due to changes in the Okta Registration Inline Hook request. Your application may require code updates to consume the new request format properly.
 
 In the Admin Console, the enablement of a Registration Inline Hook has changed from the former Self-Service Registration page (**Self-service Directory** > **Self-Service Registration**) to the Profile Enrollment Rules page (**Security** > **Profile Enrollment**). The creation of the Registration Inline Hook remains the same and can be completed in the Admin Console or by Inline Hook Management APIs.
 
@@ -113,7 +113,7 @@ In the Admin Console, the enablement of a Registration Inline Hook has changed f
 
 #### Sign-In Widget customization - Security image
 
-**What Changed:** The ability for end users to specify a security image when they first register for an account isn't supported with Okta Identity Engine. Additionally, existing users who may have already registered a security image, won't see that image when they sign in.
+**What Changed:** The ability for end users to specify a security image when they first register for an account isn't supported with Identity Engine. Additionally, existing users who may have already registered a security image, won't see that image when they sign in.
 
 ***
 
@@ -145,6 +145,6 @@ See the [SDK uses cases](/docs/guides/oie-embedded-sdk-use-cases/-/oie-embedded-
 
 #### Password recovery limitations with the /authn API
 
-Developers who use the `/api/v1/authn` APIs to build custom password reset and account unlock experiences can't use the new recovery options in the Identity Engine. Specifically, if developers set a password policy rule to require Okta Verify Push for recovery or configure **Any enrolled authenticator used for MFA/SSO** for additional verification, end users who use the Classic Engine Authentication APIs are denied recovery.
+Developers who use the `/api/v1/authn` APIs to build custom password reset and account unlock experiences can't use the new recovery options in Identity Engine. Specifically, if developers set a password policy rule to require Okta Verify Push for recovery or configure **Any enrolled authenticator used for MFA/SSO** for additional verification, end users who use the Classic Engine Authentication APIs are denied recovery.
 
 **Further information:** [Recovery operations](https://developer.okta.com/docs/reference/api/authn/#recovery-operations) section of the Authentication API.

--- a/packages/@okta/vuepress-site/docs/guides/ie-limitations/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/ie-limitations/index.md
@@ -6,13 +6,13 @@ excerpt: The Okta Identity Engine introduces a lot of changes to the Okta platfo
 <ApiLifecycle access="ie" /><br>
 <ApiLifecycle access="Limited GA" />
 
-The Okta Identity Engine introduces a lot of changes to the Okta platform. Some of these changes result in a lack of support for previously available features. Additionally, some of these changes result in Okta Identity Engine features not supported for use with Okta Classic APIs.
+The Okta Identity Engine introduces a lot of changes to the Okta platform. Some of these changes result in a lack of support for previously available features. Additionally, some of these changes result in Okta Identity Engine features not supported for use with Okta Classic Engine APIs.
 
-> **Note:** This doc is designed for people who are familiar with Okta Classic. If you are new to Okta and Okta Identity Engine, see [Get started](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie) with Okta Identity Engine.
+> **Note:** This doc is designed for people who are familiar with Classic Engine. If you are new to Okta and Okta Identity Engine, see [Get started](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie) with Okta Identity Engine.
 
 Are you an admin? See the Okta Identity Engine [Limitations](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-oie-limitations) doc for admins.
 
-### Okta Classic features not supported in Okta Identity Engine
+### Classic Engine features not supported in Okta Identity Engine
 
 #### Event Type availability for Event Hooks
 
@@ -21,7 +21,7 @@ Are you an admin? See the Okta Identity Engine [Limitations](https://help.okta.c
 * `user.authentication.authenticate`
 * `user.credential.enroll`
 
-The following Event Types are available only in the Okta Identity Engine and can't be used by Okta Classic customers:
+The following Event Types are available only in the Okta Identity Engine and can't be used by Classic Engine customers:
 
 * `device.enrollment.create`
 * `user.mfa.factor.suspend`
@@ -125,7 +125,7 @@ In the Admin Console, the enablement of a Registration Inline Hook has changed f
 
 ***
 
-### Okta Identity Engine features not supported with Okta Classic APIs
+### Okta Identity Engine features not supported with Classic Engine APIs
 
 #### Factor API enrollment limitations
 
@@ -145,6 +145,6 @@ See the [SDK uses cases](/docs/guides/oie-embedded-sdk-use-cases/-/oie-embedded-
 
 #### Password recovery limitations with the /authn API
 
-Developers who use the `/api/v1/authn` APIs to build custom password reset and account unlock experiences can't use the new recovery options in Okta Identity Engine. Specifically, if developers set a password policy rule to require Okta Verify Push for recovery or configure **Any enrolled authenticator used for MFA/SSO** for additional verification, end users who use the Okta Classic Authentication APIs are denied recovery.
+Developers who use the `/api/v1/authn` APIs to build custom password reset and account unlock experiences can't use the new recovery options in Okta Identity Engine. Specifically, if developers set a password policy rule to require Okta Verify Push for recovery or configure **Any enrolled authenticator used for MFA/SSO** for additional verification, end users who use the Classic Engine Authentication APIs are denied recovery.
 
 **Further information:** [Recovery operations](https://developer.okta.com/docs/reference/api/authn/#recovery-operations) section of the Authentication API.

--- a/packages/@okta/vuepress-site/docs/guides/migrate-to-oie/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/migrate-to-oie/index.md
@@ -1,21 +1,21 @@
 ---
-title: Upgrade to Identity Engine
+title: Upgrade to Okta Identity Engine
 meta:
   - name: description
-    content: Our guide shows how to upgrade your organization and clients to Identity Engine
+    content: Our guide shows how to upgrade your organization and clients to Okta Identity Engine
 layout: Guides
 ---
 
 <ApiLifecycle access="ie" /><br>
 <ApiLifecycle access="Limited GA" />
 
-## Enable Identity Engine for your organization
+## Enable Okta Identity Engine for your organization
 
-To upgrade to Identity Engine, contact your account manager. If you do not have an account manager, email <oie@okta.com> for more information.
+To upgrade to the Identity Engine, contact your account manager. If you do not have an account manager, email <oie@okta.com> for more information.
 
 ## Enable interaction code grant
 
-After the Identity Engine feature is enabled for your org, it should become active for Okta-hosted sign-in flows that don't involve an OAuth application. Enabling the `interaction_code` grant type allows OAuth applications to use Identity Engine.
+After the Identity Engine feature is enabled for your org, it should become active for Okta-hosted sign-in flows that don't involve an OAuth application. Enabling the `interaction_code` grant type allows OAuth applications to use the Identity Engine.
 
 ### Enable interaction code grant on an authorization server
 
@@ -37,13 +37,13 @@ After the Identity Engine feature is enabled for your org, it should become acti
 
 ### Okta-hosted sign-in page (default)
 
-For most authentication flows that involve redirecting to Okta, there should be no other changes needed. After the feature is enabled, Identity Engine will be used automatically, by default.
+For most authentication flows that involve redirecting to Okta, there should be no other changes needed. After the feature is enabled, the Identity Engine will be used automatically, by default.
 
 ### Customized sign-in page / custom domain
 
-For most users of the [custom domain](/docs/guides/custom-url-domain/overview/) feature, there are no other changes needed. The default template detects and uses Identity Engine automatically.
+For most users of the [custom domain](/docs/guides/custom-url-domain/overview/) feature, there are no other changes needed. The default template detects and uses the Identity Engine automatically.
 
-However, if you have [modified the template](/docs/guides/style-the-widget/style-okta-hosted/) in certain ways (such as to perform redirects or set cookies), these modifications may not be compatible with Identity Engine. In particular, these methods and objects won't work with Identity Engine:
+However, if you have [modified the template](/docs/guides/style-the-widget/style-okta-hosted/) in certain ways (such as to perform redirects or set cookies), these modifications may not be compatible with the Identity Engine. In particular, these methods and objects won't work with the Identity Engine:
 
 - `setCookieAndRedirect`
 - `sessionToken`
@@ -97,7 +97,7 @@ For reference, here is the default template:
 
 > **Note:** "Embedded" means the Sign-In Widget is included directly in your application through npm module or script tag. The `@okta/okta-signin-widget` version 5.2.0 or above is needed to enable the interaction code flow.
 
-Set the option `useInteractionCodeFlow` to `true` on the object passed to the Sign-In Widget constructor. This enables Identity Engine for the Widget. Both the authorization server and the application must have the [interaction code](#enable-interaction-code-grant) grant type enabled.
+Set the option `useInteractionCodeFlow` to `true` on the object passed to the Sign-In Widget constructor. This enables the Identity Engine for the Widget. Both the authorization server and the application must have the [interaction code](#enable-interaction-code-grant) grant type enabled.
 
 > **Note:** Your code may break if it is calling the `renderEl` method and expects `sessionToken` or `session.setCookieAndRedirect` on the response object. Instead of `renderEl`, we recommend calling the `showSignInToGetTokens` method. This method receives and returns tokens without any browser redirect.
 

--- a/packages/@okta/vuepress-site/docs/guides/migrate-to-oie/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/migrate-to-oie/index.md
@@ -11,11 +11,11 @@ layout: Guides
 
 ## Enable Okta Identity Engine for your organization
 
-To upgrade to Identity Engine, contact your account manager. If you do not have an account manager, email <oie@okta.com> for more information.
+To upgrade to the Identity Engine, contact your account manager. If you do not have an account manager, email <oie@okta.com> for more information.
 
 ## Enable interaction code grant
 
-After Identity Engine is enabled for your org, it should become active for Okta-hosted sign-in flows that don't involve an OAuth application. Enabling the `interaction_code` grant type allows OAuth applications to use Identity Engine.
+After the Identity Engine is enabled for your org, it should become active for Okta-hosted sign-in flows that don't involve an OAuth application. Enabling the `interaction_code` grant type allows OAuth applications to use the Identity Engine.
 
 ### Enable interaction code grant on an authorization server
 
@@ -37,13 +37,13 @@ After Identity Engine is enabled for your org, it should become active for Okta-
 
 ### Okta-hosted sign-in page (default)
 
-For most authentication flows that involve redirecting to Okta, there should be no other changes needed. After the feature is enabled, Identity Engine is used automatically, by default.
+For most authentication flows that involve redirecting to Okta, there should be no other changes needed. After the feature is enabled, the Identity Engine is used automatically, by default.
 
 ### Customized sign-in page / custom domain
 
-For most users of the [custom domain](/docs/guides/custom-url-domain/overview/) feature, there are no other changes needed. The default template detects and uses Identity Engine automatically.
+For most users of the [custom domain](/docs/guides/custom-url-domain/overview/) feature, there are no other changes needed. The default template detects and uses the Identity Engine automatically.
 
-However, if you have [modified the template](/docs/guides/style-the-widget/style-okta-hosted/) in certain ways (such as to perform redirects or set cookies), these modifications may not be compatible with Identity Engine. In particular, these methods and objects won't work with Identity Engine:
+However, if you have [modified the template](/docs/guides/style-the-widget/style-okta-hosted/) in certain ways (such as to perform redirects or set cookies), these modifications may not be compatible with the Identity Engine. In particular, these methods and objects won't work with the Identity Engine:
 
 - `setCookieAndRedirect`
 - `sessionToken`
@@ -97,7 +97,7 @@ For reference, here is the default template:
 
 > **Note:** "Embedded" means the Sign-In Widget is included directly in your application through npm module or script tag. The `@okta/okta-signin-widget` version 5.2.0 or above is needed to enable the interaction code flow.
 
-Set the option `useInteractionCodeFlow` to `true` on the object passed to the Sign-In Widget constructor. This step enables Identity Engine for the Widget. Both the Authorization Server and the application must have the [interaction code](#enable-interaction-code-grant) grant type enabled.
+Set the option `useInteractionCodeFlow` to `true` on the object passed to the Sign-In Widget constructor. This step enables the Identity Engine for the Widget. Both the Authorization Server and the application must have the [interaction code](#enable-interaction-code-grant) grant type enabled.
 
 > **Note:** Your code may break if it is calling the `renderEl` method and expects `sessionToken` or `session.setCookieAndRedirect` on the response object. Instead of `renderEl`, we recommend calling the `showSignInToGetTokens` method. This method receives and returns tokens without any browser redirect.
 

--- a/packages/@okta/vuepress-site/docs/guides/migrate-to-oie/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/migrate-to-oie/index.md
@@ -11,11 +11,11 @@ layout: Guides
 
 ## Enable Okta Identity Engine for your organization
 
-To upgrade to the Identity Engine, contact your account manager. If you do not have an account manager, email <oie@okta.com> for more information.
+To upgrade to Identity Engine, contact your account manager. If you do not have an account manager, email <oie@okta.com> for more information.
 
 ## Enable interaction code grant
 
-After the Identity Engine feature is enabled for your org, it should become active for Okta-hosted sign-in flows that don't involve an OAuth application. Enabling the `interaction_code` grant type allows OAuth applications to use the Identity Engine.
+After Identity Engine is enabled for your org, it should become active for Okta-hosted sign-in flows that don't involve an OAuth application. Enabling the `interaction_code` grant type allows OAuth applications to use Identity Engine.
 
 ### Enable interaction code grant on an authorization server
 
@@ -37,13 +37,13 @@ After the Identity Engine feature is enabled for your org, it should become acti
 
 ### Okta-hosted sign-in page (default)
 
-For most authentication flows that involve redirecting to Okta, there should be no other changes needed. After the feature is enabled, the Identity Engine will be used automatically, by default.
+For most authentication flows that involve redirecting to Okta, there should be no other changes needed. After the feature is enabled, Identity Engine is used automatically, by default.
 
 ### Customized sign-in page / custom domain
 
-For most users of the [custom domain](/docs/guides/custom-url-domain/overview/) feature, there are no other changes needed. The default template detects and uses the Identity Engine automatically.
+For most users of the [custom domain](/docs/guides/custom-url-domain/overview/) feature, there are no other changes needed. The default template detects and uses Identity Engine automatically.
 
-However, if you have [modified the template](/docs/guides/style-the-widget/style-okta-hosted/) in certain ways (such as to perform redirects or set cookies), these modifications may not be compatible with the Identity Engine. In particular, these methods and objects won't work with the Identity Engine:
+However, if you have [modified the template](/docs/guides/style-the-widget/style-okta-hosted/) in certain ways (such as to perform redirects or set cookies), these modifications may not be compatible with Identity Engine. In particular, these methods and objects won't work with Identity Engine:
 
 - `setCookieAndRedirect`
 - `sessionToken`
@@ -97,7 +97,7 @@ For reference, here is the default template:
 
 > **Note:** "Embedded" means the Sign-In Widget is included directly in your application through npm module or script tag. The `@okta/okta-signin-widget` version 5.2.0 or above is needed to enable the interaction code flow.
 
-Set the option `useInteractionCodeFlow` to `true` on the object passed to the Sign-In Widget constructor. This enables the Identity Engine for the Widget. Both the authorization server and the application must have the [interaction code](#enable-interaction-code-grant) grant type enabled.
+Set the option `useInteractionCodeFlow` to `true` on the object passed to the Sign-In Widget constructor. This step enables Identity Engine for the Widget. Both the Authorization Server and the application must have the [interaction code](#enable-interaction-code-grant) grant type enabled.
 
 > **Note:** Your code may break if it is calling the `renderEl` method and expects `sessionToken` or `session.setCookieAndRedirect` on the response object. Instead of `renderEl`, we recommend calling the `showSignInToGetTokens` method. This method receives and returns tokens without any browser redirect.
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/android/projectstructure.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/android/projectstructure.md
@@ -1,3 +1,3 @@
-The Okta Identity Engine Android SDK project consists of the following notable directory:
+The Identity Engine Android SDK project consists of the following notable directory:
 
 `okta-idx-android/app` &mdash; contains the files for the embedded authentication with SDK app sample.

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/android/sdkforyourapp.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/android/sdkforyourapp.md
@@ -7,7 +7,7 @@ Follow these steps to integrate the SDK into your own app.
 
 #### Step 2: Import packages and add framework
 
-The embedded authentication with SDK sample apps use the Android framework with the Okta Identity Engine Java SDK. Import the Okta API packages as well as any Android packages that you need.
+The embedded authentication with SDK sample apps use the Android framework with the Identity Engine Java SDK. Import the Okta API packages as well as any Android packages that you need.
 
 ```java
 package com.okta.android.example;

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/android/softwarerequirements.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/android/softwarerequirements.md
@@ -1,4 +1,4 @@
-The Okta Identity Engine Android sample app uses the Identity Engine Java SDK. The Java SDK isn't Android specific, but works with Android.
+The Okta Identity Engine Android sample app uses the Identity Engine Java SDK. The Java SDK isn't Android-specific, but works with Android.
 
 * [Android Studio](https://developer.android.com/studio) 4.2.x or later
 * [JDK 8](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html) or later

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/android/softwarerequirements.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/android/softwarerequirements.md
@@ -1,9 +1,9 @@
-The Okta Identity Engine Android sample app uses the Okta Identity Engine Java SDK. The Java SDK isn't Android specific, but works with Android.
+The Okta Identity Engine Android sample app uses the Identity Engine Java SDK. The Java SDK isn't Android specific, but works with Android.
 
 * [Android Studio](https://developer.android.com/studio) 4.2.x or later
 * [JDK 8](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html) or later
 
-    Include the following Okta Identity Engine Java SDK dependency for Apache Maven:
+    Include the following Identity Engine Java SDK dependency for Apache Maven:
 
     ```groovy
         implementation 'com.okta.idx.sdk: okta-idx-java-api:$okta_sdk_version'

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/java/projectstructure.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/java/projectstructure.md
@@ -1,4 +1,4 @@
-The Okta Identity Engine Java SDK project consists of the following directories:
+The Identity Engine Java SDK project consists of the following directories:
 
 * `okta-idx-java/api/src` &mdash; API source
 * `okta-idx-java/samples` &mdash; Root sample app directory

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/java/sdkforyourapp.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/java/sdkforyourapp.md
@@ -5,11 +5,11 @@ After you run the sample app and explore its available use cases, you can begin 
 1. In your Okta Org, [create a new application integration](/docs/guides/oie-embedded-common-org-setup/java/main/#create-a-new-application) for your app.
 1. Ensure that you have all the [software requirements](#software-requirements).
 1. Clone the [okta-idx-java](https://github.com/okta/okta-idx-java) repository.
-1. Ensure that you have set the Okta Identity Engine Java SDK [dependency](#software-requirements) for Apache Maven. Use the [latest released version](https://github.com/okta/okta-idx-java/releases).
+1. Ensure that you have set the Identity Engine Java SDK [dependency](#software-requirements) for Apache Maven. Use the [latest released version](https://github.com/okta/okta-idx-java/releases).
 
 #### Step 2: Import packages and add framework
 
-Both the embedded authentication with SDK and the embedded Sign-In Widget sample apps use the Spring Boot framework with the Okta Identity Engine Java SDK. Import the Okta API packages as well as any Spring Boot packages you need.
+Both the embedded authentication with SDK and the embedded Sign-In Widget sample apps use the Spring Boot framework with the Identity Engine Java SDK. Import the Okta API packages as well as any Spring Boot packages you need.
 
 ```java
 package com.okta.spring.example;

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/java/softwarerequirements.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/java/softwarerequirements.md
@@ -1,7 +1,7 @@
 * [JDK 8](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html) or later
 * [Apache Maven](https://maven.apache.org/download.cgi) 3.6.x or later
 
-To use the Okta Identity Engine Java SDK, include the following dependency for Apache Maven:
+To use Okta Identity Engine Java SDK, include the following dependency for Apache Maven:
 
 ``` xml
 <dependency>

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/nodejs/projectstructure.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/nodejs/projectstructure.md
@@ -1,6 +1,6 @@
-The source code from the sample app and SDK are located here:
+The source code from the sample app and SDK are located here: `.../okta-auth-js/`.
 
-`.../okta-auth-js/`. The project structure consists of the following:
+The project structure consists of the following:
 
 * `okta-auth-js/docs/idx.md`: Identity Engine introduction and reference
 * `okta-auth-js/samples/generated`: Samples directory

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/nodejs/sdkforyourapp.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/nodejs/sdkforyourapp.md
@@ -16,4 +16,4 @@ See [Using the npm module](https://github.com/okta/okta-auth-js#using-the-npm-mo
 
 #### Step 3: Review the SDK Identity Engine methods
 
-Review the Identity Engine SDK methods for use with your application. See [Usage](https://github.com/okta/okta-auth-js/blob/master/docs/idx.md#usage) for further information.
+Review Identity Engine SDK methods for use with your application. See [Usage](https://github.com/okta/okta-auth-js/blob/master/docs/idx.md#usage) for further information.

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/nodejs/sdkforyourapp.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/nodejs/sdkforyourapp.md
@@ -14,6 +14,6 @@ npm install --save @okta/okta-auth-js
 
 See [Using the npm module](https://github.com/okta/okta-auth-js#using-the-npm-module) for more information.
 
-#### Step 3: Review the SDK Identity Engine methods
+#### Step 3: Review the Identity Engine SDK methods
 
-Review Identity Engine SDK methods for use with your application. See [Usage](https://github.com/okta/okta-auth-js/blob/master/docs/idx.md#usage) for further information.
+Review the Identity Engine SDK methods for use with your application. See [Usage](https://github.com/okta/okta-auth-js/blob/master/docs/idx.md#usage) for further information.

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-cases/oie-embedded-sdk-use-case-sign-in-soc-idp/android/summaryofsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-cases/oie-embedded-sdk-use-case-sign-in-soc-idp/android/summaryofsteps.md
@@ -4,6 +4,6 @@ The following diagram shows the sequence of steps for the Facebook sign-in flow.
 
 <div class="common-image-format">
 
-![Displays the sequence diagram for Identity Engine embedded auth with Java SDK - Sign in with Facebook use case](/img/oie-embedded-sdk/oie-embedded-sdk-use-case-social-sign-in-java.png)
+![Displays the sequence diagram for the Identity Engine embedded auth with Java SDK - Sign in with Facebook use case](/img/oie-embedded-sdk/oie-embedded-sdk-use-case-social-sign-in-java.png)
 
 </div>

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-cases/oie-embedded-sdk-use-case-sign-in-soc-idp/java/summaryofsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-cases/oie-embedded-sdk-use-case-sign-in-soc-idp/java/summaryofsteps.md
@@ -4,6 +4,6 @@ The following diagram shows the sequence of steps for the Facebook sign-in flow.
 
 <div class="common-image-format">
 
-![Displays the sequence diagram for Identity Engine embedded auth with Java SDK - Sign in with Facebook use case](/img/oie-embedded-sdk/oie-embedded-sdk-use-case-social-sign-in-java.png)
+![Displays the sequence diagram for the Identity Engine embedded auth with Java SDK - Sign in with Facebook use case](/img/oie-embedded-sdk/oie-embedded-sdk-use-case-social-sign-in-java.png)
 
 </div>

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-cases/oie-embedded-sdk-use-case-sign-in-soc-idp/nodejs/summaryofsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-cases/oie-embedded-sdk-use-case-sign-in-soc-idp/nodejs/summaryofsteps.md
@@ -4,7 +4,7 @@ The following diagram shows the sequence of steps for the Facebook sign-in flow.
 
 <div class="common-image-format">
 
-![Displays the sequence diagram for Identity Engine embedded auth with Auth JS SDK - Sign in with Facebook use case](/img/oie-embedded-sdk/oie-embedded-sdk-use-case-social-sign-in-nodejs.png)
+![Displays the sequence diagram for the Identity Engine embedded auth with Auth JS SDK - Sign in with Facebook use case](/img/oie-embedded-sdk/oie-embedded-sdk-use-case-social-sign-in-nodejs.png)
 
 </div>
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-intro/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-intro/index.md
@@ -2,26 +2,26 @@
 title: Okta Identity Engine Overview
 meta:
   - name: description
-    content: Okta Identity Engine offers customizable building blocks that can support dynamic, app-based user journeys. Find out more about Okta Identity Engine, why you would use it, and how to upgrade your org.
+    content: Okta Identity Engine offers customizable building blocks that can support dynamic, app-based user journeys. Find out more about Identity Engine, why you would use it, and how to upgrade your org.
 ---
 <ApiLifecycle access="ie" /><br>
 <ApiLifecycle access="Limited GA" />
 
 ## About Okta Identity Engine
 
-Okta Identity Engine is a platform service that allows enterprises to build access experiences tailored to their organizational needs. With [Okta Identity Engine](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie), you are no longer bound to any one way of identifying, authorizing, enrolling, and issuing access to users. Instead, you can customize and extend each of these steps.
+Identity Engine is a platform service that allows enterprises to build access experiences tailored to their organizational needs. With [Identity Engine](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie), you are no longer bound to any one way of identifying, authorizing, enrolling, and issuing access to users. Instead, you can customize and extend each of these steps.
 
-The Okta Identity Engine user authentication deployment model can be divided into two approaches:
+The Identity Engine user authentication deployment model can be divided into two approaches:
 
 * **Redirect authentication:** A user sign-in flow that grants authentication control to Okta by redirecting to an Okta hosted sign-in page using open protocols like OAuth 2.0 and SAML. This approach is recommended for most developers, as it is easier to build and maintain.
 
-* **Embedded authentication:** A user sign-in flow where the application retains authentication control, without redirection to Okta, using a client-hosted Sign-In Widget, Okta Identity Engine SDKs, or directly with Okta's proprietary Identity Engine authentication APIs.
+* **Embedded authentication:** A user sign-in flow where the application retains authentication control, without redirection to Okta, using a client-hosted Sign-In Widget, Identity Engine SDKs, or directly with Okta's proprietary Identity Engine authentication APIs.
 
 See [Redirect authentication vs. embedded authentication](/docs/concepts/redirect-vs-embedded/) for a full list of reasons for using these authentication approaches and a complete overview of the different deployment models.
 
-## Okta Identity Engine SDKs
+## Identity Engine SDKs
 
-To take advantage of these new features and for a better development experience, use the [Okta Identity Engine SDKs](https://developer.okta.com/code/oie/) to manage authentication in your apps.
+To take advantage of these new features and for a better development experience, use the [Identity Engine SDKs](https://developer.okta.com/code/oie/) to manage authentication in your apps.
 
 ### Redirect authentication sample apps
 
@@ -54,9 +54,9 @@ Learn how to implement this approach with the [Embedded authentication with the 
 
 Learn how to implement this approach with the [Embedded authentication with the Sign-In Widget guide](/docs/guides/oie-embedded-widget-overview/).
 
-## Why use Okta Identity Engine?
+## Why use Identity Engine?
 
-Okta Identity Engine provides:
+Identity Engine provides:
 
 * Passwordless authentication
 
@@ -74,10 +74,10 @@ Okta Identity Engine provides:
 
   With MFA enrollment policies, you can create and enforce policies and rules for specific MFA factors and assign groups accordingly. Sign-on policies determine the types of authentication challenges end users experience when they sign in to their account. MFA enrollment policies are based on a variety of elements, such as location, group definitions, and authentication type. See [Create an MFA enrollment policy](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-create-mfa-policy).
 
-## Enable Okta Identity Engine for your organization
+## Enable Identity Engine for your organization
 
-To upgrade to Okta Identity Engine, reach out to your account manager. If you don't have an account manager, reach out to oie@okta.com for more information.
+To upgrade to Identity Engine, reach out to your account manager. If you don't have an account manager, reach out to oie@okta.com for more information.
 
-* The v1 API continues to work as before until you're ready to use new Okta Identity Engine functionality.
+* The v1 API continues to work as before until you're ready to use new Identity Engine functionality.
 * The existing Okta-hosted Widget continues to work after upgrading your org.
 * Upgrade your SDK as you would normally do with other SDK updates.

--- a/packages/@okta/vuepress-site/docs/guides/oie-intro/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-intro/index.md
@@ -9,13 +9,13 @@ meta:
 
 ## About Okta Identity Engine
 
-Identity Engine is a platform service that allows enterprises to build access experiences tailored to their organizational needs. With [Identity Engine](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie), you are no longer bound to any one way of identifying, authorizing, enrolling, and issuing access to users. Instead, you can customize and extend each of these steps.
+The Identity Engine is a platform service that allows enterprises to build access experiences tailored to their organizational needs. With the [Identity Engine](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie), you are no longer bound to any one way of identifying, authorizing, enrolling, and issuing access to users. Instead, you can customize and extend each of these steps.
 
 The Identity Engine user authentication deployment model can be divided into two approaches:
 
 * **Redirect authentication:** A user sign-in flow that grants authentication control to Okta by redirecting to an Okta hosted sign-in page using open protocols like OAuth 2.0 and SAML. This approach is recommended for most developers, as it is easier to build and maintain.
 
-* **Embedded authentication:** A user sign-in flow where the application retains authentication control, without redirection to Okta, using a client-hosted Sign-In Widget, Identity Engine SDKs, or directly with Okta's proprietary Identity Engine authentication APIs.
+* **Embedded authentication:** A user sign-in flow where the application retains authentication control, without redirection to Okta, using a client-hosted Sign-In Widget, the Identity Engine SDKs, or directly with Okta's proprietary Identity Engine authentication APIs.
 
 See [Redirect authentication vs. embedded authentication](/docs/concepts/redirect-vs-embedded/) for a full list of reasons for using these authentication approaches and a complete overview of the different deployment models.
 
@@ -54,9 +54,9 @@ Learn how to implement this approach with the [Embedded authentication with the 
 
 Learn how to implement this approach with the [Embedded authentication with the Sign-In Widget guide](/docs/guides/oie-embedded-widget-overview/).
 
-## Why use Identity Engine?
+## Why use the Identity Engine?
 
-Identity Engine provides:
+The Identity Engine provides:
 
 * Passwordless authentication
 
@@ -74,9 +74,9 @@ Identity Engine provides:
 
   With MFA enrollment policies, you can create and enforce policies and rules for specific MFA factors and assign groups accordingly. Sign-on policies determine the types of authentication challenges end users experience when they sign in to their account. MFA enrollment policies are based on a variety of elements, such as location, group definitions, and authentication type. See [Create an MFA enrollment policy](https://help.okta.com/en/oie/okta_help_CSH.htm#ext-create-mfa-policy).
 
-## Enable Identity Engine for your organization
+## Enable the Identity Engine for your organization
 
-To upgrade to Identity Engine, reach out to your account manager. If you don't have an account manager, reach out to oie@okta.com for more information.
+To upgrade to the Identity Engine, reach out to your account manager. If you don't have an account manager, reach out to oie@okta.com for more information.
 
 * The v1 API continues to work as before until you're ready to use new Identity Engine functionality.
 * The existing Okta-hosted Widget continues to work after upgrading your org.

--- a/packages/@okta/vuepress-site/docs/guides/registration-inline-hook/activate-and-enable/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/registration-inline-hook/activate-and-enable/index.md
@@ -24,7 +24,7 @@ The Registration Inline Hook is now set up with a status of active.
 
 The procedure to enable the Registration Inline Hook is dependent on the type of org you are using: Okta Identity Engine or Okta Classic Engine. Follow the procedure for your specific org.
 
-#### Enable a Registration Inline Hook in Identity Engine
+#### Enable a Registration Inline Hook in the Identity Engine
 
 <ApiLifecycle access="ie" />
 If you have an Identity Engine org, you must [enable and configure a profile enrollment policy](https://help.okta.com/oie/en-us/Content/Topics/identity-engine/policies/create-profile-enrollment-policy-sr.htm) to implement a Registration Inline Hook.

--- a/packages/@okta/vuepress-site/docs/guides/registration-inline-hook/activate-and-enable/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/registration-inline-hook/activate-and-enable/index.md
@@ -24,10 +24,10 @@ The Registration Inline Hook is now set up with a status of active.
 
 The procedure to enable the Registration Inline Hook is dependent on the type of org you are using: Okta Identity Engine or Okta Classic Engine. Follow the procedure for your specific org.
 
-#### Enable a Registration Inline Hook in Okta Identity Engine
+#### Enable a Registration Inline Hook in Identity Engine
 
 <ApiLifecycle access="ie" />
-If you have an Okta Identity Engine org, you must [enable and configure a profile enrollment policy](https://help.okta.com/oie/en-us/Content/Topics/identity-engine/policies/create-profile-enrollment-policy-sr.htm) to implement a Registration Inline Hook.
+If you have an Identity Engine org, you must [enable and configure a profile enrollment policy](https://help.okta.com/oie/en-us/Content/Topics/identity-engine/policies/create-profile-enrollment-policy-sr.htm) to implement a Registration Inline Hook.
 
 > **Note:** Profile Enrollment and Registration Inline Hooks are only supported with the [Okta Sign-In Widget](/code/javascript/okta_sign-in_widget/) version 4.5 or later.
 

--- a/packages/@okta/vuepress-site/docs/guides/registration-inline-hook/activate-and-enable/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/registration-inline-hook/activate-and-enable/index.md
@@ -22,7 +22,7 @@ The Registration Inline Hook is now set up with a status of active.
 
 ### Enable the Registration Inline Hook
 
-The procedure to enable the Registration Inline Hook is dependent on the type of org you are using: Okta Identity Engine or Okta Classic. Follow the procedure for your specific org.
+The procedure to enable the Registration Inline Hook is dependent on the type of org you are using: Okta Identity Engine or Okta Classic Engine. Follow the procedure for your specific org.
 
 #### Enable a Registration Inline Hook in Okta Identity Engine
 
@@ -47,10 +47,10 @@ Your Registration Inline Hook is now configured for Profile Enrollment. You are 
 
 > **Note:** Only one Inline Hook can be associated with your Profile Enrollment policy at a time.
 
-#### Enable the Registration Inline Hook in Okta Classic
+#### Enable the Registration Inline Hook in Classic Engine
 
 <ApiLifecycle access="ea" />
-If you have an Okta Classic org, you must enable [self-service registration (SSR)](/docs/guides/set-up-self-service-registration/before-you-begin/) to implement a Registration Inline Hook.
+If you have a Classic Engine org, you must enable [self-service registration (SSR)](/docs/guides/set-up-self-service-registration/before-you-begin/) to implement a Registration Inline Hook.
 
 > **Note:** Self-service registration and Registration Inline Hooks are only supported with the [Okta Sign-In Widget](/code/javascript/okta_sign-in_widget/) version 2.9 or later.
 

--- a/packages/@okta/vuepress-site/docs/guides/sampleapp-oie-redirectauth/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sampleapp-oie-redirectauth/index.md
@@ -1,6 +1,6 @@
 ---
 title: Use redirect auth with the sample apps
-excerpt: Learn how to test some of the features of Identity Engine with our sample apps
+excerpt: Learn how to test some of the features of Okta Identity Engine with our sample apps
 layout: Guides
 sections:
  - main

--- a/packages/@okta/vuepress-site/docs/guides/sampleapp-oie-redirectauth/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sampleapp-oie-redirectauth/main/index.md
@@ -1,13 +1,13 @@
 ---
 title: Use redirect auth with the sample apps
-excerpt: Learn how to test some of the features of Identity Engine with our sample apps
+excerpt: Learn how to test some of the features of Okta Identity Engine with our sample apps
 layout: Guides
 ---
 
 <ApiLifecycle access="ie" /><br>
 <ApiLifecycle access="Limited GA" /><br>
 
-This document walks you through setting up an Okta sample app to demonstrate some Identity Engine features. Among the many set up options available with the Okta sample apps, the apps can redirect to Okta's Sign-In Widget, or to a social Identity Provider like Facebook, for authentication. The following scenarios are included in this guide:
+This document walks you through setting up an Okta sample app to demonstrate some Okta Identity Engine features. Among the many set-up options available with the Okta sample apps, the apps can redirect to the Okta Sign-In Widget, or to a social Identity Provider like Facebook, for authentication. The following scenarios are included in this guide:
 
 * [Simple enrollment and authentication](#simple-enrollment-and-authentication)
 * [Enable self-service enrollment](#enable-self-service-enrollment)

--- a/packages/@okta/vuepress-site/docs/reference/api/authenticators-admin/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/authenticators-admin/index.md
@@ -12,7 +12,7 @@ The Authenticators Administration API enables an Org Administrator to configure 
 
 End users are required to use one or more Authenticators depending on the security requirements of the application sign-on policy.
 
-The Okta Identity Engine currently supports Authenticators for the following factors:
+Okta Identity Engine currently supports Authenticators for the following factors:
 
 **Knowledge-based:**
 

--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -759,7 +759,7 @@ Specifies a set of Groups whose Users are to be included or excluded
 <ApiLifecycle access="ie" /><br>
 <ApiLifecycle access="Limited GA" /><br>
 
-> **Note:** This feature is only available as a part of the Okta Identity Engine. Contact [Support](mailto:dev-inquiries@okta.com) for more information.
+> **Note:** This feature is only available as a part of Okta Identity Engine. Contact [Support](mailto:dev-inquiries@okta.com) for more information.
 
 Specifies which [User Types](/docs/reference/api/user-types/#user-type-object) to include and/or exclude. You can use the [User Types API](/docs/reference/api/user-types/) to manage User Types.
 
@@ -999,7 +999,7 @@ Specifies a particular platform or device to match on
 <ApiLifecycle access="ie" /><br>
 <ApiLifecycle access="Limited GA" /><br>
 
-> **Note:** This feature is only available as a part of the Okta Identity Engine. Please [contact support](mailto:dev-inquiries@okta.com) for further information.
+> **Note:** This feature is only available as a part of Identity Engine. Please [contact support](mailto:dev-inquiries@okta.com) for further information.
 
 Specifies the device condition to match on
 
@@ -1362,7 +1362,7 @@ Specifies how lookups for weak passwords are done. Designed to be extensible wit
 #### Recovery object
 
 The Password Policy object contains the factors used for password recovery and account unlock.
-However, if you are using Okta Identity Engine, it is recommended to set recovery factors in the Password Policy Rule as shown in the examples under [Password Rules Action Data](#password-actions-example).
+However, if you are using Identity Engine, it is recommended to set recovery factors in the Password Policy Rule as shown in the examples under [Password Rules Action Data](#password-actions-example).
 
 | Property | Description                                            | Data Type                                           | Required |
 | ---      | ---                                                    | ---                                                 | ---      |
@@ -1468,7 +1468,7 @@ The following conditions may be applied to Password Policy:
 <ApiLifecycle access="ie" /><br>
 <ApiLifecycle access="Limited GA" /><br>
 
-With Okta Identity Engine, Recovery Factors can be specified inside the Password Policy Rule object instead of in the Policy Settings object. Recovery Factors for the rule are defined inside the `selfServicePasswordReset` Action.
+With Identity Engine, Recovery Factors can be specified inside the Password Policy Rule object instead of in the Policy Settings object. Recovery Factors for the rule are defined inside the `selfServicePasswordReset` Action.
 
 The following three examples demonstrate how Recovery Factors are configured in the Rule based on admin requirements.
 
@@ -1575,7 +1575,7 @@ In the final example, end users are required to verify two Authenticators before
 
 ##### Self Service Password Reset Action object
 
-> **Note:** The following indicated objects and properties are only available as a part of Okta Identity Engine. Please contact support for further information.
+> **Note:** The following indicated objects and properties are only available as a part of Identity Engine. Please contact support for further information.
 
 | Property                                                       | Data Type   | Description                                                                                 | Supported Values                | Required | Default
 | ---                                                            | ---         | ---                                                                                         | ---                             | ---      | ---
@@ -1626,7 +1626,7 @@ You can apply the following conditions to the IdP Discovery Policy:
 | ---       | ---                                                                  | ---       | ---      |
 | providers | List of configured Identity Providers that a given Rule can route to | array     | Yes      |
 
-> **Note:** Ability to define multiple providers is a part of Okta Identity Engine.
+> **Note:** Ability to define multiple providers is a part of Identity Engine.
 > Please [contact support](mailto:dev-inquiries@okta.com) for further information.
 
 > **Note:** IdP types of `OKTA`, `AgentlessDSSO`, and `IWA` don't require an `id`.
@@ -1651,7 +1651,7 @@ You can apply the following conditions to the IdP Discovery Policy:
 <ApiLifecycle access="ie" />
 <ApiLifecycle access="Limited GA" /><br>
 
-> **Note:** This feature is only available as a part of Okta Identity Engine. [Contact support](mailto:dev-inquiries@okta.com) for further information.
+> **Note:** This feature is only available as a part of Identity Engine. [Contact support](mailto:dev-inquiries@okta.com) for further information.
 
 You can define multiple IdP instances in a single Policy Action. This allows users to choose a Provider when they sign in.
 
@@ -1702,9 +1702,9 @@ You can define multiple IdP instances in a single Policy Action. This allows use
 <ApiLifecycle access="ie" /><br>
 <ApiLifecycle access="Limited GA" /><br>
 
-> **Note:** This feature is only available as a part of Okta Identity Engine. [Contact support](mailto:dev-inquiries@okta.com) for further information.
+> **Note:** This feature is only available as a part of Identity Engine. [Contact support](mailto:dev-inquiries@okta.com) for further information.
 
-The app sign-on policy determines the extra levels of authentication (if any) that must be performed before you can invoke a specific Okta application. It is always associated with an app through a Mapping. Okta Identity Engine always evaluates both the Okta sign-on policy and the sign-on policy for the app. The resulting user experience is the union of both policies. App sign-on policies have the type `ACCESS_POLICY`.
+The app sign-on policy determines the extra levels of authentication (if any) that must be performed before you can invoke a specific Okta application. It is always associated with an app through a Mapping. Identity Engine always evaluates both the Okta sign-on policy and the sign-on policy for the app. The resulting user experience is the union of both policies. App sign-on policies have the type `ACCESS_POLICY`.
 
 > **Note:** You can have a maximum of 5000 app sign-on policies in an org.
 > There is a max limit of 100 rules allowed per policy.
@@ -1936,7 +1936,7 @@ The number of Authenticator class constraints in each Constraint object must be 
 <ApiLifecycle access="ie" /><br>
 <ApiLifecycle access="Limited GA" /><br>
 
-> **Note:** This feature is only available as a part of Okta Identity Engine. [Contact support](mailto:dev-inquiries@okta.com) for further information.
+> **Note:** This feature is only available as a part of Identity Engine. [Contact support](mailto:dev-inquiries@okta.com) for further information.
 
 Profile Enrollemnt policies specify which profile attributes are required for creating new Users through self-service registration, and also can be used for progressive profiling. The type is specified as `PROFILE_ENROLLMENT`.
 

--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -564,7 +564,7 @@ The Policy object defines several attributes:
 | Parameter   | Description                                                                                                                                          | Data Type                                         | Required | Default                |
 | ---------   | -----------                                                                                                                                          | ---------                                         | -------- | -------                |
 | id          | Identifier of the Policy                                                                                                                             | String                                            | No       | Assigned               |
-| type        | Specifies the [type of Policy](#policy-types). Valid values: `OKTA_SIGN_ON`, `PASSWORD`, `MFA_ENROLL`, `OAUTH_AUTHORIZATION_POLICY`, or `IDP_DISCOVERY`.<br><br> <ApiLifecycle access="ie" /><br>**Note:** The following policy types are available only with Identity Engine: `ACCESS_POLICY` or `PROFILE_ENROLLMENT`.<br> [Contact support](mailto:dev-inquiries@okta.com) for more information on Identity Engine.  | String                                            | Yes      |                        |
+| type        | Specifies the [type of Policy](#policy-types). Valid values: `OKTA_SIGN_ON`, `PASSWORD`, `MFA_ENROLL`, `OAUTH_AUTHORIZATION_POLICY`, or `IDP_DISCOVERY`.<br><br> <ApiLifecycle access="ie" /><br>**Note:** The following policy types are available only with the Identity Engine: `ACCESS_POLICY` or `PROFILE_ENROLLMENT`.<br> [Contact support](mailto:dev-inquiries@okta.com) for more information on the Identity Engine.  | String                                            | Yes      |                        |
 | name        | Name of the Policy                                                                                                                                   | String                                            | Yes      |                        |
 | system      | This is set to `true` on system policies, which cannot be deleted.                                                                                   | Boolean                                           | No       | `false`                |
 | description | Description of the Policy.                                                                                                                           | String                                            | No       | Null                   |
@@ -680,7 +680,7 @@ The Rules object defines several attributes:
 | Parameter     | Description                                                        | Data Type                                      | Required   | Default                |
 | :------------ | :----------------------------------------------------------------- | :--------------------------------------------- | :--------- | :--------------------- |
 | id            | Identifier of the Rule                                             | String                                         | No         | Assigned               |
-| type          | Rule type. Valid values: `SIGN_ON`, `PASSWORD`, `MFA_ENROLL`, `IDP_DISCOVERY`.<br><br> <ApiLifecycle access="ie" /><br>**Note:** The following policy types are available only with Identity Engine: `ACCESS_POLICY` or `PROFILE_ENROLLMENT`. <br>[Contact support](mailto:dev-inquiries@okta.com) for more information on Identity Engine.| String (Enum)                                  | Yes        |                        |
+| type          | Rule type. Valid values: `SIGN_ON`, `PASSWORD`, `MFA_ENROLL`, `IDP_DISCOVERY`.<br><br> <ApiLifecycle access="ie" /><br>**Note:** The following policy types are available only with the Identity Engine: `ACCESS_POLICY` or `PROFILE_ENROLLMENT`. <br>[Contact support](mailto:dev-inquiries@okta.com) for more information on the Identity Engine.| String (Enum)                                  | Yes        |                        |
 | name          | Name of the Rule                                                   | String                                         | Yes        |                        |
 | status        | Status of the Rule: `ACTIVE` or `INACTIVE`                         | String (Enum)                                  | No         | ACTIVE                 |
 | priority      | Priority of the Rule                                               | Integer                                        | No         | Last / Lowest Priority |
@@ -759,7 +759,7 @@ Specifies a set of Groups whose Users are to be included or excluded
 <ApiLifecycle access="ie" /><br>
 <ApiLifecycle access="Limited GA" /><br>
 
-> **Note:** This feature is only available as a part of Okta Identity Engine. Contact [Support](mailto:dev-inquiries@okta.com) for more information.
+> **Note:** This feature is only available as a part of the Identity Engine. Contact [Support](mailto:dev-inquiries@okta.com) for more information.
 
 Specifies which [User Types](/docs/reference/api/user-types/#user-type-object) to include and/or exclude. You can use the [User Types API](/docs/reference/api/user-types/) to manage User Types.
 
@@ -999,7 +999,7 @@ Specifies a particular platform or device to match on
 <ApiLifecycle access="ie" /><br>
 <ApiLifecycle access="Limited GA" /><br>
 
-> **Note:** This feature is only available as a part of Identity Engine. Please [contact support](mailto:dev-inquiries@okta.com) for further information.
+> **Note:** This feature is only available as a part of the Identity Engine. Please [contact support](mailto:dev-inquiries@okta.com) for further information.
 
 Specifies the device condition to match on
 
@@ -1011,8 +1011,8 @@ Specifies the device condition to match on
 > **Note:** When `managed` is passed, `registered` must also be included and must be set to `true`.
 
 For details on integration with a device management system, see
- - [Configure Device Trust on Identity Engine for desktop devices](https://help.okta.com/oie/en-us/Content/Topics/identity-engine/devices/config-desktop.htm)
- - [Configure Device Trust on Identity Engine for mobile devices](https://help.okta.com/oie/en-us/Content/Topics/identity-engine/devices/config-mobile.htm)
+ - [Configure Device Trust on the Identity Engine for desktop devices](https://help.okta.com/oie/en-us/Content/Topics/identity-engine/devices/config-desktop.htm)
+ - [Configure Device Trust on the Identity Engine for mobile devices](https://help.okta.com/oie/en-us/Content/Topics/identity-engine/devices/config-mobile.htm)
 #### Device Condition object example
 
 ```json
@@ -1362,7 +1362,7 @@ Specifies how lookups for weak passwords are done. Designed to be extensible wit
 #### Recovery object
 
 The Password Policy object contains the factors used for password recovery and account unlock.
-However, if you are using Identity Engine, it is recommended to set recovery factors in the Password Policy Rule as shown in the examples under [Password Rules Action Data](#password-actions-example).
+However, if you are using the Identity Engine, it is recommended to set recovery factors in the Password Policy Rule as shown in the examples under [Password Rules Action Data](#password-actions-example).
 
 | Property | Description                                            | Data Type                                           | Required |
 | ---      | ---                                                    | ---                                                 | ---      |
@@ -1468,7 +1468,7 @@ The following conditions may be applied to Password Policy:
 <ApiLifecycle access="ie" /><br>
 <ApiLifecycle access="Limited GA" /><br>
 
-With Identity Engine, Recovery Factors can be specified inside the Password Policy Rule object instead of in the Policy Settings object. Recovery Factors for the rule are defined inside the `selfServicePasswordReset` Action.
+With the Identity Engine, Recovery Factors can be specified inside the Password Policy Rule object instead of in the Policy Settings object. Recovery Factors for the rule are defined inside the `selfServicePasswordReset` Action.
 
 The following three examples demonstrate how Recovery Factors are configured in the Rule based on admin requirements.
 
@@ -1575,7 +1575,7 @@ In the final example, end users are required to verify two Authenticators before
 
 ##### Self Service Password Reset Action object
 
-> **Note:** The following indicated objects and properties are only available as a part of Identity Engine. Please contact support for further information.
+> **Note:** The following indicated objects and properties are only available as a part of the Identity Engine. Please contact support for further information.
 
 | Property                                                       | Data Type   | Description                                                                                 | Supported Values                | Required | Default
 | ---                                                            | ---         | ---                                                                                         | ---                             | ---      | ---
@@ -1626,7 +1626,7 @@ You can apply the following conditions to the IdP Discovery Policy:
 | ---       | ---                                                                  | ---       | ---      |
 | providers | List of configured Identity Providers that a given Rule can route to | array     | Yes      |
 
-> **Note:** Ability to define multiple providers is a part of Identity Engine.
+> **Note:** Ability to define multiple providers is a part of the Identity Engine.
 > Please [contact support](mailto:dev-inquiries@okta.com) for further information.
 
 > **Note:** IdP types of `OKTA`, `AgentlessDSSO`, and `IWA` don't require an `id`.
@@ -1651,7 +1651,7 @@ You can apply the following conditions to the IdP Discovery Policy:
 <ApiLifecycle access="ie" />
 <ApiLifecycle access="Limited GA" /><br>
 
-> **Note:** This feature is only available as a part of Identity Engine. [Contact support](mailto:dev-inquiries@okta.com) for further information.
+> **Note:** This feature is only available as a part of the Identity Engine. [Contact support](mailto:dev-inquiries@okta.com) for further information.
 
 You can define multiple IdP instances in a single Policy Action. This allows users to choose a Provider when they sign in.
 
@@ -1702,9 +1702,9 @@ You can define multiple IdP instances in a single Policy Action. This allows use
 <ApiLifecycle access="ie" /><br>
 <ApiLifecycle access="Limited GA" /><br>
 
-> **Note:** This feature is only available as a part of Identity Engine. [Contact support](mailto:dev-inquiries@okta.com) for further information.
+> **Note:** This feature is only available as a part of the Identity Engine. [Contact support](mailto:dev-inquiries@okta.com) for further information.
 
-The app sign-on policy determines the extra levels of authentication (if any) that must be performed before you can invoke a specific Okta application. It is always associated with an app through a Mapping. Identity Engine always evaluates both the Okta sign-on policy and the sign-on policy for the app. The resulting user experience is the union of both policies. App sign-on policies have the type `ACCESS_POLICY`.
+The app sign-on policy determines the extra levels of authentication (if any) that must be performed before you can invoke a specific Okta application. It is always associated with an app through a Mapping. The Identity Engine always evaluates both the Okta sign-on policy and the sign-on policy for the app. The resulting user experience is the union of both policies. App sign-on policies have the type `ACCESS_POLICY`.
 
 > **Note:** You can have a maximum of 5000 app sign-on policies in an org.
 > There is a max limit of 100 rules allowed per policy.
@@ -1936,7 +1936,7 @@ The number of Authenticator class constraints in each Constraint object must be 
 <ApiLifecycle access="ie" /><br>
 <ApiLifecycle access="Limited GA" /><br>
 
-> **Note:** This feature is only available as a part of Identity Engine. [Contact support](mailto:dev-inquiries@okta.com) for further information.
+> **Note:** This feature is only available as a part of the Identity Engine. [Contact support](mailto:dev-inquiries@okta.com) for further information.
 
 Profile Enrollemnt policies specify which profile attributes are required for creating new Users through self-service registration, and also can be used for progressive profiling. The type is specified as `PROFILE_ENROLLMENT`.
 

--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language-in-identity-engine/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language-in-identity-engine/index.md
@@ -1,18 +1,18 @@
 ---
-title: Expression Language in Identity Engine
+title: Okta Expression Language in Okta Identity Engine
 meta:
 - name: description
-  content: Learn more about the features and syntax of the Okta Expression Language in Identity Engine.
+  content: Learn more about the features and syntax of the Okta Expression Language in Okta Identity Engine.
 ---
 
-# Okta Expression Language in Identity Engine
+# Okta Expression Language in Okta Identity Engine
 
 <ApiLifecycle access="ie" /><br>
 <ApiLifecycle access="Limited GA" />
 
 ## Overview
 
-This document details the features and syntax of the Okta Expression Language used in the Identity Engine. Expressions being used outside of the Identity Engine should continue using the features and syntax of [the legacy Okta Expression Language](/docs/reference/okta-expression-language/). This document is updated as new capabilities are added to the language. Okta Expression Language is based on a subset of [SpEL functionality](http://docs.spring.io/spring/docs/3.0.x/reference/expressions.html).
+This document details the features and syntax of Okta Expression Language used in Identity Engine. Expressions used outside of Identity Engine should continue using the features and syntax of [the legacy Okta Expression Language](/docs/reference/okta-expression-language/). This document is updated as new capabilities are added to the language. Okta Expression Language is based on a subset of [SpEL functionality](http://docs.spring.io/spring/docs/3.0.x/reference/expressions.html).
 
 ## Unsupported features
 

--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language-in-identity-engine/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language-in-identity-engine/index.md
@@ -12,7 +12,7 @@ meta:
 
 ## Overview
 
-This document details the features and syntax of Okta Expression Language used in Identity Engine. Expressions used outside of Identity Engine should continue using the features and syntax of [the legacy Okta Expression Language](/docs/reference/okta-expression-language/). This document is updated as new capabilities are added to the language. Okta Expression Language is based on a subset of [SpEL functionality](http://docs.spring.io/spring/docs/3.0.x/reference/expressions.html).
+This document details the features and syntax of Okta Expression Language used in the Identity Engine. Expressions used outside of the Identity Engine should continue using the features and syntax of [the legacy Okta Expression Language](/docs/reference/okta-expression-language/). This document is updated as new capabilities are added to the language. Okta Expression Language is based on a subset of [SpEL functionality](http://docs.spring.io/spring/docs/3.0.x/reference/expressions.html).
 
 ## Unsupported features
 

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -21,7 +21,7 @@ For information on the API for registering external service endpoints with Okta,
 
 For steps to enable this Inline Hook, see below, [Enabling a Registration Inline Hook](#enable-a-registration-inline-hook-for-profile-enrollment-in-okta-identity-engine). <ApiLifecycle access="ie" /><br>
 
-For steps to enable this Inline Hook in Okta Classic Engine, see below, [Enabling a Registration Inline Hook in Classic Engine](#enable-a-registration-inline-hook-for-self-service-registration-in-classic-engine)
+For steps to enable this Inline Hook in Okta Classic Engine, see [Enabling a Registration Inline Hook in the Classic Engine].(#enable-a-registration-inline-hook-for-self-service-registration-in-classic-engine)
 
 For an example implementation of this Inline Hook, see [Registration Inline Hook](/docs/guides/registration-inline-hook).
 
@@ -237,7 +237,7 @@ If there is a response timeout after receiving the Okta request, the Okta proces
 
 <ApiLifecycle access="ie" /><br>
 
-> **Note:** This feature is only available as a part of Identity Engine. Please [contact support](mailto:dev-inquiries@okta.com) for further information.
+> **Note:** This feature is only available as a part of the Identity Engine. Please [contact support](mailto:dev-inquiries@okta.com) for further information.
 
 To activate the Inline Hook, you first need to register your external service endpoint with Okta; see [Inline Hook Setup](/docs/concepts/inline-hooks/#inline-hooks_setup).
 
@@ -257,11 +257,11 @@ Your Registration Inline Hook is now configured for Profile Enrollment.
 
 > **Note:** Only one Inline Hook can be associated with your Profile Enrollment policy at a time.
 
-## Enable a Registration Inline Hook for Self-Service Registration in Classic Engine
+## Enable a Registration Inline Hook for Self-Service Registration in the Classic Engine
 
 <ApiLifecycle access="ea" />
 
-> **Note:** Self-Service Registration only exists in Classic Engine. For Identity Engine, please see instructions for Profile Enrollment above.
+> **Note:** Self-Service Registration only exists in the Classic Engine. For the Identity Engine, please see instructions for Profile Enrollment above.
 
 To activate the Inline Hook, you first need to register your external service endpoint with Okta; see [Inline Hook Setup](/docs/concepts/inline-hooks/#inline-hooks_setup).
 

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -237,7 +237,7 @@ If there is a response timeout after receiving the Okta request, the Okta proces
 
 <ApiLifecycle access="ie" /><br>
 
-> **Note:** This feature is only available as a part of the Okta Identity Engine. Please [contact support](mailto:dev-inquiries@okta.com) for further information.
+> **Note:** This feature is only available as a part of Identity Engine. Please [contact support](mailto:dev-inquiries@okta.com) for further information.
 
 To activate the Inline Hook, you first need to register your external service endpoint with Okta; see [Inline Hook Setup](/docs/concepts/inline-hooks/#inline-hooks_setup).
 
@@ -261,7 +261,7 @@ Your Registration Inline Hook is now configured for Profile Enrollment.
 
 <ApiLifecycle access="ea" />
 
-> **Note:** Self-Service Registration only exists in Classic Engine. For Okta Identity Engine, please see instructions for Profile Enrollment above.
+> **Note:** Self-Service Registration only exists in Classic Engine. For Identity Engine, please see instructions for Profile Enrollment above.
 
 To activate the Inline Hook, you first need to register your external service endpoint with Okta; see [Inline Hook Setup](/docs/concepts/inline-hooks/#inline-hooks_setup).
 

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -21,7 +21,7 @@ For information on the API for registering external service endpoints with Okta,
 
 For steps to enable this Inline Hook, see below, [Enabling a Registration Inline Hook](#enable-a-registration-inline-hook-for-profile-enrollment-in-okta-identity-engine). <ApiLifecycle access="ie" /><br>
 
-For steps to enable this Inline Hook in Okta classic, see below, [Enabling a Registration Inline Hook in Okta Classic](#enable-a-registration-inline-hook-for-self-service-registration-in-okta-classic)
+For steps to enable this Inline Hook in Okta Classic Engine, see below, [Enabling a Registration Inline Hook in Classic Engine](#enable-a-registration-inline-hook-for-self-service-registration-in-classic-engine)
 
 For an example implementation of this Inline Hook, see [Registration Inline Hook](/docs/guides/registration-inline-hook).
 
@@ -257,11 +257,11 @@ Your Registration Inline Hook is now configured for Profile Enrollment.
 
 > **Note:** Only one Inline Hook can be associated with your Profile Enrollment policy at a time.
 
-## Enable a Registration Inline Hook for Self-Service Registration in Okta Classic
+## Enable a Registration Inline Hook for Self-Service Registration in Classic Engine
 
 <ApiLifecycle access="ea" />
 
-> **Note:** Self-Service Registration only exists in Okta Classic. For Okta Identity Engine, please see instructions for Profile Enrollment above.
+> **Note:** Self-Service Registration only exists in Classic Engine. For Okta Identity Engine, please see instructions for Profile Enrollment above.
 
 To activate the Inline Hook, you first need to register your external service endpoint with Okta; see [Inline Hook Setup](/docs/concepts/inline-hooks/#inline-hooks_setup).
 

--- a/packages/@okta/vuepress-site/docs/reference/rl-additional-limits/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/rl-additional-limits/index.md
@@ -52,7 +52,7 @@ These rate limits apply to all new Okta organizations. For orgs created before 2
 Okta limits the number of requests:
 * From the Admin Console and the End-User Dashboard, to 40 requests per user per 10 seconds per endpoint. This rate limit protects users from each other and from other API requests in the system.
 
-* To the Identity Engine, to 20 requests per user per 5 seconds and 10 requests per state token per 5 seconds. <ApiLifecycle access="ie" />
+* To Identity Engine, to 20 requests per user per 5 seconds and 10 requests per state token per 5 seconds. <ApiLifecycle access="ie" />
 
 If a user exceeds this limit, they receive an HTTP 429 error response without affecting other users in your org. A message is written to the System Log that indicates that the end-user rate limit was encountered.
 

--- a/packages/@okta/vuepress-site/docs/reference/rl-additional-limits/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/rl-additional-limits/index.md
@@ -52,7 +52,7 @@ These rate limits apply to all new Okta organizations. For orgs created before 2
 Okta limits the number of requests:
 * From the Admin Console and the End-User Dashboard, to 40 requests per user per 10 seconds per endpoint. This rate limit protects users from each other and from other API requests in the system.
 
-* To Identity Engine, to 20 requests per user per 5 seconds and 10 requests per state token per 5 seconds. <ApiLifecycle access="ie" />
+* To the Identity Engine, to 20 requests per user per 5 seconds and 10 requests per state token per 5 seconds. <ApiLifecycle access="ie" />
 
 If a user exceeds this limit, they receive an HTTP 429 error response without affecting other users in your org. A message is written to the System Log that indicates that the end-user rate limit was encountered.
 

--- a/packages/@okta/vuepress-site/docs/reference/rl-system-log-events/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/rl-system-log-events/index.md
@@ -306,7 +306,7 @@ The following is an example System Log rate limit event where too many OTP verif
 The following is an example of a System Log rate limit event for too many profile reload attempts through Active Directory or LDAP agent.
 
 <ApiLifecycle access="ie" /><br>
-> **Note:** This event is valid for Identity Engine only.
+> **Note:** This event is valid for the Identity Engine only.
 
 ```json
 {
@@ -412,7 +412,7 @@ The following is an example of a System Log rate limit event for too many profil
 The following table includes the available `Subtypes` for operation rate limits.
 
 <ApiLifecycle access="ie" /><br>
-> **Note:** The `AD agent` and `LDAP agent` subtypes are only available for Identity Engine.
+> **Note:** The `AD agent` and `LDAP agent` subtypes are only available for the Identity Engine.
 
 | Subtype           | Description                                                         |
 | ----------------- | ------------------------------------------------------------------- |

--- a/packages/@okta/vuepress-site/docs/reference/rl-system-log-events/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/rl-system-log-events/index.md
@@ -306,7 +306,7 @@ The following is an example System Log rate limit event where too many OTP verif
 The following is an example of a System Log rate limit event for too many profile reload attempts through Active Directory or LDAP agent.
 
 <ApiLifecycle access="ie" /><br>
-> **Note:** This event is valid for Okta Identity Engine only.
+> **Note:** This event is valid for Identity Engine only.
 
 ```json
 {
@@ -412,7 +412,7 @@ The following is an example of a System Log rate limit event for too many profil
 The following table includes the available `Subtypes` for operation rate limits.
 
 <ApiLifecycle access="ie" /><br>
-> **Note:** The `AD agent` and `LDAP agent` subtypes are only available for Okta Identity Engine.
+> **Note:** The `AD agent` and `LDAP agent` subtypes are only available for Identity Engine.
 
 | Subtype           | Description                                                         |
 | ----------------- | ------------------------------------------------------------------- |

--- a/packages/@okta/vuepress-site/docs/release-notes/2021/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2021/index.md
@@ -487,7 +487,7 @@ When an OAuth2 request was made with an access token instead of a required ID to
 
 * When `AppUser` was updated after enabling `APPLICATION_ENTITLEMENT_POLICY`, some [user attributes](/docs/guides/build-provisioning-integration/-/attribute-mapping/), such as the Manager attribute, were prevented from being updated in an application. (OKTA-329758)
 
-* When using the [`/api/v1/users` endpoint](/docs/reference/api/users/) to generate the sign-in request for an Identity engine user through a mapping, if you created the same user by sending in more than one request at the same time, an incorrect 500 error message (internal server error) was sometimes returned instead of a 400 error message. (OKTA-318474)
+* When using the [`/api/v1/users` endpoint](/docs/reference/api/users/) to generate the sign-in request for an Okta Identity engine user through a mapping, if you created the same user by sending in more than one request at the same time, an incorrect 500 error message (internal server error) was sometimes returned instead of a 400 error message. (OKTA-318474)
 
 ### Monthly Release 2021.03.0
 

--- a/packages/@okta/vuepress-site/docs/release-notes/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/index.md
@@ -7,7 +7,7 @@ meta:
 
 # Okta API Products Release Notes
 
-These release notes list customer-visible changes to API Products by release number. Additionally, separate Okta Identity Engine API release notes are provided that list customer-visible changes to Okta Identity Engine API Products by release number.
+These release notes list customer-visible changes to API Products by release number. Additionally, separate Okta Identity Engine API release notes are provided that list customer-visible changes to the Identity Engine API Products by release number.
 
 The release notes are organized by year in descending order. In the left-side navigation bar, select the year of the release note that you want to view. The page for the release year opens where you can select the month and release note from the right-side navigation bar.
 
@@ -16,7 +16,7 @@ We release first to preview orgs and then production orgs. Dates for preview rel
 To verify the current release for an org, check the footer of the Admin Console. If necessary, click **Admin** to navigate to your Admin Console.<br>
 ![Release Number in Footer](/img/release_notes/version_footer.png)
 
-> **Note:** Changes to Okta unrelated to API Products are published in the [Okta Release Notes](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_okta_relnotes) for admins. See [Okta Identity Engine Release Notes](https://help.okta.com/oie/en-us/Content/Topics/ReleaseNotes/oie-relnotes.htm) for changes to Okta Identity Engine that are unrelated to Okta Identity Engine API Products.
+> **Note:** Changes to Okta unrelated to API Products are published in the [Okta Release Notes](https://help.okta.com/en/prod/okta_help_CSH.htm#ext_okta_relnotes) for admins. See [Identity Engine Release Notes](https://help.okta.com/oie/en-us/Content/Topics/ReleaseNotes/oie-relnotes.htm) for changes to the Identity Engine that are unrelated to the Identity Engine API Products.
 
 <div class="next-section">
   <RouterLink to='/docs/release-notes/2021'>

--- a/packages/@okta/vuepress-site/signup/oie-preview.md
+++ b/packages/@okta/vuepress-site/signup/oie-preview.md
@@ -3,11 +3,11 @@ layout: AuthorizationLayout
 ---
 
 ::: slot signup-description
- # Sign up for Identity Engine
+ # Sign up for Okta Identity Engine
 
-Identity Engine is still in development and not yet generally available. Orgs created here aren't intended for production use.
+The Identity Engine is still in development and not yet generally available. Orgs created here aren't intended for production use.
 
-<a href="https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie" target="_blank">Learn more about Identity Engine</a>
+<a href="https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie" target="_blank">Learn more about the Identity Engine</a>
 
 :::
 


### PR DESCRIPTION
## Description:
- **What's changed?** Updated docs to use one of the formal names for the two versions of our platform: Okta Identity Engine or Okta Classic Engine. We use the full formal name for the first mention on a page. Subsequent mentions on a page use the truncated versions of the names: the Identity Engine or the Classic Engine. Note the use of article ("the") with the truncated names, but not with the full names.
- **Other notes** If the front matter of a page contains mentions of these terms, I treat the front matter as a separate "page". That is, the first mention gets the formal name and subsequent mentions (in the front matter) get the truncated name. Also, the first mention of a name in a file may not be the first mention of a name on a page when Netlify renders it. I tried to ensure that the final render follows the style guide.

- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-425097](https://oktainc.atlassian.net/browse/OKTA-425097)
