### PR TITLE
Update to Identity Engine common-download-setup-app file Scope configuration section

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/index.md
@@ -58,7 +58,7 @@ This is the same value as the **Redirect URI** for the application that you crea
 
 #### Scopes
 
-For the sample app, use the following scopes: `openid`, `profile`, `offline_access`. See [OpenID Connect & OAuth 2.0 API](https://developer.okta.com/docs/reference/api/oidc/#scopes) for more information.
+The sample app uses the default scopes provided in the SDK, which include `openid`, `profile`, and others. See [OpenID Connect & OAuth 2.0 API](https://developer.okta.com/docs/reference/api/oidc/#scopes) for more information on OIDC scopes associated with access tokens.
 
 ## Set the configuration values
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/index.md
@@ -58,7 +58,7 @@ This is the same value as the **Redirect URI** for the application that you crea
 
 #### Scopes
 
-The sample app uses the default scopes provided in the SDK, which include `openid`, `profile`, and others. See [OpenID Connect & OAuth 2.0 API](https://developer.okta.com/docs/reference/api/oidc/#scopes) for more information on OIDC scopes associated with access tokens.
+The sample app uses the default scopes provided in the SDK, which include `openid`, `profile`, and others. See [OpenID Connect & OAuth 2.0 API](/docs/reference/api/oidc/#scopes) for more information on OIDC scopes associated with access tokens.
 
 ## Set the configuration values
 


### PR DESCRIPTION

## Description:
- **What's changed?** Re-worded the [Scopes section](https://developer.okta.com/docs/guides/oie-embedded-common-download-setup-app/android/main/#scopes) to state: use the scopes included with your SDK. Detailed config of scopes deemed outside the scope, ahem, of the these use-cases.
 
- **Is this PR related to a Monolith release?**  n/a

### Resolves:

* [OKTA-417605](https://oktainc.atlassian.net/browse/OKTA-417065)
