### PR TITLE
Add help for styling sign-in widget IdP buttons

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/style-the-widget/style-self-hosted/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/style-the-widget/style-self-hosted/index.md
@@ -155,6 +155,14 @@ Position:
 }
 ```
 
+##### Identity provider buttons
+
+```css
+#okta-sign-in.auth-container .custom-style {
+  background: url(logo.png) no-repeat 10px, linear-gradient(90deg, hotpink 50px, lightpink 0);
+}
+```
+
 ##### Video Tutorial
 
 For a more in-depth look at styling the widget, you can watch this video:

--- a/packages/@okta/vuepress-site/docs/guides/style-the-widget/style-self-hosted/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/style-the-widget/style-self-hosted/index.md
@@ -155,7 +155,7 @@ Position:
 }
 ```
 
-##### Identity provider buttons
+##### Identity Provider buttons
 
 ```css
 #okta-sign-in.auth-container .custom-style {


### PR DESCRIPTION
<img width="1030" alt="Identity provider buttons" src="https://user-images.githubusercontent.com/39924696/134066977-49b2f165-4330-48b2-9314-19b70d0a9108.png">

## Description:

- **What's changed?** We've added help for styling sign-in widget IdP buttons. This helps when admins are using an IdP we don't have a pre-styled button for.
- **Is this PR related to a Monolith release?** No

The live dev docs page: [link](https://developer.okta.com/docs/guides/style-the-widget/style-self-hosted/)
The spike that triggered this: [link](https://oktawiki.atlassian.net/wiki/spaces/~883806289/pages/2315363996/Updating+the+sign-in+widget+for+new+IdPs+spike)

### Resolves:

* [OKTA-429706](https://oktainc.atlassian.net/browse/OKTA-429706)
