### PR TITLE
fixing subscriptions api sidebar link

### DIFF
--- a/packages/@okta/vuepress-theme-prose/const/navbar.const.js
+++ b/packages/@okta/vuepress-theme-prose/const/navbar.const.js
@@ -660,7 +660,7 @@ export const reference = [
           { title: "Risk Providers", path: "/docs/reference/api/risk-providers/" },
           { title: "Schemas", path: "/docs/reference/api/schemas/" },
           { title: "Sessions", path: "/docs/reference/api/sessions/" },
-          { title: "Subscriptions", path: "/docs/reference/api/admin-notifications" },
+          { title: "Subscriptions", path: "/docs/reference/api/admin-notifications/" },
           { title: "System Log", path: "/docs/reference/api/system-log/" },
           { title: "Templates", path: "/docs/reference/api/templates/" },
           { title: "ThreatInsight", path: "/docs/reference/api/threat-insight/" },


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** When the "Subscriptions" link was followed (under Reference > Core Okta API), the correct page was opened, but the tree nav didn't open to show the position of the opened article. This PR fixes that.
- **Is this PR related to a Monolith release?** No

### Resolves:

* Very quick fix; I didn't bother to file a ticket for this one.
