### PR TITLE
add link to 3rd party risk provider guide to risk events api reference

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/risk-events/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/risk-events/index.md
@@ -11,6 +11,8 @@ The Okta Risk Events API provides the ability for third-party Risk Providers to 
 ## Get Started
 Explore the Risk Events API: [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/1c449b51a4a0adf90198)
 
+See [Third-party risk provider integration overview](/docs/guides/third-party-risk-integration/overview/) for guidance on integrating third-party risk providers with Okta.
+
 ## Risk Events Operations
 The Risk Events API has the following operations:
 

--- a/packages/@okta/vuepress-site/docs/reference/api/risk-providers/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/risk-providers/index.md
@@ -11,6 +11,8 @@ The Okta Risk Providers API provides the ability to manage the Risk Providers wi
 ## Get Started
 Explore the Risk Providers API: [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/6831b9d37e12fe1f3401)
 
+See [Third-party risk provider integration overview](/docs/guides/third-party-risk-integration/overview/) for guidance on integrating third-party risk providers with Okta.
+
 ## Risk Providers Operations
 The Risk Providers API has the following CRUD operations:
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** A JIRA ticket was opened because a user couldn't find implementation on 3rd party risk provider integration, starting at the risk events api. I decided to add a link between the two to help future visitors.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-429931](https://oktainc.atlassian.net/browse/OKTA-429931)
