### PR TITLE
Add missing authenticator types

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/authenticators-admin/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/authenticators-admin/index.md
@@ -537,7 +537,7 @@ The Authenticator object defines the following properties:
 | `status`      | `ACTIVE`,`INACTIVE`                                             | Status of the Authenticator                                |
 | `lastUpdated` | String (ISO-8601)                                               | Timestamp when the Authenticator was last modified                             |
 | `name`        | String                                                          | Display name of this Authenticator                                             |
-| `type`        | String (Enum)                                                   | The type of Authenticator. Values include: `password`, `security_question`, `phone`, `email`, `app`, `federated` and `security_key`.                            |
+| `type`        | String (Enum)                                                   | The type of Authenticator. Values include: `password`, `security_question`, `phone`, `email`, `app`, `federated`, and `security_key`.                            |
 | `settings.allowedFor`        | String (Enum)                                    | The allowed types of uses for the Authenticator. Values include: `recovery`, `sso`, `any`, and `none`.                            |
 | `settings.tokenLifetimeInMinutes` | Number                                      | Specifies the lifetime of an `email` token, and only applies to the `email` Authenticator type. Default value is `5` minutes.                            |
 

--- a/packages/@okta/vuepress-site/docs/reference/api/authenticators-admin/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/authenticators-admin/index.md
@@ -537,7 +537,7 @@ The Authenticator object defines the following properties:
 | `status`      | `ACTIVE`,`INACTIVE`                                             | Status of the Authenticator                                |
 | `lastUpdated` | String (ISO-8601)                                               | Timestamp when the Authenticator was last modified                             |
 | `name`        | String                                                          | Display name of this Authenticator                                             |
-| `type`        | String (Enum)                                                   | The type of Authenticator. Values include: `password`, `security_question`, `phone`, `email`, and `security_key`.                            |
+| `type`        | String (Enum)                                                   | The type of Authenticator. Values include: `password`, `security_question`, `phone`, `email`, `app`, `federated` and `security_key`.                            |
 | `settings.allowedFor`        | String (Enum)                                    | The allowed types of uses for the Authenticator. Values include: `recovery`, `sso`, `any`, and `none`.                            |
 | `settings.tokenLifetimeInMinutes` | Number                                      | Specifies the lifetime of an `email` token, and only applies to the `email` Authenticator type. Default value is `5` minutes.                            |
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- Add `app` and `federated` types to authenticator admin object
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->
- @okta/developerdocs 


<img width="1141" alt="Screen Shot 2021-09-30 at 12 59 18 PM" src="https://user-images.githubusercontent.com/39062292/135499091-f6a26467-082e-453c-86e3-21074e1f1c7d.png">
### Resolves:

* [OKTA-428730](https://oktainc.atlassian.net/browse/OKTA-428730)
