### PR TITLE
Fix typo in install-sdk section of Implement authorization by grant type

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/authcode/install-sdk.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/authcode/install-sdk.md
@@ -1,5 +1,5 @@
 ## Use an SDK
 
-Okta recommends using existing libraries and OAuth 2.0 helper methods to implement your authentication flow. You can use one of Okta's many language and framework SDKs or an open-source library if an appropriate Okta SDK is not available. See [Languages & SDKs overivew](/code/) for a list of Okta SDKs that you can download to start using with your app.
+Okta recommends using existing libraries and OAuth 2.0 helper methods to implement your authentication flow. You can use one of Okta's many language and framework SDKs or an open-source library if an appropriate Okta SDK is not available. See [Languages & SDKs overview](/code/) for a list of Okta SDKs that you can download to start using with your app.
 
 Refer to [Add and configure packages](/docs/guides/sign-into-web-app/-/configure-packages) for instructions on how to install and use Okta back-end framework SDKs. You can download Okta sample apps to see how the SDKs are used in your app's framework. See [Examples](#examples) for a list of sample apps.

--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/authcodepkce/install-sdk.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/authcodepkce/install-sdk.md
@@ -1,5 +1,5 @@
 ## Use an SDK
 
-Okta recommends using existing libraries and OAuth 2.0 helper methods to implement your authentication flow. You can use one of Okta's array of language and framework SDKs or an open-source library if an appropriate Okta SDK is not available. See [Languages & SDKs overivew](/code/) for a list of Okta SDKs that you can download to start using with your app.
+Okta recommends using existing libraries and OAuth 2.0 helper methods to implement your authentication flow. You can use one of Okta's array of language and framework SDKs or an open-source library if an appropriate Okta SDK is not available. See [Languages & SDKs overview](/code/) for a list of Okta SDKs that you can download to start using with your app.
 
 For instructions on how to install and use Okta SDKs, refer to [Configure the SDK](/docs/guides/sign-into-spa/-/configure-the-sdk) for front-end SDKs and [Add and configure packages](/docs/guides/sign-into-mobile-app/-/configure-packages/) for mobile native SDKs. You can download Okta sample apps to see how the SDKs are used in your app's framework. See [Examples](#examples) for a list of sample apps.

--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/clientcreds/install-sdk.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/clientcreds/install-sdk.md
@@ -1,3 +1,3 @@
 ## Use an SDK
 
-Okta recommends using existing libraries and OAuth 2.0 helper methods to implement your authentication flow. You can use one of Okta's SDKs or an open-source library if an appropriate Okta SDK is not available. See [Languages & SDKs overivew](/code/) for a list of Okta SDKs that you can download to start using with your app.
+Okta recommends using existing libraries and OAuth 2.0 helper methods to implement your authentication flow. You can use one of Okta's SDKs or an open-source library if an appropriate Okta SDK is not available. See [Languages & SDKs overview](/code/) for a list of Okta SDKs that you can download to start using with your app.

--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/implicit/install-sdk.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/implicit/install-sdk.md
@@ -1,3 +1,3 @@
 ## Use an SDK
 
-Okta recommends using existing libraries and OAuth 2.0 helper methods to implement your authentication flow. You can use one of Okta's SDKs or an open-source library if an appropriate Okta SDK is not available. See [Languages & SDKs overivew](/code/) for a list of Okta SDKs that you can download to start using with your app.
+Okta recommends using existing libraries and OAuth 2.0 helper methods to implement your authentication flow. You can use one of Okta's SDKs or an open-source library if an appropriate Okta SDK is not available. See [Languages & SDKs overview](/code/) for a list of Okta SDKs that you can download to start using with your app.

--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/saml2assert/install-sdk.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/saml2assert/install-sdk.md
@@ -1,3 +1,3 @@
 ## Use an SDK
 
-Okta recommends using existing libraries and OAuth 2.0 helper methods to implement your authentication flow. You can use one of Okta's SDKs or an open-source library if an appropriate Okta SDK is not available. See [Languages & SDKs overivew](/code/) for a list of Okta SDKs that you can download to start using with your app.
+Okta recommends using existing libraries and OAuth 2.0 helper methods to implement your authentication flow. You can use one of Okta's SDKs or an open-source library if an appropriate Okta SDK is not available. See [Languages & SDKs overview](/code/) for a list of Okta SDKs that you can download to start using with your app.


### PR DESCRIPTION
## Description:
- **What's changed?** Fix typo in "Use an SDK" section of the "Implement authorization by grant type" guide
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
