### PR TITLE
Simplify Spring Boot setup

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/before-you-begin/springboot/create-app.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app/before-you-begin/springboot/create-app.md
@@ -1,6 +1,6 @@
-The [Spring Boot Getting Started Guide](https://spring.io/guides/gs/spring-boot/) teaches you the basics of building a Spring Boot application. 
+The [Spring Boot Getting Started Guide](https://spring.io/guides/gs/spring-boot/) teaches you the basics of building a Spring Boot application.
 
-You can create a new Spring Boot project with Okta by visiting the [Spring Initializr](https://start.spring.io) and selecting the dependencies **Web**, **Security**, and **Okta**, then clicking **Generate Project** to download a zip file.
+You can create a new Spring Boot project with Okta by visiting the [Spring Initializr](https://start.spring.io) and selecting the dependencies **Web** and **Okta**, then clicking **Generate Project** to download a zip file.
 
 You can also use the command line:
 
@@ -8,9 +8,7 @@ You can also use the command line:
 curl https://start.spring.io/starter.tgz  \
   -d groupId=com.example \
   -d artifactId=demo \
-  -d dependencies=web,security,okta \
-  -d language=java \
-  -d type=maven-project \
+  -d dependencies=web,okta \
   -d baseDir=demo \
 | tar -xzvf -
 ```


### PR DESCRIPTION
Since security is included by the Okta starter and Maven and Java are the defaults

## Description:
- **What's changed?** Simplified what's needed for a new Spring Boot app.
- **Is this PR related to a Monolith release?** No.
