### PR TITLE
Clarifies `email_verified` claim for OIDC apps

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/submit-app/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/submit-app/overview/index.md
@@ -15,6 +15,8 @@ This guide covers submissions that use one or more of these protocols:
 
     >**Note:** To support the potentially large numbers of Okta orgs accessing it through the OIN, an OIDC integration can't use a custom authorization server, including the `default` server.
 
+    >**Note:** ISVs shouldn't rely on the `email_verified` scope-dependent claim returned by an OIDC integration to evaluate whether a user has verified ownership of the email address associated with their profile.
+
 * [Security Assertion Markup Language (SAML)](https://en.wikipedia.org/wiki/SAML_2.0)
 
     >**Note:** SAML integrations must use SHA256 encryption for security. If you are using SHA-1 for encryption, see our guide on how to [Upgrade SAML Apps to SHA256](/docs/guides/updating-saml-cert/overview/).


### PR DESCRIPTION
## Description:
- **What's changed?** 

Adds to the OIN submission doc that ISVs shouldn't use the `email_verified` field to validate a user has ownership of the email address in their profile.

- **Is this PR related to a Monolith release?** 
No

### Resolves:

* [OKTA-320992](https://oktainc.atlassian.net/browse/OKTA-320992)
