### PR TITLE
Quality Update - editing update and fix to missing variable

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/update-default-provider/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/update-default-provider/index.md
@@ -46,7 +46,7 @@ This procedure retrieves the default risk provider profile and Provider ID.
 ### Update the risk provider
 This procedure updates the default risk provider profile with the service application ID, risk provider name, and the risk provider action.
 
-1. Call the following PUT API from the Risk Integration Postman collection: **Admin: API to Update Provider Settings** (`https://${yourOktaDomain}/api/v1/risk/providers/{{providerId}}`), which updates the default risk provider's data. This data is included in the request body:
+1. Call the following PUT API from the Risk Integration Postman collection: **Admin: API to Update Provider Settings** (`https://${yourOktaDomain}/api/v1/risk/providers/${providerId}`), which updates the default risk provider's data. This data is included in the request body:
 
     ```JSON
     {

--- a/packages/@okta/vuepress-site/docs/reference/hooks-best-practices/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/hooks-best-practices/index.md
@@ -59,7 +59,7 @@ Your external service processing Hook requests must take into consideration that
 
 | Hook Type | Limit Type | Limit | Description |
 | --------- | -----------| ----- | ----------- |
-| Event Hook | Number of daily Event Hooks | 200K | A maximum of 100,000 Event Hooks can be fired, per org, per day. Event Hooks are not recorded or replayed after this point. If a request times out after three seconds, Event Hooks are retried once. Retries do not count toward the org limit.
+| Event Hook | Number of daily Event Hooks | 200,000 | A maximum of 200,000 Event Hooks can be fired, per org, per day. Event Hooks are not recorded or replayed after this point. If a request times out after three seconds, Event Hooks are retried once. Retries do not count toward the org limit.
 |            | Maximum number of Event Hooks per org | 10 | A maximum of 10 active Event Hooks can be configured per org. Each Event Hook can be configured to deliver multiple event types. |
 | Inline Hook | Timeout | 3 seconds | Inline Hooks have a completion timeout of three seconds with a single retry. However, a request is not retried if your endpoint returns a 4xx HTTP error code. Any 2xx code is considered successful, and the request is not retried. If the external service endpoint responds with a redirect, it is not followed. |
 |             | Maximum number of Inline Hooks per org | 50 | The maximum number of Inline Hooks that can be configured per org is 50, which is a combined total for any combination of Inline Hook types. |


### PR DESCRIPTION

## Description:
- **What's changed?** Updated this Third-Party Risk Integration [page](https://developer.okta.com/docs/guides/third-party-risk-integration/update-default-provider/#update-the-risk-provider) that was missing a variable on the API call; updated the Hooks Best Practices guide to include an editing update (K > 100,00); a broken external link is now working correctly, not updated as per the ticket.
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* [OKTA-443639](https://oktainc.atlassian.net/browse/OKTA-443639)
