### PR TITLE
fixing broken links and redirects for quickstart

### DIFF
--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -2683,3 +2683,27 @@ redirects:
     to: /docs/guides/configure-signon-policy/main/#prompt-for-an-mfa-factor-when-a-user-is-outside-the-us
   - from: /docs/guides/configure-signon-policy/next-steps/index.html
     to: /docs/guides/configure-signon-policy/main/#next-steps
+  - from: /docs/guides/quickstart/create-org
+    to: /docs/guides/quickstart/-/main/#create-your-okta-organization
+  - from: /docs/guides/quickstart/using-console
+    to: /docs/guides/quickstart/-/main/#using-the-admin-console
+  - from: /docs/guides/quickstart/add-user
+    to: /docs/guides/quickstart/-/main/#add-a-user-using-the-admin-console
+  - from: /docs/guides/quickstart/register-app
+    to: /docs/guides/quickstart/-/main/#register-your-app
+  - from: /docs/guides/quickstart/sign-in
+    to: /docs/guides/quickstart/-/main/#try-signing-in
+  - from: /docs/guides/quickstart/try-api
+    to: /docs/guides/quickstart/-/main/#next-steps
+  - from: /docs/guides/quickstart/create-org/index.html
+    to: /docs/guides/quickstart/-/main/#create-your-okta-organization
+  - from: /docs/guides/quickstart/using-console/index.html
+    to: /docs/guides/quickstart/-/main/#using-the-admin-console
+  - from: /docs/guides/quickstart/add-user/index.html
+    to: /docs/guides/quickstart/-/main/#add-a-user-using-the-admin-console
+  - from: /docs/guides/quickstart/register-app/index.html
+    to: /docs/guides/quickstart/-/main/#register-your-app
+  - from: /docs/guides/quickstart/sign-in/index.html
+    to: /docs/guides/quickstart/-/main/#try-signing-in
+  - from: /docs/guides/quickstart/try-api/index.html
+    to: /docs/guides/quickstart/-/main/#next-steps

--- a/packages/@okta/vuepress-site/docs/guides/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/index.md
@@ -97,7 +97,7 @@ If you're using Okta as an identity layer in your app for the first time, we rec
     * [OAuth 2.0 and OpenID Connect overview](/docs/concepts/oauth-openid/)
     * [Authorization servers](/docs/concepts/auth-servers/)
     * [Policies](/docs/concepts/policies/)
-    * [Quickstart: Signing in your first user](/docs/guides/quickstart/cli/main)
+    * [Quickstart: Signing in your first user](/docs/guides/quickstart/cli/main/)
     * [Set up self-service registration](/docs/guides/set-up-self-service-registration)
 
 2. Sign users in


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** In https://github.com/okta/okta-developer-docs/pull/2636, I changed the quickstart guide to a single page guide. However, I didn't set up the redirects correctly or check the possible broken links as a result. This PR fixes that.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-438714](https://oktainc.atlassian.net/browse/OKTA-438714)
