### PR TITLE
fixing redirectsand internal links to updating-saml-cert guide

### DIFF
--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -1212,17 +1212,17 @@ redirects:
   - from: /guides/sign-users-out/springboot/sign-out-of-your-app/index.html
     to: /docs/guides/sign-users-out/springboot/sign-out-of-your-app/
   - from: /guides/updating-saml-cert/-/generate-new-key-credential/index.html
-    to: /docs/guides/updating-saml-cert/-/generate-new-key-credential/
+    to: /docs/guides/updating-saml-cert/main/#generate-a-new-application-key-credential
   - from: /guides/updating-saml-cert/-/get-app-info/index.html
-    to: /docs/guides/updating-saml-cert/-/get-app-info/
+    to: /docs/guides/updating-saml-cert/main/#get-the-app-info
   - from: /guides/updating-saml-cert/-/overview/index.html
-    to: /docs/guides/updating-saml-cert/-/overview/
+    to: /docs/guides/updating-saml-cert/
   - from: /guides/updating-saml-cert/-/revert-to-sha1/index.html
-    to: /docs/guides/updating-saml-cert/-/revert-to-sha1/
+    to: /docs/guides/updating-saml-cert/main/#reverting-to-a-sha1-certificate
   - from: /guides/updating-saml-cert/-/update-key-credential/index.html
-    to: /docs/guides/updating-saml-cert/-/update-key-credential/
+    to: /docs/guides/updating-saml-cert/main/#update-the-key-credential-for-the-app-to-specify-the-new-signing-key-id
   - from: /guides/updating-saml-cert/-/upload-cert-to-isv/index.html
-    to: /docs/guides/updating-saml-cert/-/upload-cert-to-isv/
+    to: /docs/guides/updating-saml-cert/main/#upload-the-new-certificate-to-the-isv
   - from: /guides/validate-access-tokens/-/overview/index.html
     to: /docs/guides/validate-access-tokens/-/overview/
   - from: /guides/validate-id-tokens/-/overview/index.html
@@ -2367,18 +2367,30 @@ redirects:
     to: /docs/guides/sharing-cert/main/
   - from: /docs/guides/saml-tracer/overview/
     to: /docs/guides/saml-tracer/main/
-  - from: /docs/guides/updating-saml-cert/overview/
-    to: /docs/guides/updating-saml-cert/main/
-  - from: /docs/guides/updating-saml-cert/get-app-info/
-    to: /docs/guides/updating-saml-cert/main/
-  - from: /docs/guides/updating-saml-cert/generate-new-key-credential/
-    to: /docs/guides/updating-saml-cert/main/
-  - from: /docs/guides/updating-saml-cert/update-key-credential/
-    to: /docs/guides/updating-saml-cert/main/
-  - from: /docs/guides/updating-saml-cert/upload-cert-to-isv/
-    to: /docs/guides/updating-saml-cert/main/
-  - from: /docs/guides/updating-saml-cert/revert-to-sha1/
-    to: /docs/guides/updating-saml-cert/main/
+  - from: /docs/guides/updating-saml-cert/overview
+    to: /docs/guides/updating-saml-cert/
+  - from: /docs/guides/updating-saml-cert/get-app-info
+    to: /docs/guides/updating-saml-cert/main/#get-the-app-info
+  - from: /docs/guides/updating-saml-cert/generate-new-key-credential
+    to: /docs/guides/updating-saml-cert/main/#generate-a-new-application-key-credential
+  - from: /docs/guides/updating-saml-cert/update-key-credential
+    to: /docs/guides/updating-saml-cert/main/#update-the-key-credential-for-the-app-to-specify-the-new-signing-key-id
+  - from: /docs/guides/updating-saml-cert/upload-cert-to-isv
+    to: /docs/guides/updating-saml-cert/main/#upload-the-new-certificate-to-the-isv
+  - from: /docs/guides/updating-saml-cert/revert-to-sha1
+    to: /docs/guides/updating-saml-cert/main/#reverting-to-a-sha1-certificate
+  - from: /docs/guides/updating-saml-cert/overview/index.html
+    to: /docs/guides/updating-saml-cert/
+  - from: /docs/guides/updating-saml-cert/get-app-info/index.html
+    to: /docs/guides/updating-saml-cert/main/#get-the-app-info
+  - from: /docs/guides/updating-saml-cert/generate-new-key-credential/index.html
+    to: /docs/guides/updating-saml-cert/main/#generate-a-new-application-key-credential
+  - from: /docs/guides/updating-saml-cert/update-key-credential/index.html
+    to: /docs/guides/updating-saml-cert/main/#update-the-key-credential-for-the-app-to-specify-the-new-signing-key-id
+  - from: /docs/guides/updating-saml-cert/upload-cert-to-isv/index.html
+    to: /docs/guides/updating-saml-cert/main/#upload-the-new-certificate-to-the-isv
+  - from: /docs/guides/updating-saml-cert/revert-to-sha1/index.html
+    to: /docs/guides/updating-saml-cert/main/#reverting-to-a-sha1-certificate
   - from: /docs/guides/create-an-api-token/overview/
     to: /docs/guides/create-an-api-token/
   - from: /docs/guides/create-an-api-token/overview/index.html

--- a/packages/@okta/vuepress-site/docs/guides/build-sso-integration/before-you-begin/saml2/prep.md
+++ b/packages/@okta/vuepress-site/docs/guides/build-sso-integration/before-you-begin/saml2/prep.md
@@ -9,4 +9,4 @@ Before you create a new SAML integration in Okta:
 1. (Optional). Set up a Default Relay State page, where users land after they successfully sign in to the SP using SAML. This must be a valid URL.
 1. Gather any required SAML attributes. You can choose to share Okta user profile field values as SAML attributes with your application.
 
-**Note:** SAML integrations must use SHA256 encryption for security. If you are using SHA-1 for encryption, see our guide on how to [Upgrade SAML Apps to SHA256](/docs/guides/updating-saml-cert/main/).
+**Note:** SAML integrations must use SHA256 encryption for security. If you are using SHA-1 for encryption, see our guide on how to [Upgrade SAML Apps to SHA256](/docs/guides/updating-saml-cert/).

--- a/packages/@okta/vuepress-site/docs/guides/submit-app/overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/submit-app/overview/index.md
@@ -19,7 +19,7 @@ This guide covers submissions that use one or more of these protocols:
 
 * [Security Assertion Markup Language (SAML)](https://en.wikipedia.org/wiki/SAML_2.0)
 
-    >**Note:** SAML integrations must use SHA256 encryption for security. If you are using SHA-1 for encryption, see our guide on how to [Upgrade SAML Apps to SHA256](/docs/guides/updating-saml-cert/main/).
+    >**Note:** SAML integrations must use SHA256 encryption for security. If you are using SHA-1 for encryption, see our guide on how to [Upgrade SAML Apps to SHA256](/docs/guides/updating-saml-cert/).
 
 ## Prerequisites
 

--- a/packages/@okta/vuepress-site/docs/guides/updating-saml-cert/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/updating-saml-cert/main/index.md
@@ -17,7 +17,7 @@ This article shows you how to upgrade older Okta SAML apps from SHA1 certificate
 
 **What you need**
 
-* A SAML app to upgrade (see [Building a SAML SSO integration](https://developer.okta.com/docs/guides/build-sso-integration/saml2/before-you-begin/) for more information on creating one).
+* A SAML app to upgrade (see [Building a SAML SSO integration](https://developer.okta.com/docs/guides/build-sso-integration/saml2/before-you-begin/) for more information on creating one)
 
 ---
 

--- a/packages/@okta/vuepress-site/docs/guides/updating-saml-cert/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/updating-saml-cert/main/index.md
@@ -10,18 +10,14 @@ This article shows you how to upgrade older Okta SAML apps from SHA1 certificate
 
 **Learning outcomes**
 
-* Find out which certificate your SAML app uses, and download your certificate.
-* Use the [Apps API](/docs/reference/api/apps/#list-applications) to return data on the apps that need updating and generate new credentials for each.
-* Update the apps to use the new certificate.
-* Learn how to revert to SHA1 if necessary.
+* Find out which certificate your SAML app uses, and download your certificate
+* Use the [Apps API](/docs/reference/api/apps/#list-applications) to return data on the apps that need updating and generate new credentials for each
+* Update the apps to use the new certificate
+* Learn how to revert to SHA1 if necessary
 
 **What you need**
 
 * A SAML app to upgrade (see [Building a SAML SSO integration](https://developer.okta.com/docs/guides/build-sso-integration/saml2/before-you-begin/) for more information on creating one).
-
-**Sample code**
-
-n/a
 
 ---
 

--- a/packages/@okta/vuepress-site/docs/guides/updating-saml-cert/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/updating-saml-cert/main/index.md
@@ -11,7 +11,7 @@ This article shows you how to upgrade older Okta SAML apps from SHA1 certificate
 **Learning outcomes**
 
 * Find out which certificate your SAML app uses, and download your certificate
-* Use the [Apps API](/docs/reference/api/apps/#list-applications) to return data on the apps that need updating and generate new credentials for each
+* Use the [Apps API](/docs/reference/api/apps/#list-applications) to return data on the apps that need updating and generate new credentials for each app
 * Update the apps to use the new certificate
 * Learn how to revert to SHA1 if necessary
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** https://github.com/okta/okta-developer-docs/pull/2638 converted https://developer.okta.com/docs/guides/updating-saml-cert/ to a single page guide, but it didn't implement the redirects correctly or thoroughly test for broken links. This PR fixes that.
- **Is this PR related to a Monolith release?** No
- Redirects tested on staging 11/16/21. Redirects work fine, as expected.

### Resolves:

* [OKTA-438721](https://oktainc.atlassian.net/browse/OKTA-438721)
