### PR TITLE
fixing redirects for unlock-mobile-app-with-biometrics guide

### DIFF
--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -2543,6 +2543,54 @@ redirects:
     to: /docs/guides/unlock-mobile-app-with-biometrics/-/main/#retrieve-refresh-token
   - from: /docs/guides/unlock-mobile-app-with-biometrics/-/next-steps/index.html
     to: /docs/guides/unlock-mobile-app-with-biometrics/-/main/
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/overview
+    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/configure-packages
+    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/#add-and-configure-packages
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/store-tokens
+    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/#store-tokens
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/discard-access-tokens
+    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/#discard-access-tokens
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/retrieve-refresh-token
+    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/#retrieve-refresh-token
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/next-steps
+    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/overview/index.html
+    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/configure-packages/index.html
+    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/#add-and-configure-packages
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/store-tokens/index.html
+    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/#store-tokens
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/discard-access-tokens/index.html
+    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/#discard-access-tokens
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/retrieve-refresh-token/index.html
+    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/#retrieve-refresh-token
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/next-steps/index.html
+    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/overview
+    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/configure-packages
+    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/#add-and-configure-packages
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/store-tokens
+    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/#store-tokens
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/discard-access-tokens
+    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/#discard-access-tokens
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/retrieve-refresh-token
+    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/#retrieve-refresh-token
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/next-steps
+    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/overview/index.html
+    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/configure-packages/index.html
+    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/#add-and-configure-packages
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/store-tokens/index.html
+    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/#store-tokens
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/discard-access-tokens/index.html
+    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/#discard-access-tokens
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/retrieve-refresh-token/index.html
+    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/#retrieve-refresh-token
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/next-steps/index.html
+    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/
   - from: /docs/guides/common-hook-set-up-steps/-/overview/index.html
     to: /docs/guides/common-hook-set-up-steps/
   - from: /docs/guides/common-hook-set-up-steps/-/overview

--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -2519,52 +2519,30 @@ redirects:
     to: /docs/guides/sign-into-mobile-app/-/main/#use-the-access-token
   - from: /docs/guides/sign-into-mobile-app/-/next-steps/index.html
     to: /docs/guides/sign-into-mobile-app/-/main/#next-steps
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/overview/
-    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/configure-packages/
-    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/store-tokens/
-    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/discard-access-tokens/
-    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/retrieve-refresh-token/
-    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/next-steps/
-    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/overview/index.html
-    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/configure-packages/index.html
-    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/store-tokens/index.html
-    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/discard-access-tokens/index.html
-    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/retrieve-refresh-token/index.html
-    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/android/next-steps/index.html
-    to: /docs/guides/unlock-mobile-app-with-biometrics/android/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/overview/
-    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/configure-packages/
-    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/store-tokens/
-    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/discard-access-tokens/
-    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/retrieve-refresh-token/
-    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/next-steps/
-    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/overview/index.html
-    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/configure-packages/index.html
-    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/store-tokens/index.html
-    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/discard-access-tokens/index.html
-    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/retrieve-refresh-token/index.html
-    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/-/overview
+    to: /docs/guides/unlock-mobile-app-with-biometrics/-/main/
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/-/configure-packages
+    to: /docs/guides/unlock-mobile-app-with-biometrics/-/main/#add-and-configure-packages
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/-/store-tokens
+    to: /docs/guides/unlock-mobile-app-with-biometrics/-/main/#store-tokens
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/-/discard-access-tokens
+    to: /docs/guides/unlock-mobile-app-with-biometrics/-/main/#discard-access-tokens
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/-/retrieve-refresh-token
+    to: /docs/guides/unlock-mobile-app-with-biometrics/-/main/#retrieve-refresh-token
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/-/next-steps
+    to: /docs/guides/unlock-mobile-app-with-biometrics/-/main/
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/-/overview/index.html
+    to: /docs/guides/unlock-mobile-app-with-biometrics/-/main/
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/-/configure-packages/index.html
+    to: /docs/guides/unlock-mobile-app-with-biometrics/-/main/#add-and-configure-packages
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/-/store-tokens/index.html
+    to: /docs/guides/unlock-mobile-app-with-biometrics/-/main/#store-tokens
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/-/discard-access-tokens/index.html
+    to: /docs/guides/unlock-mobile-app-with-biometrics/-/main/#discard-access-tokens
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/-/retrieve-refresh-token/index.html
+    to: /docs/guides/unlock-mobile-app-with-biometrics/-/main/#retrieve-refresh-token
+  - from: /docs/guides/unlock-mobile-app-with-biometrics/-/next-steps/index.html
+    to: /docs/guides/unlock-mobile-app-with-biometrics/-/main/
   - from: /docs/guides/common-hook-set-up-steps/-/overview/index.html
     to: /docs/guides/common-hook-set-up-steps/
   - from: /docs/guides/common-hook-set-up-steps/-/overview
@@ -2581,8 +2559,6 @@ redirects:
     to: /docs/guides/common-hook-set-up-steps/-/main/#troubleshoot-hook-implementations
   - from: /docs/guides/common-hook-set-up-steps/-/troubleshooting
     to: /docs/guides/common-hook-set-up-steps/-/main/#troubleshoot-hook-implementations
-  - from: /docs/guides/unlock-mobile-app-with-biometrics/ios/next-steps/index.html
-    to: /docs/guides/unlock-mobile-app-with-biometrics/ios/main/
   - from: /docs/guides/sign-into-spa/-/before-you-begin
     to: /docs/guides/sign-into-spa/
   - from: /docs/guides/sign-into-spa/-/define-callback

--- a/packages/@okta/vuepress-site/docs/guides/unlock-mobile-app-with-biometrics/main/android/samplecode.md
+++ b/packages/@okta/vuepress-site/docs/guides/unlock-mobile-app-with-biometrics/main/android/samplecode.md
@@ -1,0 +1,1 @@
+We have a sample available in our [Android samples repo](https://github.com/okta/samples-android/tree/master/browser-sign-in).

--- a/packages/@okta/vuepress-site/docs/guides/unlock-mobile-app-with-biometrics/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/unlock-mobile-app-with-biometrics/main/index.md
@@ -10,18 +10,16 @@ In this guide you will learn how to integrate biometric authentication like Face
 
 **Learning outcomes**
 
-* Add the required packages to your application.
-* Handle biometric challenges for your users, storing and retrieving tokens as required.
-* Delete access tokens when no longer required. 
+* Handle biometric challenges for your users, storing and retrieving tokens as required
+* Delete access tokens when no longer required
 
 **What you need**
 
-* Biometric unlock with Touch ID, Face ID, and Smart Lock — added by following the [Sign users in to your mobile apps](/docs/guides/sign-into-mobile-app/) guide.
+Biometric unlock with Touch ID, Face ID, and Smart Lock — added by following the [Sign users in to your mobile apps](/docs/guides/sign-into-mobile-app/) guide.
 
 **Sample code**
 
-* Android — we have a sample available in our [Android samples repo](https://github.com/okta/samples-android/tree/master/browser-sign-in).
-* iOS — We have a sample available in our [iOS samples repo](https://github.com/okta/samples-ios/tree/master/browser-sign-in-and-biometric-storage).
+See the [Sample code](#sample-code) section.
 
 ---
 
@@ -60,3 +58,7 @@ To get a new refresh token, present a biometric challenge to the user.
 Then, use the refresh token to get a new access token.
 
 <StackSelector snippet="getnewaccesstoken" />
+
+## Sample code
+
+<StackSelector snippet="samplecode" />

--- a/packages/@okta/vuepress-site/docs/guides/unlock-mobile-app-with-biometrics/main/ios/samplecode.md
+++ b/packages/@okta/vuepress-site/docs/guides/unlock-mobile-app-with-biometrics/main/ios/samplecode.md
@@ -1,0 +1,1 @@
+We have a sample available in our [iOS samples repo](https://github.com/okta/samples-ios/tree/master/browser-sign-in-and-biometric-storage).


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** https://github.com/okta/okta-developer-docs/pull/2651 converted https://developer.okta.com/docs/guides/unlock-mobile-app-with-biometrics/android/main/ to a single-page guide, but it didn't implement the redirects properly, or check thoroughly for broken links. This PR fixes that.
- **Is this PR related to a Monolith release?** No.
- Redirects tested on staging, 11/16/21. They all work as expected.

### Resolves:

* [OKTA-438726](https://oktainc.atlassian.net/browse/OKTA-438726)
