### PR TITLE
Add Github link to okta-sdk-dotnet from the dotnet/blazor code page

### DIFF
--- a/packages/@okta/vuepress-site/code/dotnet/blazor/index.md
+++ b/packages/@okta/vuepress-site/code/dotnet/blazor/index.md
@@ -40,7 +40,15 @@ New to Okta? Our Blazor WebAssembly & Server-Side samples will walk you through 
 
 ## Other .NET Libraries
 
-<Card href="" cardTitle="Okta management SDK for .NET">Enable your ASP.NET application to work with Okta through OAuth 2.0/OIDC</Card>
+<ul class="language-libraries">
+	<li>
+		<i class='fa fa-github'></i>
+		<a href="https://github.com/okta/okta-sdk-dotnet">
+			 <span>Okta Management SDK for .NET</span>
+		</a>
+	</li>
+</ul>
+
 
 ## Recommended Guides
 


### PR DESCRIPTION
## Description:
- **What's changed?** On the /code/dotnet/blazor/index.md page:
     - removed chiclet (since we can't reference external sites) 
     - added "Okta Management SDK for .NET" GitHub icon link to https://github.com/okta/okta-sdk-dotnet
     - removed "Enable your ASP.NET application to work with Okta via OAuth 2.0/OIDC" (since this contradicts the statement in the /code/dotnet/aspnet page)
- **Is this PR related to a Monolith release?** No
### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
