### PR TITLE
update react quickstart

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/main/react/config.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/main/react/config.md
@@ -56,9 +56,13 @@ const config = {
 const oktaAuth = new OktaAuth(config);
 
 const App = () => {
+  const restoreOriginalUri = () => {
+    // Callback function to restore URI during login
+  };
+  
   return (
     <Router>
-      <Security oktaAuth={oktaAuth}>
+      <Security oktaAuth={oktaAuth} restoreOriginalUri={restoreOriginalUri}>
         { /* App routes go here */ }
       </Security>
     </Router>

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/main/react/config.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/main/react/config.md
@@ -50,7 +50,11 @@ import { Security } from '@okta/okta-react';
 import { OktaAuth } from '@okta/okta-auth-js';
 
 const config = {
-  // Configuration here
+  clientId: '${clientId}',
+  issuer: `https://${yourOktaDomain}/oauth2/default`,
+  redirectUri: 'http://localhost:8080/login/callback',
+  scopes: ['openid', 'profile', 'email'],
+  pkce: true
 };
 
 const oktaAuth = new OktaAuth(config);

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/main/react/define-route.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/main/react/define-route.md
@@ -1,4 +1,4 @@
-Define a route that handles a path like `/login/callback`. Here's how to do it in [react-router](https://github.com/ReactTraining/react-router):
+Define a route that handles a path like `/login/callback`. Here's how to do it in [react-router@5](https://github.com/ReactTraining/react-router):
 
 
 ```jsx

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/main/react/handle-callback.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/main/react/handle-callback.md
@@ -14,9 +14,13 @@ const oktaAuth = new OktaAuth(config);
 const CALLBACK_PATH = '/login/callback';
 
 const App = () => {
+  const restoreOriginalUri = () => {
+    // Callback function to restore URI during login
+  };
+
   return (
     <Router>
-      <Security oktaAuth={oktaAuth}>
+      <Security oktaAuth={oktaAuth} restoreOriginalUri={restoreOriginalUri}>
           <Route path={CALLBACK_PATH} component={LoginCallback} />
       </Security>
     </Router>

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/main/react/installsdk.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/main/react/installsdk.md
@@ -1,5 +1,5 @@
 The React SDK is hosted on npm as [@okta/okta-react](https://www.npmjs.com/package/@okta/okta-react).
 
 ```
-npm install @okta/okta-react
+npm install @okta/okta-react @okta/okta-auth-js
 ```


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Added missing instructions to React quickstart guide so a developer successfully creates an authenticated app. I added a version qualifier to react-router because it looks like v6 no longer exports the` useRouteMatch` method that Okta react SDK expected
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* No Jira ticket (yet).
