### PR TITLE
Removing sample code n/a from customize-tokens-dynamic guide

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/customize-tokens-dynamic/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-tokens-dynamic/main/index.md
@@ -19,10 +19,6 @@ This article shows you how to define custom Groups claims for tokens returned fr
 * An [OpenID Connect client application](https://help.okta.com/okta_help.htm?id=ext_Apps_App_Integration_Wizard-oidc) in Okta with at least [one user assigned to it](https://help.okta.com/okta_help.htm?id=ext-assign-apps).
 * A [group in Okta](https://help.okta.com/okta_help.htm?id=ext_Directory_Groups) with at least one person assigned to it.
 
-**Sample code**
-
-n/a
-
 ---
 
 ## Overview


### PR DESCRIPTION
Another small bit of cleanup work arising from the single page guide conversion work.
