### PR TITLE
Removing Sample code n/a from customize-authz-server guide nut facts

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/customize-authz-server/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-authz-server/main/index.md
@@ -20,10 +20,6 @@ See [Which Authorization Server should you use](/docs/concepts/auth-servers/#whi
 
 An [Okta Developer Edition](https://developer.okta.com/signup/) account.
 
-**Sample code**
-
-n/a
-
 ---
 
 ## Create an authorization server


### PR DESCRIPTION
Another small fix to get the nut facts updated to the latest agreed guidelines, this time for this customize-authz-server guide.
