### PR TITLE
Add note to legacy EL docs

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
@@ -178,7 +178,10 @@ Group functions return either an array of groups or **True** or **False**.
 | `isMemberOfGroupNameContains`   | Boolean     | `isMemberOfGroupNameContains("admin")`                          |
 | `isMemberOfGroupNameRegex`      | Boolean     | `isMemberOfGroupNameRegex("/.*admin.*")`                        |
 
-**Note:** The `Groups.contains`, `Groups.startsWith`, and `Groups.endsWith` group functions are designed to work only with group claims. You can't use these functions with property mappings.
+> **Note:** The `Groups.contains`, `Groups.startsWith`, and `Groups.endsWith` group functions are designed to work only with group claims. You can't use these functions with property mappings.
+>
+
+> **Note:** The `isMemberOfGroupName`, `isMemberOfGroup`, `isMemberOfAnyGroup`, `isMemberOfGroupNameStartsWith`, `isMemberOfGroupNameContains`, `isMemberOfGroupNameRegex` group functions are designed only to retrieve an Okta user's group memberships. Do not use them to retrieve an app user's group memberships.
 
 For an example using group functions and for more information on using group functions for dynamic and static allow lists, see [Customize tokens returned from Okta](/docs/guides/customize-tokens-returned-from-okta/).
 

--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
@@ -181,7 +181,7 @@ Group functions return either an array of groups or **True** or **False**.
 > **Note:** The `Groups.contains`, `Groups.startsWith`, and `Groups.endsWith` group functions are designed to work only with group claims. You can't use these functions with property mappings.
 >
 
-> **Note:** The `isMemberOfGroupName`, `isMemberOfGroup`, `isMemberOfAnyGroup`, `isMemberOfGroupNameStartsWith`, `isMemberOfGroupNameContains`, `isMemberOfGroupNameRegex` group functions are designed only to retrieve an Okta user's group memberships. Do not use them to retrieve an app user's group memberships.
+> **Note:** The `isMemberOfGroupName`, `isMemberOfGroup`, `isMemberOfAnyGroup`, `isMemberOfGroupNameStartsWith`, `isMemberOfGroupNameContains`, `isMemberOfGroupNameRegex` group functions are designed to retrieve only an Okta user's group memberships. Don't use them to retrieve an app user's group memberships.
 
 For an example using group functions and for more information on using group functions for dynamic and static allow lists, see [Customize tokens returned from Okta](/docs/guides/customize-tokens-returned-from-okta/).
 


### PR DESCRIPTION
## Description:
- **What's changed?** Add note to legacy EL docs - group membership group functions can only be used on Okta user, not app user.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-444467](https://oktainc.atlassian.net/browse/OKTA-444467)

@nghadge-okta @williamyang-okta 