### PR TITLE
put all migrate-to-okta guides in the main guides list, and tweak links

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/index.md
@@ -30,6 +30,8 @@ guides:
  - implement-grant-type
  - mfa
  - migrate-to-okta-prerequisites
+ - migrate-to-okta-bulk
+ - migrate-to-okta-password-hooks
  - oin-oidc-overview
  - oin-oidc-best-practices
  - oin-oidc-multi-tenancy

--- a/packages/@okta/vuepress-site/docs/guides/migrate-to-okta-bulk/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/migrate-to-okta-bulk/main/index.md
@@ -19,7 +19,7 @@ Perform a bulk migration of users into Okta using Okta APIs.
 * An Okta developer org. (Don't have one? [Create an org for free.](https://developer.okta.com/signup))
 * Postman client to run API requests. See [Use Postman with the Okta REST APIs](https://developer.okta.com/code/rest/) for information on setting up Postman.
 * Example or test source data to test user and group creation requests. (Do not use real user data when testing!)
-* [A plan for migrating existing users to Okta](/docs/guides/migrate-to-okta-prerequisites/main/).
+* [A plan for migrating existing users to Okta](/docs/guides/migrate-to-okta-prerequisites/).
 
 **Sample code**
 

--- a/packages/@okta/vuepress-site/docs/guides/migrate-to-okta-password-hooks/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/migrate-to-okta-password-hooks/main/index.md
@@ -19,7 +19,7 @@ Migrate users into Okta as they authenticate using Password Import Inline Hooks.
 * An Okta developer org. (Don't have one? [Create an org for free.](https://developer.okta.com/signup))
 * Postman client to run API requests. See [Use Postman with the Okta REST APIs](https://developer.okta.com/code/rest/) for information on setting up Postman.
 * Example or test source data to test user and group creation requests. (Do not use real user data when testing!)
-* [A plan for migrating existing users to Okta](/docs/guides/migrate-to-okta-prerequisites/main/).
+* [A plan for migrating existing users to Okta](/docs/guides/migrate-to-okta-prerequisites/).
 
 **Sample code**
 

--- a/packages/@okta/vuepress-site/docs/guides/migrate-to-okta-prerequisites/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/migrate-to-okta-prerequisites/main/index.md
@@ -172,5 +172,5 @@ With a plan in place, you're ready to move on to implementation, which differs a
 
 Have a look at our migration guides:
 
-* [Bulk migration with credentials](/docs/guides/migrate-to-okta-bulk/main/)
-* [Import Users with Inline Password Hooks](/docs/guides/migrate-to-okta-password-hooks/main/)
+* [Bulk migration with credentials](/docs/guides/migrate-to-okta-bulk/)
+* [Import Users with Inline Password Hooks](/docs/guides/migrate-to-okta-password-hooks/)


### PR DESCRIPTION
…ks to those guides

<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** https://github.com/okta/okta-developer-docs/pull/2893 updated https://developer.okta.com/docs/guides/migrate-to-okta-password-hooks/main/ to multiple single-page guides, but it didn't add those guides to the main guides index.md file. This PR fixes that, and tweaks a few links so they can take advantage of the flexibility this brings.
- **Is this PR related to a Monolith release?** No
