### PR TITLE
convert production-deployment to single page guide

### DIFF
--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -4685,3 +4685,5 @@ redirects:
     to: /docs/guides/migrate-to-okta-bulk/main/
   - from: /docs/guides/migrate-to-okta/migrate-users-password-hooks/index.html
     to: /docs/guides/migrate-to-okta-password-hooks/main/
+  - from: /docs/guides/production-deployment/deployment-checklist/
+    to: /docs/guides/deployment-checklist/main/

--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -4687,5 +4687,5 @@ redirects:
     to: /docs/guides/migrate-to-okta-password-hooks/main/
   - from: /docs/guides/production-deployment/deployment-checklist
     to: /docs/guides/deployment-checklist/
-    from: /docs/guides/production-deployment/deployment-checklist/index.html
+  - from: /docs/guides/production-deployment/deployment-checklist/index.html
     to: /docs/guides/deployment-checklist/

--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -4685,7 +4685,7 @@ redirects:
     to: /docs/guides/migrate-to-okta-bulk/main/
   - from: /docs/guides/migrate-to-okta/migrate-users-password-hooks/index.html
     to: /docs/guides/migrate-to-okta-password-hooks/main/
-  - from: /docs/guides/production-deployment/deployment-checklist/
+  - from: /docs/guides/production-deployment/deployment-checklist
     to: /docs/guides/deployment-checklist/
     from: /docs/guides/production-deployment/deployment-checklist/index.html
     to: /docs/guides/deployment-checklist/

--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -4686,4 +4686,6 @@ redirects:
   - from: /docs/guides/migrate-to-okta/migrate-users-password-hooks/index.html
     to: /docs/guides/migrate-to-okta-password-hooks/main/
   - from: /docs/guides/production-deployment/deployment-checklist/
-    to: /docs/guides/deployment-checklist/main/
+    to: /docs/guides/deployment-checklist/
+    from: /docs/guides/production-deployment/deployment-checklist/index.html
+    to: /docs/guides/deployment-checklist/

--- a/packages/@okta/vuepress-site/docs/guides/deployment-checklist/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/deployment-checklist/index.md
@@ -1,0 +1,7 @@
+---
+title: Deployment and pre-launch checklists
+excerpt: Learn about the items you might want to check when completing a deployment to production.
+layout: Guides
+sections: 
+ - main
+---

--- a/packages/@okta/vuepress-site/docs/guides/deployment-checklist/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/deployment-checklist/main/index.md
@@ -8,7 +8,7 @@ Now that you've built an app, there are a few final steps for you to take to cus
 
 ## Brand and customization
 
-Ensure your application fits your brand:
+Ensure that your application fits your brand:
 
 * [Use a custom domain](/docs/guides/custom-url-domain/): Customize your Okta organization by replacing your Okta domain name (for example, dev-12345.okta.com) with your own domain name (for example, id.example.com) so that all URLs look like your application.
 * [Customize and add branding to your sign-in page](/docs/guides/custom-widget/): Tailor the sign-in page to fit your brand or your application's look and feel so that your user experience is consistent and seamless.

--- a/packages/@okta/vuepress-site/docs/guides/deployment-checklist/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/deployment-checklist/main/index.md
@@ -6,7 +6,7 @@ layout: Guides
 
 Now that you've built an app, there are a few final steps for you to take to customize your app and get it ready to launch. This guide provides multiple checklists to help you take your app over the finish line.
 
-## Branding and customization
+## Brand and customization
 
 Ensure your application fits your brand:
 

--- a/packages/@okta/vuepress-site/docs/guides/deployment-checklist/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/deployment-checklist/main/index.md
@@ -22,7 +22,7 @@ Ensure that your application fits your brand:
 * [Update Redirect URI for your domain](/docs/guides/sign-into-web-app/): If you created an Okta application that uses `localhost` or a test domain, you need to update your Okta application (or create a new one) using publicly accessible URLs.
 * [Configure Cross-Origin Resource Sharing (CORS)](/docs/guides/enable-cors/): If you are building a SPA or you are embedding the [Okta Sign-In Widget](/code/javascript/okta_sign-in_widget/) into your own app, you must configure CORS for your domain.
 
-> **Note:** Configuring CORS isn't needed if you are using Okta's [custom domain feature](/docs/guides/custom-url-domain/main/#enable-the-custom-domain).
+> **Note:** Configuring CORS isn't required if you're using the Okta [custom domain feature](/docs/guides/custom-url-domain/main/#enable-the-custom-domain).
 
 ## User authorization and registration
 

--- a/packages/@okta/vuepress-site/docs/guides/deployment-checklist/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/deployment-checklist/main/index.md
@@ -1,14 +1,12 @@
 ---
-title: Pre-launch checklist
+title: Deployment and pre-launch checklists
+excerpt: Learn about the items you might want to check when completing a deployment to production.
+layout: Guides
 ---
 
-Now that you've built an app, get it ready to launch!
+Now that you've built an app, there are a few final steps for you to take to customize your app and get it ready to launch. This guide provides multiple checklists to help you take your app over the finish line.
 
-By now, you might have built your first app with Okta, congrats! There are just a few final steps for you to take to customize your app and get it ready to launch. The guides below help you take your app to the finish line.
-
-Here's your pre-launch checklist:
-
-### Branding and customization
+## Branding and customization
 
 Ensure your application fits your brand:
 
@@ -19,21 +17,21 @@ Ensure your application fits your brand:
 * [Customize email templates](/docs/guides/custom-email/main/#customize-email-templates): Change the look and feel of the emails sent to users by Okta.
 * [Manage access to protected resources](/docs/guides/validate-access-tokens/): If your app has to validate the signed tokens that are issued to end-users. Learn about this process and best practices for validating your user's tokens.
 
-### Application settings
+## Application settings
 
 * [Update Redirect URI for your domain](/docs/guides/sign-into-web-app/): If you created an Okta application that uses `localhost` or a test domain, you need to update your Okta application (or create a new one) using publicly accessible URLs.
 * [Configure Cross-Origin Resource Sharing (CORS)](/docs/guides/enable-cors/): If you are building a SPA or you are embedding the [Okta Sign-In Widget](/code/javascript/okta_sign-in_widget/) into your own app, you must configure CORS for your domain.
 
 > **Note:** Configuring CORS isn't needed if you are using Okta's [custom domain feature](/docs/guides/custom-url-domain/main/#enable-the-custom-domain).
 
-### User authorization and registration
+## User authorization and registration
 
 * [Migrate your users in bulk](/docs/guides/migrate-to-okta-bulk/): Use the Okta API to bulk create your users with or without credentials. Make sure to sign into the Admin Console, and check out your settings for Security/General/Security Notification Emails, to configure whether or not you want your newly imported users to receive notification emails.
 * [Configure Multi-Factor Authentication (MFA)](/docs/guides/mfa/ga/set-up-org/): Set up which security factors are used when users sign in.
 * [Set up Self-Service Registration](/docs/guides/set-up-self-service-registration/): Allow users to sign up for an account with an email address.
 * [Enable Social Authentication](/docs/guides/add-an-external-idp/): Allow your users to sign in with their other services.
 
-### Rate limits
+## Rate limits
 
 * [Review how Okta's rate limits work](/docs/reference/rate-limits/): Requests made to the Okta API have rate limits to prevent abuse.
 

--- a/packages/@okta/vuepress-site/docs/guides/deployment-checklist/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/deployment-checklist/main/index.md
@@ -35,9 +35,9 @@ Ensure that your application fits your brand:
 
 * [Review how Okta's rate limits work](/docs/reference/rate-limits/): Requests made to the Okta API have rate limits to prevent abuse.
 
-## Troubleshooting
+## Troubleshoot
 
 Okta provides a set of reports and logs to help you troubleshoot user problems. These reports are available under the **Reports** menu.
 
 * [View activity and security reports](https://help.okta.com/okta_help.htm?id=ext_Reports): Help diagnose sign-in problems for your users.
-* [View events in the System Log](https://help.okta.com/okta_help.htm?id=ext_Reports_SysLog): To see a more general log of all events in your Okta organization.
+* [View events in the System Log](https://help.okta.com/okta_help.htm?id=ext_Reports_SysLog): See all event logs in your Okta org.

--- a/packages/@okta/vuepress-site/docs/guides/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/index.md
@@ -134,8 +134,8 @@ If you're using Okta as an identity layer in your app for the first time, we rec
 
 5. Deploy to production
 
-    * [Pre-launch checklist](/docs/guides/production-deployment/deployment-checklist/)
-    * [Deploy your app](/docs/guides/deploy-your-app/overview/)
+    * [Pre-launch checklist](/docs/guides/deployment-checklist/)
+    * [Deploy your app](/docs/guides/deploy-your-app/)
     * [Migrate to Okta](/docs/guides/migrate-to-okta-prerequisites/)
 
 6. Customize Okta process flows with Event or Inline Hooks

--- a/packages/@okta/vuepress-site/docs/guides/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/index.md
@@ -38,7 +38,7 @@ guides:
  - build-sso-integration
  - custom-sms-messaging
  - submit-app
- - production-deployment
+ - deployment-checklist
  - deploy-your-app
  - protect-your-api
  - quickstart

--- a/packages/@okta/vuepress-site/docs/guides/production-deployment/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/production-deployment/index.md
@@ -1,7 +1,0 @@
----
-title: Deployment checklist
-excerpt: Learn about the items you might want to complete to deploy to production.
-layout: Guides
-sections: 
- - deployment-checklist
----

--- a/packages/@okta/vuepress-theme-prose/const/navbar.const.js
+++ b/packages/@okta/vuepress-theme-prose/const/navbar.const.js
@@ -448,7 +448,7 @@ export const guides = [
       {
         title: "Deploy to Production",
         subLinks: [
-          { title: "Deployment checklist", guideName: "production-deployment" },
+          { title: "Deployment checklists", path: "/docs/guides/deployment-checklist/main/" },
           { title: "Deploy your app", guideName: "deploy-your-app" },
           {
             title: "Migrate to Okta",


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** I noticed that there was one multi-page guide that had not been updated as part of the previous conversion work — https://developer.okta.com/docs/guides/production-deployment/deployment-checklist/. This PR converts that to single page, and cleans up a bunch of prose.
- **Is this PR related to a Monolith release?** No