### PR TITLE
TBS OKTA-453902 moves custom email domain content to custom Okta URL guide

### DIFF
--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -4134,9 +4134,9 @@ redirects:
   - from: /docs/guides/email-customization/customize-email-templates/index.html
     to: /docs/guides/custom-email/main/#customize-email-templates
   - from: /docs/guides/email-customization/configure-custom-email-domain
-    to: /docs/guides/custom-email/main/#configure-a-custom-email-domain
+    to: /docs/guides/custom-url-domain/main/#configure-a-custom-email-domain
   - from: /docs/guides/email-customization/configure-custom-email-domain/index.html
-    to: /docs/guides/custom-email/main/#configure-a-custom-email-domain
+    to: /docs/guides/custom-url-domain/main/#configure-a-custom-email-domain
   - from: /docs/guides/email-customization/next-steps
     to: /docs/guides/custom-email/main/#see-also
   - from: /docs/guides/email-customization/next-steps/index.html

--- a/packages/@okta/vuepress-site/docs/guides/custom-email/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-email/main/index.md
@@ -193,6 +193,6 @@ You can send yourself a test email to see how a custom email template looks and 
 
 Read more on customizing and styling various Okta assets to match your company's visual identity and branding:
 
-- [Customize the Okta URL domain](/docs/guides/custom-url-domain/)
-- [SMS customization](/docs/guides/custom-sms-messaging/)
+- [Customize the Okta URL and email notification domains](/docs/guides/custom-url-domain/)
+- [Customize SMS messages](/docs/guides/custom-sms-messaging/)
 - [Style the Widget](/docs/guides/style-the-widget/)

--- a/packages/@okta/vuepress-site/docs/guides/custom-email/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-email/main/index.md
@@ -30,7 +30,7 @@ You can customize and style the default email notifications that Okta sends to e
 - forgotten password
 - unknown device notification
 
-Email notifications are based on templates that are generated automatically and sent to end users according to your settings. Okta email templates are available in each Okta-supported language. You can use the default email templates as is, or you can edit the email template text to send end users custom Okta-generated email messages.
+Email notifications are based on templates that are generated automatically and sent to end users according to your settings. Okta email templates are available in each Okta-supported language. You can use the default email templates as they are, or you can edit the text of the various email templates to send end users custom Okta-generated email messages.
 
 ### Use the Brands API
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-email/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-email/main/index.md
@@ -70,7 +70,7 @@ Use these steps to add or edit a template in one of the Okta-supported languages
 
 ## Expression Language variables
 
-Email templates use common and unique [Expression Language (EL) variables](https://help.okta.com/okta_help.htm?id=ext-expression-language). EL variables enable advanced customization and, when used in place of hard-coded URLs, can prevent potential broken links.
+Email templates use common and unique [Expression Language (EL) variables](https://help.okta.com/okta_help.htm?id=ext-expression-language). EL variables enable advanced customization and can prevent potential broken links when they're used in place of hard-coded URLs.
 
 > **Note:** Some templates listed in the [variables tables](https://help.okta.com/okta_help.htm?id=ext-expression-language) may not appear in your org. To obtain these templates, contact [Okta Support](https://support.okta.com/help/s/?_ga=2.17747641.1660906902.1597076228-1076744453.1575496867).
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-email/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-email/main/index.md
@@ -24,7 +24,7 @@ See the [Example of using app context to brand an email](#example-of-using-app-c
 
 ## About email customization
 
-You can customize and style the default email notifications that Okta sends to end users. Okta sends email notifications for a variety of reasons:
+You can customize and style the default email notifications that Okta sends to end users. Okta sends email notifications for a variety of reasons, such as:
 
 - user activation
 - forgotten password

--- a/packages/@okta/vuepress-site/docs/guides/custom-email/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-email/main/index.md
@@ -193,6 +193,6 @@ You can send yourself a test email to see how a custom email template looks and 
 
 Read more on customizing and styling various Okta assets to match your company's visual identity and branding:
 
-- [Customize the Okta URL domain](/docs/guides/custom-url-and-email-domain/)
+- [Customize the Okta URL domain](/docs/guides/custom-url-domain/)
 - [SMS customization](/docs/guides/custom-sms-messaging/)
 - [Style the Widget](/docs/guides/style-the-widget/)

--- a/packages/@okta/vuepress-site/docs/guides/custom-email/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-email/main/index.md
@@ -18,7 +18,7 @@ An [Okta Developer Edition organization](https://developer.okta.com/signup)
 
 **Sample code**
 
-See the [Using app context to brand an email](#example-of-using-app-context-to-brand-an-email) section.
+See the [Example of using app context to brand an email](#example-of-using-app-context-to-brand-an-email) section.
 
 ---
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-email/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-email/main/index.md
@@ -14,7 +14,7 @@ Customize email notifications.
 
 **What you need**
 
-An [Okta Developer Edition organization](/signup)
+An [Okta Developer Edition organization](https://developer.okta.com/signup)
 
 **Sample code**
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-email/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-email/main/index.md
@@ -1,26 +1,20 @@
 ---
-title: Customize email notifications and domains
-excerpt: Learn how to customize and style the default email notifications that Okta sends to end users and customize email domains.
+title: Customize email notifications
+excerpt: Learn how to customize and style the default email notifications that Okta sends to end users.
 layout: Guides
 ---
 
-This guide teaches you how to customize and style default Okta email notifications and how to create a custom email domain.
+This guide teaches you how to customize and style the default Okta email notifications.
 
 ---
 
 **Learning outcomes**
 
-- Customize email notifications.
-- Configure a custom email domain.
+Customize email notifications.
 
 **What you need**
 
 An [Okta Developer Edition organization](/signup)
-
-For configuring a custom email domain:
-
-- Access to the DNS records of your public custom domain.
-- An implementation of the [Sender Policy Framework (SPF)](https://tools.ietf.org/html/rfc7208) to prevent sender address forgery. If you already implement SPF in your custom domain, be aware that you must update the SPF record.
 
 **Sample code**
 
@@ -28,17 +22,13 @@ See the [Using app context to brand an email](#example-of-using-app-context-to-b
 
 ---
 
-## Overview
+## About email customization
 
 You can customize and style the default email notifications that Okta sends to end users. Okta sends email notifications for a variety of reasons:
 
 - user activation
 - forgotten password
 - unknown device notification
-
-You can also configure a custom email domain to present a branded experience to your end users.
-
-### Customize and brand templates
 
 Email notifications are based on templates that are generated automatically and sent to end users according to your settings. Okta email templates are available in each Okta-supported language. You can use the default email templates as is, or you can edit the email template text to send end users custom Okta-generated email messages.
 
@@ -56,9 +46,7 @@ The [Brands API](/docs/reference/api/brands/) is a feature (currently in Early A
 
 - If you customize an email template, you need to manually create a translation for each additional language that you support in your org.
 
-## Customize email templates
-
-### Add or edit email templates
+## Add or edit email templates
 
 Use these steps to add or edit a template in one of the Okta-supported languages.
 
@@ -72,7 +60,7 @@ Use these steps to add or edit a template in one of the Okta-supported languages
 6. Make your edits, and then click **Add Translation**.
 7. Repeat steps 5 and 6 for additional languages.
 
-### Localization notes
+## Localization notes
 
 * When multiple translations have been added for a template, the translation provided in the default language appears at the top of the list. You can designate any added translation as the default language by selecting it from the **Default Language** drop-down box. Doing so reorders the list of added translations automatically. You can edit the templates through the pencil icon, but you can't delete the default language template.
 
@@ -80,13 +68,13 @@ Use these steps to add or edit a template in one of the Okta-supported languages
 
 * If you want to delete all custom translations and revert to the original Okta-provided template, click **Reset to Default**.
 
-### Expression Language variables
+## Expression Language variables
 
 Email templates use common and unique [Expression Language (EL) variables](https://help.okta.com/okta_help.htm?id=ext-expression-language). EL variables enable advanced customization and, when used in place of hard-coded URLs, can prevent potential broken links.
 
 > **Note:** Some templates listed in the [variables tables](https://help.okta.com/okta_help.htm?id=ext-expression-language) may not appear in your org. To obtain these templates, contact [Okta Support](https://support.okta.com/help/s/?_ga=2.17747641.1660906902.1597076228-1076744453.1575496867).
 
-### Enhanced Email Macros
+## Enhanced Email Macros
 
 <ApiLifecycle access="ea" />
 
@@ -114,7 +102,7 @@ Previously with EL syntax, you could reference the first name of the user by usi
 
 The previously available template variables are listed in [Customization Variables](https://help.okta.com/okta_help.htm?id=ext_ref_email_variables).
 
-### Use all User Profile attributes
+## Use all User Profile attributes
 
 You can reference any Okta User Profile attribute in your email templates. The reference notation is `$user.profile.attributeName`, where `attributeName` is an attribute from the Okta User Profile. For example, use `$user.profile.displayName` to reference the User Profile `displayName` attribute.
 
@@ -125,7 +113,7 @@ Other examples include:
 
 See [Profile object](/docs/reference/api/users/#profile-object) for more information on the available User Profile attributes.
 
-### Use functions for email templates
+## Use functions for email templates
 
 In addition to customizing your emails with variables, you can use the following functions in each of the email templates. Functions are useful to normalize the dynamic output of variables, such as lowercasing a string, or producing a localized date for the email recipient.
 
@@ -156,7 +144,7 @@ VTL syntax:
 | escapeHtml(String html)                                       | Escapes the characters in the provided string using HTML entities                                                             |
 | escapeHtmlAttr(String html)                                   | Encodes data for use in HTML attributes                                                                           |
 
-### Use org attributes
+## Use org attributes
 
 You can also reference these org-level attributes, such as:
 
@@ -170,7 +158,7 @@ You can also reference these org-level attributes, such as:
 
 All conditional logic that is supported by the Velocity Templating Engine, such as `if`, `elseif`, or `else` constructs and `foreach` loops, is available for you to use in your templates. See the [Velocity documentation](http://velocity.apache.org/engine/1.7/user-guide.html).
 
-### Use app context
+## Use app context
 
 Okta Identity Engine orgs have access to app context within emails using the Velocity Templating Language. When an end user enters an authentication flow, Identity Engine stores the app context in the state token. The following properties are available in the app context:
 
@@ -194,69 +182,17 @@ When these properties are used with conditional logic, you can trigger branding 
 #end
 ```
 
-### Test custom email templates
+## Test custom email templates
 
 You can send yourself a test email to see how a custom email template looks and functions. This can help you validate macro attributes and translations in the customized template as well as see how the template renders in different email environments. This eliminates the need to create a real end-to-end workflow to test customization. The test email is sent to the primary email address of the admin that initiates the test email.
 
 1. Click the email icon to the right of the email template that you have customized. The Send test email dialog box appears and lists who the email is sent to and from what sender the email is coming from.
 2. Click **Send test email**.
 
-## Configure a custom email domain
-
-A custom email domain allows you to present a branded experience to your end users. Email that Okta sends to your end users appears to come from your custom email domain instead of `noreply@okta.com`. You can switch to a different custom domain or revert to the default Okta domain, but you can use only one email domain at a time.
-
-Okta sends your super admins a confirmation email after your custom domain is configured and operating correctly. To ensure continuous operation, Okta polls your custom email domain once every 24 hours. If a problem occurs, Okta alerts super admins by email, and Okta-generated emails are sent from the default domain `noreply@okta.com` until the problem is resolved.
-
-To configure a custom email domain:
-
-1. In the Admin Console, go to **Settings** and then **Emails & SMS**.
-
-2. Click the **Sender:** link (**Okta <noreply@okta.com>**) near the top of the page.
-
-3. On the Configure Email Sender dialog box, select **Custom email domain** as the type of sender that you want to send system notification emails from.
-
-4. In the **Email address to send from**, enter the email address that you want to send the system notification emails from. This is what displays in the emails sent to your users.
-
-5. Enter the **Name of sender**. This name appears as the sender in the emails sent to your users.
-
-6. In the **Mail domain to send from** box, enter a unique mail domain that your organization has dedicated for Okta to send mail from. Later in this procedure, you add the unique mail domain to the SPF record to your DNS zone (the root domain) as an include-statement to show that you allow Okta to send mail from this unique mail domain.
-
-7. Click the **Save & View Required DNS Records** button to save your changes and view your org's DNS records that you need to update before your settings can take effect.
-
-8. Update your DNS records using the provided values.
-
-9. When you have updated your DNS records through your domain provider, click **I've updated the DNS records**. Okta begins polling your DNS records until it detects your updates (may take up to 24 hours). Your configuration is pending until the DNS updates are detected.
-
-    Alternatively, you can click **I will update the DNS records later**. Your records aren't polled and your configuration is incomplete until you update the relevant DNS records and click **I've updated the DNS records**. You can view the list of records that require an update at any time.
-
-10. Add the SPF record to your DNS zone (the root domain). An SPF record specifies the mail servers that your organization has authorized to send mail from your domain. If your root domain already has an SPF record, the following update can prevent spoofers from sending mail that mimics your domain.
-
-    For example, if you only send mail from Microsoft Office 365, your SPF record has an include-statement like this:
-
-    ```plain
-    example.com TXT    v=spf1 include:spf.protection.outlook.com -all
-    ```
-
-    To finish configuring your custom email domain, you must add another include-statement that specifies the mail domain that you specified in the **Mail domain to send from** box in step 6. This is also the host that appears in the first CNAME row in the DNS Records table in the Configure Email Sender dialog box.
-
-    ![CNAME Example](/img/CNAMEExample.png "CNAME table with an arrow pointing at the first CNAME row in the table")
-
-    Add the host to the existing record to configure a combined SPF record similar to this:
-
-    ```plain
-    example.com TXT    v=spf1 include:oktamail.example.com include:spf.protection.outlook.com -all
-    ```
-
-### Known Issues
-
-- You can't configure Okta to send emails through a domain that uses SendGrid. Instead, configure a subdomain on your DNS provider for custom Okta emails.
-
-- You can't have more than 10 DNS lookups in your SPF record.
-
 ## See also
 
 Read more on customizing and styling various Okta assets to match your company's visual identity and branding:
 
-- [Customize the Okta URL domain](/docs/guides/custom-url-domain/)
+- [Customize the Okta URL domain](/docs/guides/custom-url-and-email-domain/)
 - [SMS customization](/docs/guides/custom-sms-messaging/)
 - [Style the Widget](/docs/guides/style-the-widget/)

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/index.md
@@ -1,6 +1,6 @@
 ---
-title: Customize the Okta URL domain
-excerpt: Learn how to add a custom domain name to your Okta organization.
+title: Customize the Okta URL and email notification domains
+excerpt: Learn how to add a custom domain name to your Okta organization and configure a custom email notification domain.
 layout: Guides
 sections:
  - main

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -281,7 +281,7 @@ You need to update your Authorization Server to use your custom domain to fix th
 3. Change the **Issuer** to use **Custom URL**.
 4. Try `./well-known/openid-configuration` again. It should now display your custom domain.
 
-## About configuring a custom email domain
+## About custom email domain configuration
 
 A custom email domain allows you to present a branded experience to your end users. Email that Okta sends to your end users appears to come from your custom email domain instead of `noreply@okta.com`. You can switch to a different custom domain or revert to the default Okta domain, but you can use only one email domain at a time.
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -281,13 +281,13 @@ You need to update your Authorization Server to use your custom domain to fix th
 3. Change the **Issuer** to use **Custom URL**.
 4. Try `./well-known/openid-configuration` again. It should now display your custom domain.
 
-## About custom email domain configuration
+## About custom email notification domain configuration
 
 A custom email domain allows you to present a branded experience to your end users. Emails that Okta sends to your end users appears to come from your custom email domain instead of `noreply@okta.com`. You can switch to a different custom domain or revert to the default Okta domain, but you can use only one email domain at a time.
 
 Okta sends your super admins a confirmation email after your custom domain is configured and operating correctly. To ensure continuous operation, Okta polls your custom email domain once every 24 hours. If a problem occurs, Okta alerts super admins by email, and Okta-generated emails are sent from the default domain `noreply@okta.com` until the problem is resolved.
 
-## Configure a custom email domain
+## Configure a custom email notification domain
 
 1. In the Admin Console, go to **Settings** and then **Emails & SMS**.
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -311,7 +311,7 @@ Okta sends your super admins a confirmation email after your custom domain is co
 
 10. Add the SPF record to your DNS zone (the root domain). An SPF record specifies the mail servers that your organization has authorized to send mail from your domain. If your root domain already has an SPF record, the following update can prevent spoofers from sending mail that mimics your domain.
 
-    For example, if you only send mail from Microsoft Office 365, your SPF record has an include-statement like this:
+    For example, if you only send mail from Microsoft Office 365, your SPF record has an include-statement similar to:
 
     ```plain
     example.com TXT    v=spf1 include:spf.protection.outlook.com -all

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -1,10 +1,10 @@
 ---
-title: Customize the Okta URL and email domains
+title: Customize the Okta URL and email notification domains
 excerpt: Learn how to add a custom domain name to your Okta organization and configure a custom email notification domain.
 layout: Guides
 ---
 
-This guide teaches you how to customize the Okta URL domain and how to configure a custom email domain.
+This guide teaches you how to customize the Okta URL domain and how to configure a custom email notification domain.
 
 ---
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -283,7 +283,7 @@ You need to update your Authorization Server to use your custom domain to fix th
 
 ## About custom email domain configuration
 
-A custom email domain allows you to present a branded experience to your end users. Email that Okta sends to your end users appears to come from your custom email domain instead of `noreply@okta.com`. You can switch to a different custom domain or revert to the default Okta domain, but you can use only one email domain at a time.
+A custom email domain allows you to present a branded experience to your end users. Emails that Okta sends to your end users appears to come from your custom email domain instead of `noreply@okta.com`. You can switch to a different custom domain or revert to the default Okta domain, but you can use only one email domain at a time.
 
 Okta sends your super admins a confirmation email after your custom domain is configured and operating correctly. To ensure continuous operation, Okta polls your custom email domain once every 24 hours. If a problem occurs, Okta alerts super admins by email, and Okta-generated emails are sent from the default domain `noreply@okta.com` until the problem is resolved.
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -317,7 +317,7 @@ Okta sends your super admins a confirmation email after your custom domain is co
     example.com TXT    v=spf1 include:spf.protection.outlook.com -all
     ```
 
-    To finish configuring your custom email domain, you must add another include-statement that specifies the mail domain that you specified in the **Mail domain to send from** box in step 6. This is also the host that appears in the first CNAME row in the DNS Records table in the Configure Email Sender dialog box.
+    To finish configuring your custom email domain, you must add another include-statement that specifies the mail domain that you specified in the **Mail domain to send from** field from the Configure Email Sender dialog box in step 6. This is also the host that appears in the first CNAME row in the DNS Records table.
 
     ![CNAME Example](/img/CNAMEExample.png "CNAME table with an arrow pointing at the first CNAME row in the table")
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -1,27 +1,35 @@
 ---
-title: Customize the Okta URL domain
-excerpt: Learn how to add a custom domain name to your Okta organization.
+title: Customize the Okta URL domain and an email domain
+excerpt: Learn how to add a custom domain name to your Okta organization and configure a custom email domain.
 layout: Guides
 ---
 
-This guide teaches you how to customize the Okta URL domain, meaning that Okta-hosted pages are served with your own branded URL&mdash;an important step towards creating a seamless experience for your users.
+This guide teaches you how to customize the Okta URL domain and how to configure a custom email domain.
 
 ---
 
 **Learning outcomes**
 
-Customize the Okta URL domain.
+* Customize the Okta URL domain.
+* Configure a custom email domain.
 
 **What you need**
+
+For customizing your Okta URL domain:
 
 * A domain that you own, for example, `example.com`
 * A subdomain that you want to use, for example, `login.example.com`
 * A valid TLS certificate (PEM-encoded) for your subdomain
 * A 2048-bit private key (PEM-encoded)
 
+For configuring a custom email domain:
+
+* Access to the DNS records of your public custom domain
+* An implementation of the [Sender Policy Framework (SPF)](https://tools.ietf.org/html/rfc7208) to prevent sender address forgery. If you already implement SPF in your custom domain, be aware that you must update the SPF record.
+
 ---
 
-## Overview
+## About customizing the Okta URL domain
 
 You can customize your Okta organization by replacing the Okta domain name with your own domain name. Your customized domain name allows you to create a seamless branded experience for your users so that all URLs look like your app.
 
@@ -30,6 +38,8 @@ For example, you use Okta as a user store for your apps, but you don't want your
 > **Note:** You must first customize the Okta URL domain if you also want to customize the Okta-hosted [sign-in page](/docs/guides/custom-widget/main/#style-the-okta-hosted-sign-in-widget) or [error pages](/docs/guides/custom-error-pages/).
 
 Okta serves pages on your custom domain over HTTPS. To set up this feature, you need to provide a TLS certificate that is valid for your domain. See [Validate your TLS certificate](#validate-your-tls-certificate).
+
+You can also configure a custom email domain to present a branded experience to your end users.
 
 ### Caveats
 
@@ -154,9 +164,7 @@ Okta serves traffic over HTTPS (TLS) on your custom domain. Use this section to 
 2. Paste your PEM-encoded private key for your subdomain in the **Private Key** field. Be sure to include the `-----BEGIN RSA PRIVATE KEY-----` and `-----END RSA PRIVATE KEY-----` lines.
 3. We recommend that you enter a PEM-encoded certificate chain (if you have one) in the **Certificate Chain** field. Certificate chain files can contain keys that are up to 4096 bits. The order in which the root and intermediary certificates appear in the file matters. The intermediate CA certificate should be at the top and then the root CA certificate at the bottom.
 
-    > **Note**: If your app includes servers that make API calls to Okta, you need to ensure that your intermediate or certificate chain is added to the **Certificate Chain** field, especially if you are doing local token validation. Failure to do so is a common cause of TLS handshake errors.
-
-    > **Note**: Android devices require a certificate chain. You must provide a certificate chain if you want your custom domain to work with apps on Android. For a list of trusted root certificates on Android, see [Official List of Trusted Root Certificates on Android](https://www.digicert.com/blog/official-list-trusted-root-certificates-android/).
+    > **Note:** Android devices require a certificate chain. You must provide a certificate chain if you want your custom domain to work with apps on Android. For a list of trusted root certificates on Android, see the [Official List of Trusted Root Certificates on Android](https://www.digicert.com/blog/official-list-trusted-root-certificates-android/).
 
 4. Click **Next**. Making your custom domain an alias for your Okta domain is the next step in the configuration wizard.
 
@@ -273,6 +281,58 @@ You need to update your Authorization Server to use your custom domain to fix th
 3. Change the **Issuer** to use **Custom URL**.
 4. Try `./well-known/openid-configuration` again. It should now display your custom domain.
 
+## About configuring a custom email domain
+
+A custom email domain allows you to present a branded experience to your end users. Email that Okta sends to your end users appears to come from your custom email domain instead of `noreply@okta.com`. You can switch to a different custom domain or revert to the default Okta domain, but you can use only one email domain at a time.
+
+Okta sends your super admins a confirmation email after your custom domain is configured and operating correctly. To ensure continuous operation, Okta polls your custom email domain once every 24 hours. If a problem occurs, Okta alerts super admins by email, and Okta-generated emails are sent from the default domain `noreply@okta.com` until the problem is resolved.
+
+## Configure a custom email domain
+
+1. In the Admin Console, go to **Settings** and then **Emails & SMS**.
+
+2. Click the **Sender:** link (**Okta <noreply@okta.com>**) near the top of the page.
+
+3. On the Configure Email Sender dialog box, select **Custom email domain** as the type of sender that you want to send system notification emails from.
+
+4. In the **Email address to send from**, enter the email address that you want to send the system notification emails from. This is what displays in the emails sent to your users.
+
+5. Enter the **Name of sender**. This name appears as the sender in the emails sent to your users.
+
+6. In the **Mail domain to send from** box, enter a unique mail domain that your organization has dedicated for Okta to send mail from. Later in this procedure, you add the unique mail domain to the SPF record to your DNS zone (the root domain) as an include-statement to show that you allow Okta to send mail from this unique mail domain.
+
+7. Click the **Save & View Required DNS Records** button to save your changes and view your org's DNS records that you need to update before your settings can take effect.
+
+8. Update your DNS records using the provided values.
+
+9. When you have updated your DNS records through your domain provider, click **I've updated the DNS records**. Okta begins polling your DNS records until it detects your updates (may take up to 24 hours). Your configuration is pending until the DNS updates are detected.
+
+    Alternatively, you can click **I will update the DNS records later**. Your records aren't polled and your configuration is incomplete until you update the relevant DNS records and click **I've updated the DNS records**. You can view the list of records that require an update at any time.
+
+10. Add the SPF record to your DNS zone (the root domain). An SPF record specifies the mail servers that your organization has authorized to send mail from your domain. If your root domain already has an SPF record, the following update can prevent spoofers from sending mail that mimics your domain.
+
+    For example, if you only send mail from Microsoft Office 365, your SPF record has an include-statement like this:
+
+    ```plain
+    example.com TXT    v=spf1 include:spf.protection.outlook.com -all
+    ```
+
+    To finish configuring your custom email domain, you must add another include-statement that specifies the mail domain that you specified in the **Mail domain to send from** box in step 6. This is also the host that appears in the first CNAME row in the DNS Records table in the Configure Email Sender dialog box.
+
+    ![CNAME Example](/img/CNAMEExample.png "CNAME table with an arrow pointing at the first CNAME row in the table")
+
+    Add the host to the existing record to configure a combined SPF record similar to this:
+
+    ```plain
+    example.com TXT    v=spf1 include:oktamail.example.com include:spf.protection.outlook.com -all
+    ```
+
+### Known Issues
+
+- You can't configure Okta to send emails through a domain that uses SendGrid. Instead, configure a subdomain on your DNS provider for custom Okta emails.
+
+- You can't have more than 10 DNS lookups in your SPF record.
+
 ## Next steps
 
 The following customization options require a custom URL domain:
@@ -283,5 +343,5 @@ The following customization options require a custom URL domain:
 The following customization options don't require a custom URL domain:
 
 * [Customize SMS messages](/docs/guides/custom-sms-messaging/)
-* [Customize email notifications and email domains](/docs/guides/custom-email/)
+* [Customize email notifications](/docs/guides/custom-email/)
 * [Customize themes](/docs/guides/customize-themes)

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -39,7 +39,7 @@ For example, you use Okta as a user store for your apps, but you don't want your
 
 Okta serves pages on your custom domain over HTTPS. To set up this feature, you need to provide a TLS certificate that is valid for your domain. See [Validate your TLS certificate](#validate-your-tls-certificate).
 
-You can also configure a custom email domain to present a branded experience to your end users.
+You can also [configure a custom email notification domain](#about-custom-email-domain-configuration) to present a branded experience to your end users.
 
 ### Caveats
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -25,7 +25,7 @@ For customizing your Okta URL domain:
 For configuring a custom email notification domain:
 
 * Access to the DNS records of your public custom domain
-* An implementation of the [Sender Policy Framework (SPF)](https://tools.ietf.org/html/rfc7208) to prevent sender address forgery. If you already implement SPF in your custom domain, be aware that you must update the SPF record.
+* An implementation of the [Sender Policy Framework (SPF)](https://tools.ietf.org/html/rfc7208) to prevent sender address forgery. If you already implemented SPF in your custom domain, ensure that you update the SPF record.
 
 ---
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -1,6 +1,6 @@
 ---
 title: Customize the Okta URL domain and an email domain
-excerpt: Learn how to add a custom domain name to your Okta organization and configure a custom email domain.
+excerpt: Learn how to add a custom domain name to your Okta organization and configure a custom email notification domain.
 layout: Guides
 ---
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -299,7 +299,7 @@ Okta sends your super admins a confirmation email after your custom domain is co
 
 5. Enter the **Name of sender**. This name appears as the sender in the emails sent to your users.
 
-6. In the **Mail domain to send from** box, enter a unique mail domain that your organization has dedicated for Okta to send mail from. Later in this procedure, you add the unique mail domain to the SPF record to your DNS zone (the root domain) as an include-statement to show that you allow Okta to send mail from this unique mail domain.
+6. In the **Mail domain to send from** box, enter a unique mail domain that your organization has dedicated for Okta to send mail from. Later in this procedure, you add the unique mail domain to the SPF record in your DNS zone (the root domain) as an include-statement to show that you allow Okta to send mail from this unique mail domain.
 
 7. Click **Save & View Required DNS Records** to save your changes and view your org's DNS records that you need to update before your settings can take effect.
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -301,7 +301,7 @@ Okta sends your super admins a confirmation email after your custom domain is co
 
 6. In the **Mail domain to send from** box, enter a unique mail domain that your organization has dedicated for Okta to send mail from. Later in this procedure, you add the unique mail domain to the SPF record to your DNS zone (the root domain) as an include-statement to show that you allow Okta to send mail from this unique mail domain.
 
-7. Click the **Save & View Required DNS Records** button to save your changes and view your org's DNS records that you need to update before your settings can take effect.
+7. Click **Save & View Required DNS Records** to save your changes and view your org's DNS records that you need to update before your settings can take effect.
 
 8. Update your DNS records using the provided values.
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -11,7 +11,7 @@ This guide teaches you how to customize the Okta URL domain and how to configure
 **Learning outcomes**
 
 * Customize the Okta URL domain.
-* Configure a custom email domain.
+* Configure a custom email notification domain.
 
 **What you need**
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -22,7 +22,7 @@ For customizing your Okta URL domain:
 * A valid TLS certificate (PEM-encoded) for your subdomain
 * A 2048-bit private key (PEM-encoded)
 
-For configuring a custom email domain:
+For configuring a custom email notification domain:
 
 * Access to the DNS records of your public custom domain
 * An implementation of the [Sender Policy Framework (SPF)](https://tools.ietf.org/html/rfc7208) to prevent sender address forgery. If you already implement SPF in your custom domain, be aware that you must update the SPF record.

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -29,7 +29,7 @@ For configuring a custom email notification domain:
 
 ---
 
-## About customizing the Okta URL domain
+## About Okta URL domain customization
 
 You can customize your Okta organization by replacing the Okta domain name with your own domain name. Your customized domain name allows you to create a seamless branded experience for your users so that all URLs look like your app.
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -1,5 +1,5 @@
 ---
-title: Customize the Okta URL domain and an email domain
+title: Customize the Okta URL and email domains
 excerpt: Learn how to add a custom domain name to your Okta organization and configure a custom email notification domain.
 layout: Guides
 ---

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -305,7 +305,7 @@ Okta sends your super admins a confirmation email after your custom domain is co
 
 8. Update your DNS records using the provided values.
 
-9. When you have updated your DNS records through your domain provider, click **I've updated the DNS records**. Okta begins polling your DNS records until it detects your updates (may take up to 24 hours). Your configuration is pending until the DNS updates are detected.
+9. After you've updated your DNS records through your domain provider, click **I've updated the DNS records**. Okta begins polling your DNS records until it detects your updates (this may take up to 24 hours). Your configuration is pending until the DNS updates are detected.
 
     Alternatively, you can click **I will update the DNS records later**. Your records aren't polled and your configuration is incomplete until you update the relevant DNS records and click **I've updated the DNS records**. You can view the list of records that require an update at any time.
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -329,7 +329,7 @@ Okta sends your super admins a confirmation email after your custom domain is co
 
 ### Known Issues
 
-- You can't configure Okta to send emails through a domain that uses SendGrid. Instead, configure a subdomain on your DNS provider for custom Okta emails.
+- You can't configure Okta to send emails through a domain that uses SendGrid. Instead, configure a subdomain with your DNS provider for custom Okta emails.
 
 - You can't have more than 10 DNS lookups in your SPF record.
 


### PR DESCRIPTION
## Description:
- **What's changed?** Moves the custom email domain content to the custom Okta URL domain guide.
- **Is this PR related to a Monolith release?** nope

### Resolves:

* [OKTA-453902](https://oktainc.atlassian.net/browse/OKTA-453902)
