### PR TITLE
OKTA-443653 - Updates to Inline Hook content on concurrent rate limits

### DIFF
--- a/packages/@okta/vuepress-site/docs/concepts/inline-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/inline-hooks/index.md
@@ -152,6 +152,8 @@ When Okta calls an external service, it enforces a default timeout of 3 seconds.
 
 The Okta process flow that triggered the Inline Hook remains in progress until a response from your external service is received. For process flows initiated by calls to Okta APIs, slow processing times by your external service can cause open API transactions to accumulate, potentially exceeding [Concurrent Rate Limits](/docs/reference/rl-additional-limits/#concurrent-rate-limits).
 
+> **Note:** Concurrent Inline Hook rate limits are based on your Okta org type.
+
 ### Inline Hook timeout behavior
 
 In the case of an Inline Hook timeout or failure, the Okta process flow either continues or stops based on the Inline Hook type:

--- a/packages/@okta/vuepress-site/docs/concepts/inline-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/inline-hooks/index.md
@@ -150,7 +150,7 @@ When Okta calls an external service, it enforces a default timeout of 3 seconds.
 
 ### Inline Hooks and concurrent rate limits
 
-The Okta process flow that triggered the Inline Hook remains in progress until a response from your external service is received. For process flows initiated by calls to Okta APIs, slow processing times by your external service can cause open API transactions to accumulate, potentially exceeding [Concurrent Rate Limits](/docs/reference/rate-limits/#concurrent-rate-limits).
+The Okta process flow that triggered the Inline Hook remains in progress until a response from your external service is received. For process flows initiated by calls to Okta APIs, slow processing times by your external service can cause open API transactions to accumulate, potentially exceeding [Concurrent Rate Limits](/docs/reference/rl-additional-limits/#concurrent-rate-limits).
 
 ### Inline Hook timeout behavior
 

--- a/packages/@okta/vuepress-site/docs/reference/hooks-best-practices/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/hooks-best-practices/index.md
@@ -63,6 +63,7 @@ Your external service processing Hook requests must take into consideration that
 |            | Maximum number of Event Hooks per org | 10 | A maximum of 10 active Event Hooks can be configured per org. Each Event Hook can be configured to deliver multiple event types. |
 | Inline Hook | Timeout | 3 seconds | Inline Hooks have a completion timeout of three seconds with a single retry. However, a request is not retried if your endpoint returns a 4xx HTTP error code. Any 2xx code is considered successful, and the request is not retried. If the external service endpoint responds with a redirect, it is not followed. |
 |             | Maximum number of Inline Hooks per org | 50 | The maximum number of Inline Hooks that can be configured per org is 50, which is a combined total for any combination of Inline Hook types. |
+|             | Maximum number of concurrent Inline Hook transactions | 50 | The maximum number of Inline Hooks that can be sent concurrently. See [Concurrent rate limits](/docs/reference/rl-additional-limits/#concurrent-rate-limits).|
 
 ## Troubleshoot your Hook implementations
 

--- a/packages/@okta/vuepress-site/docs/reference/hooks-best-practices/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/hooks-best-practices/index.md
@@ -63,7 +63,7 @@ Your external service processing Hook requests must take into consideration that
 |            | Maximum number of Event Hooks per org | 10 | A maximum of 10 active Event Hooks can be configured per org. Each Event Hook can be configured to deliver multiple event types. |
 | Inline Hook | Timeout | 3 seconds | Inline Hooks have a completion timeout of three seconds with a single retry. However, a request is not retried if your endpoint returns a 4xx HTTP error code. Any 2xx code is considered successful, and the request is not retried. If the external service endpoint responds with a redirect, it is not followed. |
 |             | Maximum number of Inline Hooks per org | 50 | The maximum number of Inline Hooks that can be configured per org is 50, which is a combined total for any combination of Inline Hook types. |
-|             | Maximum number of concurrent Inline Hook transactions | 50 | The maximum number of Inline Hooks that can be sent concurrently. See [Concurrent rate limits](/docs/reference/rl-additional-limits/#concurrent-rate-limits).|
+|             | Concurrent rate limit | 50 | The maximum number of Inline Hooks that can be sent concurrently. See [Concurrent rate limits](/docs/reference/rl-additional-limits/#concurrent-rate-limits).|
 
 ## Troubleshoot your Hook implementations
 

--- a/packages/@okta/vuepress-site/docs/reference/hooks-best-practices/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/hooks-best-practices/index.md
@@ -63,7 +63,7 @@ Your external service processing Hook requests must take into consideration that
 |            | Maximum number of Event Hooks per org | 10 | A maximum of 10 active Event Hooks can be configured per org. Each Event Hook can be configured to deliver multiple event types. |
 | Inline Hook | Timeout | 3 seconds | Inline Hooks have a completion timeout of three seconds with a single retry. However, a request is not retried if your endpoint returns a 4xx HTTP error code. Any 2xx code is considered successful, and the request is not retried. If the external service endpoint responds with a redirect, it is not followed. |
 |             | Maximum number of Inline Hooks per org | 50 | The maximum number of Inline Hooks that can be configured per org is 50, which is a combined total for any combination of Inline Hook types. |
-|             | Concurrent rate limit | 50 | The maximum number of Inline Hooks that can be sent concurrently. See [Concurrent rate limits](/docs/reference/rl-additional-limits/#concurrent-rate-limits).|
+|             | Concurrent rate limit | Variable | The maximum number of Inline Hooks that can be sent concurrently based on org type. See [Concurrent rate limits](/docs/reference/rl-additional-limits/#concurrent-rate-limits).|
 
 ## Troubleshoot your Hook implementations
 


### PR DESCRIPTION

## Description:
- **What's changed?** Updates to the Inline Hooks concepts and best practices with additional information and links to concurrent inline hook rate limits
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* [OKTA-443653](https://oktainc.atlassian.net/browse/OKTA-443653)
