### PR TITLE
Drop id from required parameters when updating resource set

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/roles/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/roles/index.md
@@ -699,7 +699,6 @@ Updates the label and description of a Resource Set
 
 | Parameter     | Description                               | Param Type   | DataType     | Required |
 | :------------ | :---------------------------------------- | :----------- | :----------- | :------- |
-| `resourceSetId` | Unique ID of the Resource Set             | URL          | String       | TRUE     |
 | `label`         | New unique name given to the Resource Set | Body         | String       | TRUE     |
 | `description`   | New description of the Resource Set   | Body         | String       | TRUE     |
 


### PR DESCRIPTION
## Description:
- **What's changed?** Drop id from required parameters when updating resource set (https://github.com/okta/okta-core/pull/61033)
- **Is this PR related to a Monolith release?** 2022.01.1

### Resolves:

* [OKTA-445144](https://oktainc.atlassian.net/browse/OKTA-445144)


cc @okta/dda 