### PR TITLE
Fix JSON body formatting in Risk Provider API cURL examples

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/risk-providers/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/risk-providers/index.md
@@ -53,7 +53,7 @@ curl -X POST \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
 -d '{
-    "name": "Risk-Partner-X"
+    "name": "Risk-Partner-X",
     "action": "log_only",
     "clientId": "00ckjsfgjkdkjdkkljjsd"
 }' "https://${yourOktaDomain}/api/v1/risk/providers"
@@ -120,7 +120,7 @@ curl -X POST \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
 -d '{
-    "name": "Risk-Partner-Y"
+    "name": "Risk-Partner-Y",
     "action": "enforce_and_log",
     "clientId": "00ckjsfgjkdkjdkkljjsd"
 }' "https://${yourOktaDomain}/api/v1/risk/providers/00rp12r4skkjkjgsn"


### PR DESCRIPTION
## Description:
- **What's changed?** Fixes two missing commas in Risk Provider API sample cURL requests' JSON bodies
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-459568](https://oktainc.atlassian.net/browse/OKTA-459568)
