### PR TITLE
fix inconsistent spring boot sample code section

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/springboot/samplecode.md
+++ b/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/springboot/samplecode.md
@@ -1,15 +1,2 @@
-* [Spring Boot Getting Started Guide](https://spring.io/guides/gs/spring-boot/) to build a Spring Boot application
+* [Spring Boot Getting Started Guide](https://spring.io/guides/gs/spring-boot/) to build a Spring Boot application. (Select the **Web**, **Security**, and **Okta** dependencies in [Spring Initializr](https://start.spring.io) to create a new Spring Boot project with Okta.)
 * [Spring Boot samples repo](https://github.com/okta/samples-java-spring/tree/master/resource-server) or [WebFlux example repo](https://github.com/okta/okta-spring-boot/tree/master/examples/webflux-resource-server) for a finished sample app that you can download
-* [Spring Initializr](https://start.spring.io) to create a new Spring Boot project with Okta. Select the dependencies **Web**, **Security**, and **Okta**, and then click **Generate Project** to download a zip file.
-* The following command line to create a Spring Boot project:
-
-```bash
-curl https://start.spring.io/starter.tgz  \
-  -d groupId=com.example \
-  -d artifactId=demo \
-  -d dependencies=web,security,okta \
-  -d language=java \
-  -d type=maven-project \
-  -d baseDir=demo \
-| tar -xzvf -
-```


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** The nutrition facts sample code section on https://developer.okta.com/docs/guides/protect-your-api/springboot/main/ is inconsistent with the sample code for the other platforms — it is too long, and it feels like the cURL stuff should be moved. This PR removes the cURL example completely, and combines the Spring Initializr instructions with the first line. My rationale here is that
  - it is not our responsibility to give our readers several options to create a sample app, just to teach them about using Okta technologies with their (sample) apps. The update still gives them an option that works.
  - The spring boot getting started guide mentions using Spring Initializr in the first line, and the initializr app itself is pretty intuitive, so I think the new placement of our Initializr instructions makes snese in the context of the other linked resources.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-460424](https://oktainc.atlassian.net/browse/OKTA-460424)
