### PR TITLE
Remove stray 'of' in Admin Console doc

### DIFF
--- a/packages/@okta/vuepress-site/docs/concepts/okta-organizations/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/okta-organizations/index.md
@@ -35,7 +35,7 @@ Production orgs are always a known-stable release, covered by our Software Licen
 The Admin Console is where you go to manage your Okta org. The first page that you see when you sign in as an Okta admin is the **Dashboard** tab. This landing page provides a summary of activity in Okta and in your apps. The page also lists notifications of any problems or outstanding work that you need to complete. The Admin Console also provides you with quick access to your application configuration and API Access Management features.
 
 ## Cells
-Each Okta org exists in a specific segment (or "cell") of Okta's infrastructure. A cell is a conceptual grouping of Okta's public-facing services and UI for a subset of orgs. Cells are completely independent of each other and of feature redundancy to ensure availability.
+Each Okta org exists in a specific segment (or "cell") of Okta's infrastructure. A cell is a conceptual grouping of Okta's public-facing services and UI for a subset of orgs. Cells are completely independent of each other and feature redundancy to ensure availability.
 
 > **Tip:** You can locate the cell that your org belongs to by looking at the footer of any page of your Okta Admin.
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Tiny change to remove a stray 'of' in the Admin Console doc I noticed while browsing the docs. The sentence doesn't make sense with it present.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
