### PR TITLE
Fix okta.yaml sample config file for OIE Embedded SDK go and aspnet guides

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/aspnet/configlocations.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/aspnet/configlocations.md
@@ -16,14 +16,14 @@ The following is the required content format for the YAML file:
 
 ```yaml
 okta:
-idx:
-  issuer: "https://${yourOktaDomain}/oauth2/default"
-  clientId: "${clientId}"
-  clientSecret: "${clientSecret}"
-  scopes:
-  - "${scope1}"
-  - "${scope2}"
-  redirectUri: "${redirectUri}"
+  idx:
+    issuer: "https://${yourOktaDomain}/oauth2/default"
+    clientId: "${clientId}"
+    clientSecret: "${clientSecret}"
+    scopes:
+      - "${scope1}"
+      - "${scope2}"
+    redirectUri: "${redirectUri}"
 ```
 
 ### Option 2: Set the values as environment variables

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/go/configlocations.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/go/configlocations.md
@@ -14,14 +14,14 @@ Add your configuration values to the file, using the following format:
 
 ```yaml
 okta:
-idx:
-  issuer: "https://${yourOktaDomain}/oauth2/default"
-  clientId: "${clientId}"
-  clientSecret: "${clientSecret}"
-  scopes:
-  - "${scope1}"
-  - "${scope2}"
-  redirectUri: "${redirectUri}"
+  idx:
+    issuer: "https://${yourOktaDomain}/oauth2/default"
+    clientId: "${clientId}"
+    clientSecret: "${clientSecret}"
+    scopes:
+      - "${scope1}"
+      - "${scope2}"
+    redirectUri: "${redirectUri}"
 ```
 
 ### Option 2: Set the values as environment variables


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** 

In the aspnet and go details for the oie-embedded-with-sdk sample, the example yaml config was formatted incorrectly. Using it as written would have resulted in an empty config. I have corrected it from

```
okta:
idx:
  clientid: blah blah
```

to

```
okta:
  idx:
    clientid: blah blah
```

which is now correct

- **Is this PR related to a Monolith release?** No

### Resolves:

Not tied to a JIRA ticket
