### PR TITLE
Adjust headings to match odyssey specs

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/base/_typography.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/base/_typography.scss
@@ -72,34 +72,28 @@ a {
 
 h1, h2, h3, h4, h5, h6 {
   color: cv('text', 'darker');
-  margin-top: 3.125rem;
+  margin-top: 2rem;
+  margin-bottom: 1.1rem;
+  font-weight: 600;
 }
 
 h1 {
-  margin-top: 20px;
-  font-size: 36px;
-  font-weight: 500;
+  font-size: 28px;
 }
 h2 {
-  font-size: 26px;
-  font-weight: 500;
-  margin-top: 2rem;
+  font-size: 24px;
 }
 h3 {
-  font-size: 20px;
-  font-weight: normal;
+  font-size: 21px;
 }
 h4 {
-  font-size: 20px;
-  font-weight: 500;
+  font-size: 18px;
 }
 h5 {
-  font-size: 20px;
-  font-weight: 500;
+  font-size: 16px;
 }
 h6 {
-  font-size: 20px;
-  font-weight: 500;
+  font-size: 14px;
 }
 
 .is-link {
@@ -113,37 +107,4 @@ blockquote {
   border-bottom: 1px solid cv('gray', '300');
   border-radius: 4px;
   padding: 1.5rem 1.5rem 1.5rem calc(1.5rem + 3px);
-}
-
-@include media("<desktop-xl") {
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    margin-top: 2rem;
-    margin-bottom: 1.1rem;
-  }
-  h1 {
-    font-size: 36px;
-    font-weight: 500;
-    margin-top: 7px;
-  }
-  h2 {
-    font-size: 28px;
-  }
-  h3 {
-    font-size: 24px;
-    font-weight: 500;
-  }
-  h4 {
-    font-size: 22px;
-  }
-  h5 {
-    font-size: 20px;
-  }
-  h6 {
-    font-size: 18px;
-  }
 }

--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_pageTitle.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_pageTitle.scss
@@ -30,6 +30,7 @@
   }
 
   h1 {
+    font-size: 36px;
     margin: 5px 0 7px;
     line-height: 1.3em;
 


### PR DESCRIPTION
## Description:
- Adjust headings to match odyssey specs
- Override `page-title`'s h1s to remain at `36px`
- Remove heading's media query (nothing relating to this in the specs Figma from Alex Cohen)

Deployed site: https://61fac2d5361d5a13f3ce0596--reverent-murdock-829d24.netlify.app/
Current site: https://developer.okta.com/docs/guides/oie-embedded-common-org-setup/aspnet/main/

### Resolves:
* [OKTA-454123](https://oktainc.atlassian.net/browse/OKTA-454123)

Before:
![Screen Shot 2022-02-02 at 11 31 38 AM](https://user-images.githubusercontent.com/72201855/152205226-2122d900-8f21-4c67-b3a3-ddb61c9a41fe.png)

After:
![Screen Shot 2022-02-02 at 11 31 33 AM](https://user-images.githubusercontent.com/72201855/152205245-2b12fa81-36dc-4398-8091-c141de8ba385.png)