### PR TITLE
Updating dev docs for existing myAccount API

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/myaccount/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/myaccount/index.md
@@ -7,6 +7,8 @@ category: management
 
 <ApiLifecycle access="deprecated" />
 
+> **Note:** This API is currently being transferred to a new namespace (```/api/v1/idp/myaccount```). The existing endpoint (```/api/v1/myaccount```) will be deprecated. We encourage you to use ```/api/v1/idp/myaccount``` if you plan to use this API. *Link to new devdocs page*
+
 The Okta MyAccount API allows end users (with or without administrator access) to fetch and update their own Okta user profiles.  It implements a subset of the existing [Users API](/docs/reference/api/users/) but with significant differences.  This API does not expose information an end user should not have access to, and it does not support lifecycle operations.
 
 All operations in this API implicitly refer to the user making the API call.  No user ID is needed (or even accepted).

--- a/packages/@okta/vuepress-site/docs/reference/api/myaccount/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/myaccount/index.md
@@ -5,7 +5,7 @@ category: management
 
 # MyAccount API
 
-<ApiLifecycle access="ea" />
+<ApiLifecycle access="deprecated" />
 
 The Okta MyAccount API allows end users (with or without administrator access) to fetch and update their own Okta user profiles.  It implements a subset of the existing [Users API](/docs/reference/api/users/) but with significant differences.  This API does not expose information an end user should not have access to, and it does not support lifecycle operations.
 

--- a/packages/@okta/vuepress-site/docs/reference/api/myaccount/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/myaccount/index.md
@@ -7,7 +7,7 @@ category: management
 
 <ApiLifecycle access="ea" />
 
-> **Note:** This API is currently being enhanced, accessible at ```/api/v1/idp/myaccount```. We encourage you to use this endpoint if you plan to use this API. Endpoints utilizing the existing endpoint (```/api/v1/myaccount```) will be deprecated. We encourage you to use ```/api/v1/idp/myaccount``` if you plan to use this API.
+> **Note:** The MyAccount API is being enhanced, accessible at `/api/v1/idp/myaccount`. Use this endpoint if you plan to use the MyAccount API. The existing endpoint (`/api/v1/myaccount`) is deprecated.
 
 The Okta MyAccount API allows end users (with or without administrator access) to fetch and update their own Okta user profiles.  It implements a subset of the existing [Users API](/docs/reference/api/users/) but with significant differences.  This API does not expose information an end user should not have access to, and it does not support lifecycle operations.
 

--- a/packages/@okta/vuepress-site/docs/reference/api/myaccount/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/myaccount/index.md
@@ -5,9 +5,9 @@ category: management
 
 # MyAccount API
 
-<ApiLifecycle access="deprecated" />
+<ApiLifecycle access="ea" />
 
-> **Note:** This API is currently being transferred to a new namespace (```/api/v1/idp/myaccount```). The existing endpoint (```/api/v1/myaccount```) will be deprecated. We encourage you to use ```/api/v1/idp/myaccount``` if you plan to use this API. *Link to new devdocs page*
+> **Note:** This API is currently being enhanced, accessible at ```/api/v1/idp/myaccount```. We encourage you to use this endpoint if you plan to use this API. Endpoints utilizing the existing endpoint (```/api/v1/myaccount```) will be deprecated. We encourage you to use ```/api/v1/idp/myaccount``` if you plan to use this API.
 
 The Okta MyAccount API allows end users (with or without administrator access) to fetch and update their own Okta user profiles.  It implements a subset of the existing [Users API](/docs/reference/api/users/) but with significant differences.  This API does not expose information an end user should not have access to, and it does not support lifecycle operations.
 
@@ -32,6 +32,7 @@ The MyAccount API has the following operations:
 ### Get Me
 
 <ApiOperation method="get" url="/api/v1/myaccount" />
+<ApiLifecycle access="deprecated" />
 
 Fetches the current user's Me object, a collection of links to information describing the user.
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description
- Adding a note onto the MyAccount dev docs page, notifying readers that there is a new namespace to use and that the existing one will be deprecated.
- **Is this PR related to a Monolith release?** Yes. 2022.05.0 (subject to change)

### Resolves:
* [OKTA-453945](https://oktainc.atlassian.net/browse/OKTA-453945)

### Details:
<img width="1102" alt="image" src="https://user-images.githubusercontent.com/64948648/156595751-ba51d73c-2c74-434d-a0dc-fd4c980f4109.png">

- Adding deprecated banner to `Get Me` endpoint that won't be available in the new MyAccount namespace
<img width="711" alt="image" src="https://user-images.githubusercontent.com/64948648/156596270-5272501a-793a-4513-96eb-ac417df00d69.png">


