### PR TITLE
OKTA-331115 Updated four curl examples to use character encoding

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -1615,7 +1615,6 @@ The following link expansions are supported to embed additional resources into t
 
 > **Note:** The `user/:uid` expansion can currently only be used in conjunction with the `user.id eq ":uid"` filter. See [List applications assigned to a user](#list-applications-assigned-to-a-user).
 
-
 ##### Response parameters
 
 Array of [Applications](#application-object)
@@ -1836,7 +1835,7 @@ curl -v -X GET \
 -H "Accept: application/json" \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
-"https://${yourOktaDomain}/api/v1/apps?filter=user.id+eq+\"00ucw2RPGIUNTDQOYPOF\"&expand=user/00ucw2RPGIUNTDQOYPOF"
+"https://${yourOktaDomain}/api/v1/apps?filter=user.id+eq+%2200ucw2RPGIUNTDQOYPOF%22&expand=user/00ucw2RPGIUNTDQOYPOF"
 ```
 
 > **Note:** The `expand=user/:uid` query parameter optionally returns the user's [Application User](#application-user-object) information in the response body's `_embedded` property.
@@ -2077,7 +2076,7 @@ curl -v -X GET \
 -H "Accept: application/json" \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
-"https://${yourOktaDomain}/api/v1/apps?filter=group.id+eq+\"00gckgEHZXOUDGDJLYLG\""
+"https://${yourOktaDomain}/api/v1/apps?filter=group.id+eq+%2200gckgEHZXOUDGDJLYLG%22"
 ```
 
 ##### Response example
@@ -2158,7 +2157,7 @@ curl -v -X GET \
 -H "Accept: application/json" \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
-"https://${yourOktaDomain}/api/v1/apps?filter=credentials.signing.kid+eq+\"SIMcCQNY3uwXoW3y0vf6VxiBb5n9pf8L2fK8d-FIbm4\""
+"https://${yourOktaDomain}/api/v1/apps?filter=credentials.signing.kid+eq+%22SIMcCQNY3uwXoW3y0vf6VxiBb5n9pf8L2fK8d-FIbm4%22"
 ```
 
 ##### Response example
@@ -2288,7 +2287,7 @@ curl -v -X GET \
 -H "Accept: application/json" \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
-"https://${yourOktaDomain}/api/v1/apps?filter=name+eq+\"workday\""
+"https://${yourOktaDomain}/api/v1/apps?filter=name+eq+%22workday%22"
 ```
 
 ##### Response example


### PR DESCRIPTION

## Description:
- **What's changed?** Updated 4 curl calls in the following sections to use character encoding `%22` in place of `/"` to escape an apostrophe.

* [ List applications assigned to a user](https://developer.okta.com/docs/reference/api/apps/#list-applications-assigned-to-a-user)
* [ List applications assigned to a group](https://developer.okta.com/docs/reference/api/apps/#list-applications-assigned-to-a-group)
* [List apps by name](https://developer.okta.com/docs/reference/api/apps/#request-example-16)
* [List applications using a key](https://developer.okta.com/docs/reference/api/apps/#request-example-15)
- **Is this PR related to a Monolith release?** n/a

All calls were tested with the new encoding character using curl and Postman, except for the **List applications using a key** call; I didn't have an org set up for this call. Requesting a test of this example on review. See my [Google doc](https://docs.google.com/document/d/1CvbONXPUAlFf9pS89qjB6R0AOnp8BMPXacRehqlD44k/edit?usp=sharing) for my testing details.

### Resolves:

* [OKTA-331115](https://oktainc.atlassian.net/browse/OKTA-331115)
