### PR TITLE
hide stack selectors from IdP pages

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/add-an-external-idp/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/add-an-external-idp/main/index.md
@@ -3,6 +3,7 @@ title: Add an external Identity Provider
 meta:
   - name: description
     content: Okta supports authentication with external OpenID Connect Identity Providers as well as SAML (also called Inbound Federation). Get an overview of the process and prerequisites, as well as the instructions required to set one up.
+showStackSelector: False
 ---
 
 ## <StackSnippet snippet="idp" inline />

--- a/packages/@okta/vuepress-site/docs/guides/social-login/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/social-login/main/index.md
@@ -3,6 +3,7 @@ title: Add a social Identity Provider
 meta:
   - name: description
     content: Okta supports authentication with social Identity Providers. Get an overview of the process and prerequisites, as well as the setup instructions.
+showStackSelector: False
 ---
 
 <StackSnippet snippet="ea-icon" inline/>


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** On the IdP pages, we originally had the stack selectors hidden, but with the recent stack selector update they are visible again:
  -  https://developer.okta.com/docs/guides/social-login/amazon/main/
  - https://developer.okta.com/docs/guides/add-an-external-idp/apple/main/
  We want them hidden. In https://github.com/okta/okta-developer-docs/pull/3027 we added a simple mechanism to do this, and in this PR I am adding the required frontmatter properties to do the actual hiding.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-467429](https://oktainc.atlassian.net/browse/OKTA-467429) — partial fix, at least.
