### PR TITLE
fix(docs): update getUserInfo call in okta-react

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa/main/react/getuserinfo.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa/main/react/getuserinfo.md
@@ -19,7 +19,7 @@ const Home = () => {
       // When user isn't authenticated, forget any user info
       setUserInfo(null);
     } else {
-      oktaAuth.getUserInfo().then(info => {
+      oktaAuth.token.getUserInfo().then(info => {
         setUserInfo(info);
       });
     }


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?**
- I guess that the function call `getUserInfo()` may be wrong in this documentation.
   - Note: I changed just the _Function-based component_ example, I didn't test if the _Class-based component_ could have the same behavior.

- Following the documentation, it throws an error in React, because the function is not in `oktaAuth`, but in `oktaAuth.token`:
![image](https://user-images.githubusercontent.com/82591370/155308979-ad47528c-da17-4968-94f1-3ef54648624a.png)

- In JS documentation, I found that it could be called as "authClient.token.getUserInfo", and the React Okta seems to have the same pattern, using `oktaAuth.token.getUserInfo()`
  - https://github.com/okta/okta-auth-js/blob/master/README.md