### PR TITLE
OKTA-460652 Add auth_time to the access token claims playload

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/oidc/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/oidc/index.md
@@ -1300,6 +1300,7 @@ The payload includes the following reserved claims:
 
 | Property | Description                                                                                                            | DataType |
 | -------- | ---------------------------------------------------------------------------------------------------------------------- | -------- |
+| auth_time| The time when the authentication occurred, represented in Unix time (seconds).                                         | Integer  |
 | cid      | Client ID of the client that requested the access token.                                                               | String   |
 | exp      | The time the access token expires, represented in Unix time (seconds).                                                 | Integer  |
 | iat      | The time the access token was issued, represented in Unix time (seconds).                                              | Integer  |


### PR DESCRIPTION
## Description:
- **What's changed?** Update access token payload to include `auth_time`
- **Is this PR related to a Monolith release?** Yes, 2022.03.0

### Resolves:

* [OKTA-460652](https://oktainc.atlassian.net/browse/OKTA-460652)
