### PR TITLE
Cleanup invalid headers in protect-your-api

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/aspnetcore3/request.md
+++ b/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/aspnetcore3/request.md
@@ -1,7 +1,8 @@
 ```http
-https://localhost:8080/api/whoami Bearer: ${TOKEN}
+https://localhost:44336/api/whoami
+Authorization: Bearer ${TOKEN}
 ```
 
 ```http
-https://localhost:8080/api/hello
+https://localhost:44336/api/hello
 ```

--- a/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/nodeexpress/request.md
+++ b/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/nodeexpress/request.md
@@ -1,5 +1,6 @@
 ```http
-https://localhost:3000/api/whoami Bearer: ${TOKEN}
+https://localhost:3000/api/whoami
+Authorization: Bearer ${TOKEN}
 ```
 
 ```http

--- a/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/springboot/request.md
+++ b/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/springboot/request.md
@@ -1,7 +1,8 @@
 ```http
-https://localhost:8080/api/whoami Bearer: ${TOKEN}
+http://localhost:8080/api/whoami
+Authorization: Bearer ${TOKEN}
 ```
 
 ```http
-https://localhost:8080/api/hello
+http://localhost:8080/api/hello
 ```


### PR DESCRIPTION
Fixing a copypasta error where the `Authorization` header is missing

> *NOTE:* This is a little different than the `go` version

https://github.com/okta/okta-developer-docs/blob/oie-by-default-quickstarts/packages/%40okta/vuepress-site/docs/guides/protect-your-api/main/go/request.md

I think the `curl` version makes it more clear that this value is a header