### PR TITLE
Fix typos found in Spring Boot quickstart

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app-redirect/main/spring-boot/getuserinfo.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app-redirect/main/spring-boot/getuserinfo.md
@@ -1,6 +1,6 @@
 Add the following code to return the user's name upon a successful sign-in flow:
 
-```
+```java
 @GetMapping("/")
 public String hello(@AuthenticationPrincipal OidcUser user) {
   return "Hello, " + user.getName();

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app-redirect/main/spring-boot/samplecode.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app-redirect/main/spring-boot/samplecode.md
@@ -1,1 +1,1 @@
-[Spring Boot redirect login sample](https://github.com/okta/samples-java-spring/tree/master/okta-hosted-login
+[Spring Boot redirect login sample](https://github.com/okta/samples-java-spring/tree/master/okta-hosted-login)

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app-redirect/main/spring-boot/testapp.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app-redirect/main/spring-boot/testapp.md
@@ -1,7 +1,7 @@
 1. Run the following command to start your app:
 
 ```shell
-./mvnw spring-boot:run
+mvn spring-boot:run
 ```
 
 2. Open a browser and navigate to `http://localhost:8080`. You are redirected to Okta to sign in. When you return, it should display your user information.


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Fixed typos and changed `./mvnw` to `mvn` so it's platform agnostic. I believe most Java developers can translate this to `./mvnw` (for Linux / macOS) and `mvnw` (on Windows) if they want to use the Maven wrapper.
- **Is this PR related to a Monolith release?** No

