### PR TITLE
Fix .okta.env filename and cleanup Okta SDK names

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/react/createproject.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/react/createproject.md
@@ -7,6 +7,6 @@ npx create-react-app@5 okta-react-quickstart
 cd okta-react-quickstart
 ```
 
-> **Note**: This guide was tested with Create React App v5, React 17, okta-react v6.4, and okta-auth-js v6.1.
+> **Note**: This guide was tested with Create React App 5, React 17, Okta React 6.4, and Okta Auth JS 6.1.
 
 > **Note**: You can also install the Okta CLI and run `okta start react` to download and configure a React app with Okta integrated. This quickstart uses Create React App's output instead, as it's easier to understand the Okta-specific additions if you work through them yourself.

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app-redirect/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app-redirect/main/index.md
@@ -60,7 +60,7 @@ okta apps create web
 2. Enter **Quickstart** when prompted for the app name.
 3. Specify the required Redirect URI values:
 <StackSnippet snippet="redirectvalues" />
-4. The Okta CLI creates an `okta.env` file with export statements containing the Client ID, Client Secret, and Issuer. Keep this safe as you use it later to configure your web app.
+4. The Okta CLI creates an `.okta.env` file with export statements containing the Client ID, Client Secret, and Issuer. Keep this safe as you use it later to configure your web app.
 
 At this point, you can move to the next step: [Creating your app](#create-app). If you want to set up the integration manually, or find out what the CLI just did for you, read on.
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app-redirect/main/python/configmid.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app-redirect/main/python/configmid.md
@@ -39,7 +39,7 @@ if __name__ == '__main__':
     app.run(host="localhost", port=5000, debug=True)
 ```
 
-2. Add the following Okta config dictionary to the bottom of `app.py`. Replace the placeholders with the values you obtained earlier (fromt `okta.env`, and from your org admin).
+2. Add the following Okta config dictionary to the bottom of `app.py`. Replace the placeholders with the values you obtained earlier (from `.okta.env`, and from your org admin).
 
 ```py
 config = {


### PR DESCRIPTION
## Description:
- **What's changed?** Change `okta.env` to `.okta.env` and be consistent on library names for React quickstart.
- **Is this PR related to a Monolith release?** No
