### PR TITLE
minor fixes for php web app quickstart

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app-redirect/main/php/createproject.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app-redirect/main/php/createproject.md
@@ -1,12 +1,14 @@
-1. Make sure you have a PHP testing environment installed on your machine.
+1. Make sure you have a PHP development environment installed on your machine.
 
-1. Inside your server document root directory, create a directory called `quickstart`.
+1. In a folder for this project, create a directory called `public`.
 
 1. Create an empty file inside it called `index.php`.
 
 ```bash
 mkdir quickstart
-touch quickstart/index.php
+cd quickstart
+mkdir public
+touch public/index.php
 ```
 
 > **Note**: This guide was written with PHP 7.4.

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app-redirect/main/php/loginredirect.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app-redirect/main/php/loginredirect.md
@@ -8,7 +8,7 @@ switch($path) {
 }
 ```
 
-2. Define the function `index()` that checks if there is an access token in the session and displays the sign-in link if not. This can go somewhere near the bottom of `index.php`:
+2. Define the function `index()` that checks if there is an ID token in the session and displays the sign-in link if not. This can go somewhere near the bottom of `index.php`:
 
 ```php
 function index() {
@@ -37,6 +37,7 @@ function index() {
 4. Create the function `start_oauth_flow()` that kicks off the OAuth Authorization Code flow and redirects the user to Okta. Again, this can go near the bottom of `index.php`:
 
 ```php
+function start_oauth_flow() {
   // Generate a random state parameter for CSRF security
   $_SESSION['oauth_state'] = bin2hex(random_bytes(10));
 
@@ -58,4 +59,5 @@ function index() {
   ]);
 
   header('Location: '.$authorize_url);
+}
 ```


### PR DESCRIPTION
* use `public` folder since that's the PHP convention and used later down in the tutorial
* fix missing function definition in the redirect block