### PR TITLE
Updating copyright year from 2021 to 2022

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/config.js
+++ b/packages/@okta/vuepress-site/.vuepress/config.js
@@ -245,7 +245,7 @@ module.exports = ctx => ({
     ],
 
     forum_url: 'https://devforum.okta.com/',
-    copyright_text: 'Copyright © 2022 Okta.'
+    copyright_text: `Copyright © ${new Date().getUTCFullYear() || '2022'} Okta.`
   },
 
   chainWebpack(config) {

--- a/packages/@okta/vuepress-site/.vuepress/config.js
+++ b/packages/@okta/vuepress-site/.vuepress/config.js
@@ -245,7 +245,7 @@ module.exports = ctx => ({
     ],
 
     forum_url: 'https://devforum.okta.com/',
-    copyright_text: 'Copyright © 2021 Okta.'
+    copyright_text: 'Copyright © 2022 Okta.'
   },
 
   chainWebpack(config) {


### PR DESCRIPTION


## Description:
- **What's changed?** Changing Dev docs footer banner copyright year
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* n/a
