### PR TITLE
Update custom error pages with note for triple-braced errorDescription macro

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/custom-error-pages/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-error-pages/main/index.md
@@ -102,22 +102,22 @@ Inserts the logo image that has been configured for your application. You can ch
 If you want to just change the logo image for your custom error pages, include the URL to the image instead of the macro:
 
 Example:
+
 ```html
 <img alt="{{orgName}}" src="https://example.com//SomeOtherImage.png" class="org-logo">
 ```
 
-### <span v-pre>`{{{errorSummary}}}`</span>
-
 ### <span v-pre>`{{{errorDescription}}}`</span>
 
-Inserts a title and detailed description of the error.
+Inserts a detailed description of the error.
 
 Example:
 
 ```html
-<h2 class="o-form-title">{{errorSummary}}</h2>
 <p class="o-form-explain">What happened? {{{errorDescription}}}</p>
 ```
+
+> **Note:** Macros with double curly braces return escaped HTML by default. Triple braces `{{{` are used for the `errorDescription` macro to return unescaped HTML. See [Mustache template](http://mustache.github.io/mustache.5.html).
 
 ### <span v-pre>`{{back}}`</span>
 


### PR DESCRIPTION
## Description:
- **What's changed?** Fix extra `errorSummary` header and add a note for triple-braced `errorDescription` macro. This is a fix for submitted PR 3032.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-476236](https://oktainc.atlassian.net/browse/OKTA-476236)
* PR [3032](https://github.com/okta/okta-developer-docs/pull/3032)