### PR TITLE
Re-add Discord, Spotify, Xero links in the TOC

### DIFF
--- a/packages/@okta/vuepress-theme-prose/const/navbar.const.js
+++ b/packages/@okta/vuepress-theme-prose/const/navbar.const.js
@@ -289,6 +289,10 @@ export const guides = [
                     path: "/docs/guides/add-an-external-idp/apple/main/"
                   },
                   {
+                    title: "Discord",
+                    path: "/docs/guides/social-login/discord/main/"
+                  },
+                  {
                     title: "Facebook",
                     path: "/docs/guides/add-an-external-idp/facebook/main/"
                   },
@@ -319,6 +323,14 @@ export const guides = [
                   {
                     title: "Salesforce",
                     path: "/docs/guides/social-login/salesforce/main/"
+                  },
+                  {
+                    title: "Spotify",
+                    path: "/docs/guides/social-login/spotify/main/"
+                  },
+                  {
+                    title: "Xero",
+                    path: "/docs/guides/social-login/xero/main/"
                   },
                   {
                     title: "Yahoo",


### PR DESCRIPTION
## Description:
- **What's changed?** Re-add Discord, Spotify, Xero links in the TOC (left-nav) from PR 2859, 2860, 2861 that was removed from a recent merge.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
