### PR TITLE
update code blog links to tagged page URLs

### DIFF
--- a/packages/@okta/vuepress-site/code/android/index.md
+++ b/packages/@okta/vuepress-site/code/android/index.md
@@ -68,4 +68,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [Android Developer Blog posts](/search/#q=android&f:@commonoktasource=[Developer%20blog]) for further useful topics.
+> **Note**: Browse our [Android Developer Blog posts](/blog/tags/android/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/android/index.md
+++ b/packages/@okta/vuepress-site/code/android/index.md
@@ -68,4 +68,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [Android Developer Blog posts](/blog/tags/android/) for further useful topics.
+> **Note**: Browse our recent [Android Developer Blog posts](https://developer.okta.com/blog/tags/android/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/angular/index.md
+++ b/packages/@okta/vuepress-site/code/angular/index.md
@@ -51,4 +51,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [Angular Developer Blog posts](/blog/tags/angular/) for further useful topics.
+> **Note**: Browse our recent [Angular Developer Blog posts](https://developer.okta.com/blog/tags/angular/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/angular/index.md
+++ b/packages/@okta/vuepress-site/code/angular/index.md
@@ -51,4 +51,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [Angular Developer Blog posts](/search/#q=angular&f:@commonoktasource=[Developer%20blog]) for further useful topics.
+> **Note**: Browse our [Angular Developer Blog posts](/blog/tags/angular/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/dotnet/aspnet/index.md
+++ b/packages/@okta/vuepress-site/code/dotnet/aspnet/index.md
@@ -94,4 +94,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [ASP.NET Developer Blog posts](/search/#q=asp%20net&f:@commonoktasource=[Developer%20blog]) for further useful topics.
+> **Note**: Browse our recent [ASP.NET Developer Blog posts](https://developer.okta.com/blog/tags/dotnet/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/dotnet/aspnetcore/index.md
+++ b/packages/@okta/vuepress-site/code/dotnet/aspnetcore/index.md
@@ -91,4 +91,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [ASP.NET Developer Blog posts](/search/#q=asp%20net&f:@commonoktasource=[Developer%20blog]) for further useful topics.
+> **Note**: Browse our recent [ASP.NET Core Developer Blog posts](https://developer.okta.com/blog/tags/aspnetcore/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/dotnet/blazor/index.md
+++ b/packages/@okta/vuepress-site/code/dotnet/blazor/index.md
@@ -70,4 +70,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [Blazor Developer Blog posts](/search/#q=blazor&f:@commonoktasource=[Developer%20blog]) for further useful topics.
+> **Note**: Browse our [Blazor Developer Blog posts](/blog/tags/blazor/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/dotnet/blazor/index.md
+++ b/packages/@okta/vuepress-site/code/dotnet/blazor/index.md
@@ -70,4 +70,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [Blazor Developer Blog posts](/blog/tags/blazor/) for further useful topics.
+> **Note**: Browse our recent [Blazor Developer Blog posts](https://developer.okta.com/blog/tags/blazor/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/go/index.md
+++ b/packages/@okta/vuepress-site/code/go/index.md
@@ -67,4 +67,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [Go Developer Blog posts](/blog/tags/go/) for further useful topics.
+> **Note**: Browse our recent [Go Developer Blog posts](https://developer.okta.com/blog/tags/go/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/go/index.md
+++ b/packages/@okta/vuepress-site/code/go/index.md
@@ -67,4 +67,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [Go Developer Blog posts](/search/#q=golang&f:@commonoktasource=[Developer%20blog]) for further useful topics.
+> **Note**: Browse our [Go Developer Blog posts](/blog/tags/go/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/ios/index.md
+++ b/packages/@okta/vuepress-site/code/ios/index.md
@@ -69,4 +69,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [iOS Developer Blog posts](/search/#q=ios&f:@commonoktasource=[Developer%20blog]) for further useful topics.
+> **Note**: Browse our [iOS Developer Blog posts](/blog/tags/ios/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/ios/index.md
+++ b/packages/@okta/vuepress-site/code/ios/index.md
@@ -69,4 +69,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [iOS Developer Blog posts](/blog/tags/ios/) for further useful topics.
+> **Note**: Browse our recent [iOS Developer Blog posts](https://developer.okta.com/blog/tags/ios/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/java/index.md
+++ b/packages/@okta/vuepress-site/code/java/index.md
@@ -65,4 +65,4 @@ Okta Classic:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [Java Developer Blog posts](/search/#q=java&f:@commonoktasource=[Developer%20blog]) for further useful topics.
+> **Note**: Browse our [Java Developer Blog posts](/blog/tags/java/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/java/index.md
+++ b/packages/@okta/vuepress-site/code/java/index.md
@@ -65,4 +65,4 @@ Okta Classic:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [Java Developer Blog posts](/blog/tags/java/) for further useful topics.
+> **Note**: Browse our recent [Java Developer Blog posts](https://developer.okta.com/blog/tags/java/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/java/spring/index.md
+++ b/packages/@okta/vuepress-site/code/java/spring/index.md
@@ -79,4 +79,4 @@ Other guides:
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 * [Spring Security SAML](/code/java/spring_security_saml/)
 
-> **Note**: Browse our [Spring Developer Blog posts](/search/#q=spring&f:@commonoktasource=[Developer%20blog]) for further useful topics.
+> **Note**: Browse our [Spring Developer Blog posts](/blog/tags/spring-boot/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/java/spring/index.md
+++ b/packages/@okta/vuepress-site/code/java/spring/index.md
@@ -79,4 +79,4 @@ Other guides:
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 * [Spring Security SAML](/code/java/spring_security_saml/)
 
-> **Note**: Browse our [Spring Developer Blog posts](/blog/tags/spring-boot/) for further useful topics.
+> **Note**: Browse our recent [Spring Developer Blog posts](https://developer.okta.com/blog/tags/spring-boot/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/javascript/index.md
+++ b/packages/@okta/vuepress-site/code/javascript/index.md
@@ -56,4 +56,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [JavaScript Developer Blog posts](/blog/tags/javascript/) for further useful topics.
+> **Note**: Browse our recent [JavaScript Developer Blog posts](https://developer.okta.com/blog/tags/javascript/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/javascript/index.md
+++ b/packages/@okta/vuepress-site/code/javascript/index.md
@@ -56,4 +56,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [JavaScript Developer Blog posts](/search/#q=javascript&f:@commonoktasource=[Developer%20blog]) for further useful topics.
+> **Note**: Browse our [JavaScript Developer Blog posts](/blog/tags/javascript/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/nodejs/index.md
+++ b/packages/@okta/vuepress-site/code/nodejs/index.md
@@ -70,4 +70,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [Node.js Developer Blog posts](/search/#q=node&f:@commonoktasource=[Developer%20blog]) for further useful topics.
+> **Note**: Browse our recent [Node.js Developer Blog posts](https://developer.okta.com/blog/tags/node/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/php/index.md
+++ b/packages/@okta/vuepress-site/code/php/index.md
@@ -56,4 +56,4 @@ Other guides:
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 * [OAuth 2.0 from the Command Line](/blog/2018/07/16/oauth-2-command-line)
 
-> **Note**: Browse our [PHP Developer Blog posts](/blog/tags/php/) for further useful topics.
+> **Note**: Browse our recent [PHP Developer Blog posts](https://developer.okta.com/blog/tags/php/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/php/index.md
+++ b/packages/@okta/vuepress-site/code/php/index.md
@@ -56,4 +56,4 @@ Other guides:
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 * [OAuth 2.0 from the Command Line](/blog/2018/07/16/oauth-2-command-line)
 
-> **Note**: Browse our [PHP Developer Blog posts](/search/#q=php&f:@commonoktasource=[Developer%20blog]) for further useful topics.
+> **Note**: Browse our [PHP Developer Blog posts](/blog/tags/php/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/python/index.md
+++ b/packages/@okta/vuepress-site/code/python/index.md
@@ -57,4 +57,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [Python Developer Blog posts](/search/#q=python&f:@commonoktasource=[Developer%20blog]) for further useful topics.
+> **Note**: Browse our [Python Developer Blog posts](/blog/tags/python/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/python/index.md
+++ b/packages/@okta/vuepress-site/code/python/index.md
@@ -57,4 +57,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [Python Developer Blog posts](/blog/tags/python/) for further useful topics.
+> **Note**: Browse our recent [Python Developer Blog posts](https://developer.okta.com/blog/tags/python/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/react-native/index.md
+++ b/packages/@okta/vuepress-site/code/react-native/index.md
@@ -43,4 +43,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [React Native Developer Blog posts](/blog/tags/react-native/) for further useful topics.
+> **Note**: Browse our recent [React Native Developer Blog posts](https://developer.okta.com/blog/tags/react-native/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/react-native/index.md
+++ b/packages/@okta/vuepress-site/code/react-native/index.md
@@ -43,4 +43,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [React Native Developer Blog posts](/search/#q=react%20native&f:@commonoktasource=[Developer%20blog]) for further useful topics.
+> **Note**: Browse our [React Native Developer Blog posts](/blog/tags/react-native/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/react/index.md
+++ b/packages/@okta/vuepress-site/code/react/index.md
@@ -51,4 +51,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [React Developer Blog posts](/blog/tags/react/) for further useful topics.
+> **Note**: Browse our recent [React Developer Blog posts](https://developer.okta.com/blog/tags/react/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/react/index.md
+++ b/packages/@okta/vuepress-site/code/react/index.md
@@ -51,4 +51,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [React Developer Blog posts](/search/#q=react&f:@commonoktasource=[Developer%20blog]) for further useful topics.
+> **Note**: Browse our [React Developer Blog posts](/blog/tags/react/) for further useful topics.

--- a/packages/@okta/vuepress-site/code/vue/index.md
+++ b/packages/@okta/vuepress-site/code/vue/index.md
@@ -51,4 +51,4 @@ Other guides:
 * [Validate access tokens](/docs/guides/validate-access-tokens)
 * [Validate ID tokens](/docs/guides/validate-id-tokens)
 
-> **Note**: Browse our [Vue Developer Blog posts](/search/#q=vue&f:@commonoktasource=[Developer%20blog]) for further useful topics.
+> **Note**: Browse our recent [Vue Developer Blog posts](https://developer.okta.com/blog/tags/vue/) for further useful topics.


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** The blog links at the bottom of the pages under https://developer.okta.com/code/ are somewhat buggy/problematic, as they also show a bunch of github links, and they don't show the pages in much of a useful order. This PR updates those to point to specific tag URLs (see https://developer.okta.com/blog/tags/). Note that I've not yet update the pages for the following, as there are a number of competing tags and it is not clear which one I should use:
  - .NET and .NET Core
  - Node/Node.js
  - Vue/VueJS
- Note: The blog links won't work in localhost, as the build doesn't build the blog (that uses a different system). But they are correct. 
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-476205](https://oktainc.atlassian.net/browse/OKTA-476205)
