### PR TITLE
OKTA-475953 - Update embedded sign-in guides with note about shared default auth policy

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/auth-js/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/auth-js/main/index.md
@@ -238,12 +238,12 @@ Create an app integration in the Okta org that represents the application you wa
 
 1. In the **Assignments** section, select **Allow everyone in your organization to access**.
 1. Click **Save**.
-1. Select the **Sign On** tab.
-1. In the **Sign On Policy** section, verify that the **Available Authenticators** settings are appropriate for your app. For this use case, ensure that the **1 factor type** authenticator is **Password / IdP**.
 1. In the **Security** > **API** > **Authorization Servers** section, verify that the custom authorization server uses the Interaction Code grant type by selecting the **default** server, clicking **Access Policies**, and editing the **Default Policy Rule**. Review the **If Grant type is** section to ensure the **Interaction Code** checkbox is selected.
 1. In the **Security** > **API** > **Trusted Origins** page, ensure that there is an entry for your sign in redirect URI (`http://localhost:8080`). See [Enable CORS](/docs/guides/enable-cors/).
 
 > **Note:** From the **General** tab of your app integration, save the generated **Client ID** value, which is used in the next section.
+
+> **Note:** New apps are automatically assigned the shared default authentication policy that has a catch-all rule that allows a user access to the app using one factor. To view more information on the default authentication policy, from the left navigation pane, select **Security** > **Authentication Polices** and then select **Default Policy**.
 
 ### Download and install the sample app
 

--- a/packages/@okta/vuepress-site/docs/guides/embedded-siw/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/embedded-siw/main/index.md
@@ -149,12 +149,12 @@ Create an app integration in the Okta org that represents the application you wa
 
 1. In the **Assignments** section, select **Allow everyone in your organization to access**.
 1. Click **Save**.
-1. Select the **Sign On** tab.
-1. In the **Sign On Policy** section, verify that the **Available Authenticators** settings are appropriate for your app. For this use case, ensure that the **1 factor type** authenticator is **Password / IdP**.
 1. In the **Security** > **API** > **Authorization Servers** section, verify that the custom authorization server uses the Interaction Code grant type by selecting the **default** server, clicking **Access Policies**, and editing the **Default Policy Rule**. Review the **If Grant type is** section to ensure the **Interaction Code** checkbox is selected.
 1. In the **Security** > **API** > **Trusted Origins** page, ensure that there is an entry for your sign in redirect URI. See [Enable CORS](/docs/guides/enable-cors/).
 
 > **Note:** From the **General** tab of your app integration, save the generated **Client ID** value, which is used in the next section.
+
+> **Note:** New apps are automatically assigned the shared default authentication policy that has a catch-all rule that allows a user access to the app using one factor. To view more information on the default authentication policy, from the left navigation pane, select **Security** > **Authentication Polices** and then select **Default Policy**.
 
 #### Create a simple SPA
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/index.md
@@ -18,6 +18,8 @@ layout: Guides
 
 <StackSnippet snippet="create-app-integration" />
 
+> **Note:** New apps are automatically assigned the shared default authentication policy that has a catch-all rule that allows a user access to the app using one factor. To view more information on the default authentication policy, from the left navigation pane, select **Security** > **Authentication Polices** and then select **Default Policy**.
+
 ## Install the SDK
 
 <StackSnippet snippet="download-sample" />

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/create-app-integration.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/create-app-integration.md
@@ -22,3 +22,5 @@ You need two pieces of information from your org and app integration for your Re
 
 * **Client ID**: From the **General** tab of your app integration, save the generated **Client ID** value.
 * **Issuer**: From the **General** tab of your app integration, save the **Okta domain** value. Use your Okta domain value for the [issuer](/docs/guides/oie-embedded-common-download-setup-app/nodejs/main/#issuer) setting, which represents the authorization server. Use `https://${yourOktaDomain}/oauth2/default` as the issuer for your app if you're using the Okta Developer Edition org. See [Issuer configuration](/docs/guides/oie-embedded-common-download-setup-app/nodejs/main/#issuer) if you want to use another Okta custom authorization server.
+
+<br>

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/vue/create-app-integration.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/vue/create-app-integration.md
@@ -18,12 +18,11 @@ Before you integrate Okta authentication to your Vue.js app, you must register y
 
     > **Note:** If you're using the [Okta CLI](https://cli.okta.com/manual/apps/create/) to create your SPA Okta app integration, ensure that **Interaction Code**, **Refresh Token**, and **Authorization Code** grant types are enabled for your app.
 
-5. Select the **Sign On** tab.
-6. In the **Sign On Policy** section, verify that the **Available Authenticators** settings are appropriate for your app. For this use case, ensure that the **1 factor type** authenticator is **Password / IdP**.
-
 ### Okta org app integration configuration settings
 
 You need two pieces of information from your org and app integration for your Vue.js app:
 
 * **Client ID**: From the **General** tab of your app integration, save the generated **Client ID** value.
 * **Issuer**: From the **General** tab of your app integration, save the **Okta domain** value. Use your Okta domain value for the [issuer](/docs/guides/oie-embedded-common-download-setup-app/nodejs/main/#issuer) setting that represents the authorization server. Use `https://${yourOktaDomain}/oauth2/default` as the issuer for your app if you're using the Okta Developer Edition org. See [Issuer configuration](/docs/guides/oie-embedded-common-download-setup-app/nodejs/main/#issuer) if you want to use another Okta custom authorization server.
+
+<br>

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/angular/create-app-integration.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/angular/create-app-integration.md
@@ -15,9 +15,7 @@ The sample application requires an integration with your Okta org to implement a
 
 1. In the **Assignments** section, select **Allow everyone in your organization to access**.
 1. Click **Save**.
-1. Select the **Sign On** tab.
-1. On the **Sign On Policy** tab, verify that the **Available Authenticators** settings are appropriate for your app. For this use case, ensure that the **1 factor type** authenticator is **Password / IdP**.
-1. On the **Security** > **API** > **Authorization Servers** page, verify that the custom authorization server uses the Interaction Code grant type by selecting the **default** server, clicking **Access Policies**, and editing the **Default Policy Rule**. Review the **If Grant type is** section to ensure the **Interaction Code** checkbox is selected.
+1. On the **Security** > **API** > **Authorization Servers** page, verify that the custom authorization server uses the Interaction Code grant type by selecting the **default** server, clicking **Access Policies**, and editing the **Default Policy Rule**. Review the **IF Grant type is** section to ensure that the **Interaction Code** checkbox is selected.
 1. On the **Security** > **API** > **Trusted Origins** page, ensure that there is an entry for your sign in redirect URI. See [Enable CORS](/docs/guides/enable-cors/).
 
 > **Note:** From the **General** tab of your app integration, save the generated **Client ID** value, which is used in the next section.

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/index.md
@@ -16,6 +16,8 @@ title: Sign in to your SPA with the embedded Okta Sign-In Widget
 
 <StackSnippet snippet="create-app-integration" />
 
+> **Note:** New apps are automatically assigned the shared default authentication policy that has a catch-all rule that allows a user access to the app using one factor. To view more information on the default authentication policy, from the left navigation pane, select **Security** > **Authentication Polices** and then select **Default Policy**.
+
 ## Install the SDK
 
 <StackSnippet snippet="download-sample" />

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/react/create-app-integration.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/react/create-app-integration.md
@@ -16,12 +16,11 @@ Before integrating Okta authentication into your React app, obtain the OpenID Co
 
     > **Note:** Cross-Origin Resource Sharing (CORS) is automatically enabled for the Trusted Origins base URI that you specified in the Admin Console. If you're using the [Okta CLI](https://cli.okta.com/manual/apps/create/) to create your SPA Okta app integration, CORS is also automatically enabled for your base URI. You can verify that both **CORS** and **redirect** are enabled for your app by reviewing the **Security** > **API** > **Trusted Origins** page in the Admin Console.
 
-5. Select the **Sign On** tab.
-6. In the **Sign On Policy** section, verify that the **Available Authenticators** settings are appropriate for your app. For this use case, ensure that the **1 factor type** authenticator is **Password / IdP**.
-
 ### Okta org app integration configuration settings
 
 You need two pieces of information from your org and app integration for your React app:
 
 * **Client ID**: From the **General** tab of your app integration, save the generated **Client ID** value.
 * **Issuer**: From the **General** tab of your app integration, save the **Okta domain** value. Use your Okta domain value for the [issuer](/docs/guides/oie-embedded-common-download-setup-app/nodejs/main/#issuer) setting that represents the authorization server. Use `https://${yourOktaDomain}/oauth2/default` as the issuer for your app if you're using an Okta Developer Edition org. See [Issuer configuration](/docs/guides/oie-embedded-common-download-setup-app/nodejs/main/#issuer) if you want to use another Okta custom authorization server.
+
+<br>

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/vue/create-app-integration.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/vue/create-app-integration.md
@@ -16,9 +16,6 @@ Before you integrate Okta authentication to your Vue.js app, register your app i
 
     > **Note:** Cross-Origin Resource Sharing (CORS) is automatically enabled for the Trusted Origins base URI that you specified in the Admin Console. If you're using the [Okta CLI](https://cli.okta.com/manual/apps/create/) to create your SPA Okta app integration, CORS is also automatically enabled for your base URI. You can verify that both **CORS** and **redirect** are enabled for your app by reviewing the **Security** > **API** > **Trusted Origins** page in the Admin Console.
 
-5. Select the **Sign On** tab.
-6. In the **Sign On Policy** section, verify that the **Available Authenticators** settings are appropriate for your app. For this use case, ensure that the **1 factor type** authenticator is **Password / IdP**.
-
 ### Okta org app integration configuration settings
 
 You need two pieces of information from your org and app integration for your Vue.js app:
@@ -26,3 +23,4 @@ You need two pieces of information from your org and app integration for your Vu
 * **Client ID**: From the **General** tab of your app integration, save the generated **Client ID** value.
 * **Issuer**: From the **General** tab of your app integration, save the **Okta domain** value. Use your Okta domain value for the [issuer](/docs/guides/oie-embedded-common-download-setup-app/nodejs/main/#issuer) setting that represents the authorization server. Use `https://${yourOktaDomain}/oauth2/default` as the issuer for your app if you're using the Okta Developer Edition org. See [Issuer configuration](/docs/guides/oie-embedded-common-download-setup-app/nodejs/main/#issuer) if you want to use another Okta custom authorization server.
 
+<br>


### PR DESCRIPTION
## Description:
- **What's changed?** Update OIE-by-default embedded sign-in guides with a note about shared default authentication policy, and removed sign-on policy steps. The following guides are updated:
     - /sign-in-to-spa-embedded-widget/
     - /sign-in-to-spa-authjs/
     - /embedded-siw/
     - /auth-js/
- **Is this PR related to a Monolith release?** 2022.03.0

### Resolves:

* [OKTA-475953](https://oktainc.atlassian.net/browse/OKTA-475953)
