### PR TITLE
OKTA-462650 Set servers parameter to optional ASA /preauthorizations

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
@@ -1097,7 +1097,7 @@ This endpoint returns an object with the following fields and a `200` code on a 
 | `expires_at`   | string | The Preauthorization ceases to work after the `expires_at` date |
 | `id`   | string | The UUID of the Preauthorization |
 | `projects`   | array | The Projects that the Preauthorization is valid for |
-| `servers`   | array | Not supported; this field will be removed in a future release of ASA. It is only documented for backward compatibility with legacy clients. |
+| `servers`   | array | Not supported. This field will be removed in a future release of ASA. It's only documented for backward compatibility with legacy clients. |
 | `user_name`   | string | The username of the ASA User that the Preauthorization is for |
 
 #### Usage example

--- a/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
@@ -1097,6 +1097,7 @@ This endpoint returns an object with the following fields and a `200` code on a 
 | `expires_at`   | string | The Preauthorization ceases to work after the `expires_at` date |
 | `id`   | string | The UUID of the Preauthorization |
 | `projects`   | array | The Projects that the Preauthorization is valid for |
+| `servers`   | array | The Servers that the Preauthorization is valid for (not supported) |
 | `user_name`   | string | The username of the ASA User that the Preauthorization is for |
 
 #### Usage example
@@ -1119,6 +1120,7 @@ https://app.scaleft.com/v1/teams/${team_name}/projects/${project_name}/preauthor
 	"projects": [
 		"the-sound-and-the-fury"
 	],
+	"servers": null,
 	"user_name": "jason.compson"
 }
 ```
@@ -1220,6 +1222,7 @@ This endpoint returns a list of objects with the following fields and a `200` co
 | `expires_at`   | string | The Preauthorization ceases to work after the `expires_at` date |
 | `id`   | string | The UUID of the Preauthorization |
 | `projects`   | array | The Projects that the Preauthorization is valid for |
+| `servers`   | array | The Servers that the Preauthorization is valid for (not supported) |
 | `user_name`   | string | The username of the ASA User that the Preauthorization is for |
 
 #### Usage example
@@ -1244,6 +1247,7 @@ https://app.scaleft.com/v1/teams/${team_name}/projects/${project_name}/preauthor
 			"projects": [
 				"the-sound-and-the-fury"
 			],
+			"servers": null,
 			"user_name": "jason.compson"
 		}
 	]
@@ -1286,6 +1290,7 @@ This endpoint returns an object with the following fields and a `200` code on a 
 | `expires_at`   | string | The Preauthorization ceases to work after the `expires_at` date |
 | `id`   | string | The UUID of the Preauthorization |
 | `projects`   | array | The Projects that the Preauthorization is valid for |
+| `servers`   | array | The Servers that the Preauthorization is valid for (not supported) |
 | `user_name`   | string | The username of the ASA User that the Preauthorization is for |
 
 #### Usage example
@@ -1317,6 +1322,7 @@ https://app.scaleft.com/v1/teams/${team_name}/projects/${project_name}/preauthor
 	"projects": [
 		"the-sound-and-the-fury"
 	],
+	"servers": null,
 	"user_name": "jason.compson"
 }
 ```

--- a/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
@@ -1097,7 +1097,7 @@ This endpoint returns an object with the following fields and a `200` code on a 
 | `expires_at`   | string | The Preauthorization ceases to work after the `expires_at` date |
 | `id`   | string | The UUID of the Preauthorization |
 | `projects`   | array | The Projects that the Preauthorization is valid for |
-| `servers`   | array | The Servers that the Preauthorization is valid for (not supported) |
+| `servers`   | array | Not supported; this field will be removed in a future release of ASA. It is only documented for backward compatibility with legacy clients. |
 | `user_name`   | string | The username of the ASA User that the Preauthorization is for |
 
 #### Usage example
@@ -1222,7 +1222,7 @@ This endpoint returns a list of objects with the following fields and a `200` co
 | `expires_at`   | string | The Preauthorization ceases to work after the `expires_at` date |
 | `id`   | string | The UUID of the Preauthorization |
 | `projects`   | array | The Projects that the Preauthorization is valid for |
-| `servers`   | array | The Servers that the Preauthorization is valid for (not supported) |
+| `servers`   | array | Not supported; this field will be removed in a future release of ASA. It is only documented for backward compatibility with legacy clients. |
 | `user_name`   | string | The username of the ASA User that the Preauthorization is for |
 
 #### Usage example
@@ -1290,7 +1290,7 @@ This endpoint returns an object with the following fields and a `200` code on a 
 | `expires_at`   | string | The Preauthorization ceases to work after the `expires_at` date |
 | `id`   | string | The UUID of the Preauthorization |
 | `projects`   | array | The Projects that the Preauthorization is valid for |
-| `servers`   | array | The Servers that the Preauthorization is valid for (not supported) |
+| `servers`   | array | Not supported; this field will be removed in a future release of ASA. It is only documented for backward compatibility with legacy clients. |
 | `user_name`   | string | The username of the ASA User that the Preauthorization is for |
 
 #### Usage example

--- a/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
@@ -1097,7 +1097,7 @@ This endpoint returns an object with the following fields and a `200` code on a 
 | `expires_at`   | string | The Preauthorization ceases to work after the `expires_at` date |
 | `id`   | string | The UUID of the Preauthorization |
 | `projects`   | array | The Projects that the Preauthorization is valid for |
-| `servers`   | array | The Servers that the Preauthorization is valid for |
+| `servers`   | array | The Servers that the Preauthorization is valid for (not supported) |
 | `user_name`   | string | The username of the ASA User that the Preauthorization is for |
 
 #### Usage example
@@ -1152,7 +1152,7 @@ This endpoint requires an object with the following fields.
 | `expires_at`   | string | The Preauthorization ceases to work after the `expires_at` date |
 | `id`   | string | The UUID of the Preauthorization |
 | `projects`   | array | The Projects that the Preauthorization is valid for |
-| `servers`   | array | The Servers that the Preauthorization is valid for |
+| `servers`   | array | The Servers that the Preauthorization is valid for (not supported) |
 | `user_name`   | string | The username of the ASA User that the Preauthorization is for |
 
 #### Response body
@@ -1173,7 +1173,6 @@ curl -v -X POST \
 	"projects": [
 		"the-sound-and-the-fury"
 	],
-	"servers": null,
 	"user_name": "jason.compson"
 }' \
 https://app.scaleft.com/v1/teams/${team_name}/projects/${project_name}/preauthorizations
@@ -1224,7 +1223,7 @@ This endpoint returns a list of objects with the following fields and a `200` co
 | `expires_at`   | string | The Preauthorization ceases to work after the `expires_at` date |
 | `id`   | string | The UUID of the Preauthorization |
 | `projects`   | array | The Projects that the Preauthorization is valid for |
-| `servers`   | array | The Servers that the Preauthorization is valid for |
+| `servers`   | array | The Servers that the Preauthorization is valid for (not supported) |
 | `user_name`   | string | The username of the ASA User that the Preauthorization is for |
 
 #### Usage example
@@ -1282,7 +1281,6 @@ This endpoint requires an object with the following fields.
 | `expires_at`   | string | The Preauthorization ceases to work after the `expires_at` date |
 | `id`   | string | The UUID of the Preauthorization |
 | `projects`   | array | The Projects that the Preauthorization is valid for |
-| `servers`   | array | The Servers that the Preauthorization is valid for |
 | `user_name`   | string | The username of the ASA User that the Preauthorization is for |
 
 #### Response body
@@ -1293,7 +1291,7 @@ This endpoint returns an object with the following fields and a `200` code on a 
 | `expires_at`   | string | The Preauthorization ceases to work after the `expires_at` date |
 | `id`   | string | The UUID of the Preauthorization |
 | `projects`   | array | The Projects that the Preauthorization is valid for |
-| `servers`   | array | The Servers that the Preauthorization is valid for |
+| `servers`   | array | The Servers that the Preauthorization is valid for (not supported) |
 | `user_name`   | string | The username of the ASA User that the Preauthorization is for |
 
 #### Usage example
@@ -1310,7 +1308,6 @@ curl -v -X PUT \
 	"projects": [
 		"the-sound-and-the-fury"
 	],
-	"servers": null,
 	"user_name": "jason.compson"
 }' \
 https://app.scaleft.com/v1/teams/${team_name}/projects/${project_name}/preauthorizations/${authorization_id}

--- a/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
@@ -1290,7 +1290,7 @@ This endpoint returns an object with the following fields and a `200` code on a 
 | `expires_at`   | string | The Preauthorization ceases to work after the `expires_at` date |
 | `id`   | string | The UUID of the Preauthorization |
 | `projects`   | array | The Projects that the Preauthorization is valid for |
-| `servers`   | array | Not supported; this field will be removed in a future release of ASA. It is only documented for backward compatibility with legacy clients. |
+| `servers`   | array | Not supported. This field will be removed in a future release of ASA. It's only documented for backward compatibility with legacy clients. |
 | `user_name`   | string | The username of the ASA User that the Preauthorization is for |
 
 #### Usage example

--- a/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
@@ -1097,7 +1097,6 @@ This endpoint returns an object with the following fields and a `200` code on a 
 | `expires_at`   | string | The Preauthorization ceases to work after the `expires_at` date |
 | `id`   | string | The UUID of the Preauthorization |
 | `projects`   | array | The Projects that the Preauthorization is valid for |
-| `servers`   | array | The Servers that the Preauthorization is valid for (not supported) |
 | `user_name`   | string | The username of the ASA User that the Preauthorization is for |
 
 #### Usage example
@@ -1120,7 +1119,6 @@ https://app.scaleft.com/v1/teams/${team_name}/projects/${project_name}/preauthor
 	"projects": [
 		"the-sound-and-the-fury"
 	],
-	"servers": null,
 	"user_name": "jason.compson"
 }
 ```
@@ -1152,7 +1150,6 @@ This endpoint requires an object with the following fields.
 | `expires_at`   | string | The Preauthorization ceases to work after the `expires_at` date |
 | `id`   | string | The UUID of the Preauthorization |
 | `projects`   | array | The Projects that the Preauthorization is valid for |
-| `servers`   | array | The Servers that the Preauthorization is valid for (not supported) |
 | `user_name`   | string | The username of the ASA User that the Preauthorization is for |
 
 #### Response body
@@ -1223,7 +1220,6 @@ This endpoint returns a list of objects with the following fields and a `200` co
 | `expires_at`   | string | The Preauthorization ceases to work after the `expires_at` date |
 | `id`   | string | The UUID of the Preauthorization |
 | `projects`   | array | The Projects that the Preauthorization is valid for |
-| `servers`   | array | The Servers that the Preauthorization is valid for (not supported) |
 | `user_name`   | string | The username of the ASA User that the Preauthorization is for |
 
 #### Usage example
@@ -1248,7 +1244,6 @@ https://app.scaleft.com/v1/teams/${team_name}/projects/${project_name}/preauthor
 			"projects": [
 				"the-sound-and-the-fury"
 			],
-			"servers": null,
 			"user_name": "jason.compson"
 		}
 	]
@@ -1291,7 +1286,6 @@ This endpoint returns an object with the following fields and a `200` code on a 
 | `expires_at`   | string | The Preauthorization ceases to work after the `expires_at` date |
 | `id`   | string | The UUID of the Preauthorization |
 | `projects`   | array | The Projects that the Preauthorization is valid for |
-| `servers`   | array | The Servers that the Preauthorization is valid for (not supported) |
 | `user_name`   | string | The username of the ASA User that the Preauthorization is for |
 
 #### Usage example
@@ -1323,7 +1317,6 @@ https://app.scaleft.com/v1/teams/${team_name}/projects/${project_name}/preauthor
 	"projects": [
 		"the-sound-and-the-fury"
 	],
-	"servers": null,
 	"user_name": "jason.compson"
 }
 ```


### PR DESCRIPTION
## Description:
- **What's changed?** This `servers` is not supported in ASA /preauthorizations. Platform PR 5491 removed the `servers` parameter.
- **Is this PR related to a Monolith release?** Yes, 2022.03.2

### Resolves:

* [OKTA-462650](https://oktainc.atlassian.net/browse/OKTA-462650)
