### PR TITLE
TBS OKTA-477959 Update registration hook error object

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -165,7 +165,7 @@ For the Registration Inline Hook, the `error` object provides a way of displayin
 * If you're using the Okta Sign-In Widget for Profile Enrollment, only the `errorSummary` messages of the `errorCauses` objects that your external service returns appear as inline errors, given the following:
 
    * You don't customize the error handling behavior of the Widget.
-   * The `errorSummary` attributes are in the correct location of the `errorCauses` object. See [Sample JSON payload of the response](#sample-json-payload-of-response).
+   * The `location` of `errorSummary` in the `errorCauses` object specifies the correct attribute. See [JSON response payload objects - error](/docs/concepts/inline-hooks/#error).
 
 * If you don't return a value for the `errorCauses` object, and deny the user's registration attempt through the `commands` object in your response to Okta, one of the following generic messages appears to the end user:</br></br>
       `Registration cannot be completed at this time.`</br></br>

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -214,31 +214,23 @@ If there is a response timeout after receiving the Okta request, the Okta proces
 ## Sample JSON payload of response
 
 ```json
-{
-   "commands":[
-      {
-         "type":"com.okta.action.update",
-         "value":{
-            "registration":"DENY"
-         }
+{ "commands":[
+                          { "type":"com.okta.action.update",
+                            "value":{ "registration": "DENY"} }
+                                   ],
+                         "error": {
+                          "errorSummary":"Incorrect email address. Please contact your admin.",
+                          "errorCauses":[
+                             {
+                                "errorSummary":"Only example.com emails can register.",
+                                "reason":"INVALID_EMAIL_DOMAIN",
+                                "locationType":"body",
+                                "location":"data.userProfile.login",
+                                "domain":"end-user"
+                             }
+                                        ]
+                         }
       }
-   ]
-}
-
-{
-   "error":{
-      "errorSummary":"Errors were found in the user profile",
-      "errorCauses":[
-         {
-            "errorSummary":"You specified an invalid email domain",
-            "reason":"INVALID_EMAIL_DOMAIN",
-            "locationType":"body",
-            "location":"data.userProfile.login",
-            "domain":"end-user"
-         }
-      ]
-   }
-}
 ```
 
 ## Enable a Registration Inline Hook for Profile Enrollment in Okta Identity Engine

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -158,17 +158,19 @@ Registrations are allowed by default, so setting a value of `ALLOW` for the `act
 
 ### error
 
-See [error](/docs/concepts/inline-hooks/#error) for general information on the structure to use for the `error` object.
+See [error](/docs/concepts/inline-hooks/#error) for general information about the structure to use for the `error` object.
+
+> **Note:** If you include an error object in your response, no commands are executed and the registration fails. This holds true even if the top-level `errorSummary` and the `errorCauses` objects are omitted.
 
 For the Registration Inline Hook, the `error` object provides a way of displaying an error message to the end user who is trying to register.
 
 * If you're using the Okta Sign-In Widget for Profile Enrollment, only the `errorSummary` messages of the `errorCauses` objects that your external service returns appear as inline errors, given the following:
-   * You haven't customized the error handling behavior of the Widget.
-   * The attributes are in the correct location of the `errorCauses` object.
-* If you don't return any value for that `errorCauses` object and deny the user's registration attempt through the `commands` object in your response to Okta, the following generic message appears to the end user (with no inline error messages): "We found some errors. Please review the form and make corrections."
-* If you don't return an `error` object at all and the registration is denied, the following generic message appears to the end user: "Registration denied."
 
-> **Note:** If you include an error object in your response, no commands will be executed and the registration will fail. This holds true even if the top-level `errorSummary` and the `errorCauses` objects are omitted.
+   * You don't customize the error handling behavior of the Widget.
+   * The attributes are in the correct location of the `errorCauses` object.
+
+* If you don't return a value for the `errorCauses` object, and deny the user's registration attempt through the `commands` object in your response to Okta, the following generic message appears to the end user (with no inline error messages): "We found some errors. Please review the form and make corrections."
+* If you don't return an `error` object at all and the registration is denied, the following generic message appears to the end user: "Registration denied."
 
 ## Timeout behavior
 

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -160,19 +160,19 @@ Registrations are allowed by default, so setting a value of `ALLOW` for the `act
 
 See [error](/docs/concepts/inline-hooks/#error) for general information about the structure to use for the `error` object.
 
-> **Note:** If you include an error object in your response, no commands are executed and the registration fails. This holds true even if the top-level `errorSummary` and the `errorCauses` objects are omitted.
-
 For the Registration Inline Hook, the `error` object provides a way of displaying an error message to the end user who is trying to register.
 
 * If you're using the Okta Sign-In Widget for Profile Enrollment, only the `errorSummary` messages of the `errorCauses` objects that your external service returns appear as inline errors, given the following:
 
    * You don't customize the error handling behavior of the Widget.
-   * The attributes are in the correct location of the `errorCauses` object. See the [sample JSON payload of the request](#sample-json-payload-of-request).
+   * The `errorSummary` attributes are in the correct location of the `errorCauses` object. See [Sample JSON payload of the response](#sample-json-payload-of-response).
 
 * If you don't return a value for the `errorCauses` object, and deny the user's registration attempt through the `commands` object in your response to Okta, the following generic message appears to the end user (with no inline error messages):</br>
       `We found some errors. Please review the form and make corrections.`
 * If you don't return an `error` object at all and the registration is denied, the following generic message appears to the end user:</br>
       `Registration denied.`
+
+> **Note:** If you include an error object in your response, no commands are executed and the registration fails. This holds true even if the top-level `errorSummary` and the `errorCauses` objects are omitted.
 
 ## Timeout behavior
 

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -169,8 +169,10 @@ For the Registration Inline Hook, the `error` object provides a way of displayin
    * You don't customize the error handling behavior of the Widget.
    * The attributes are in the correct location of the `errorCauses` object.
 
-* If you don't return a value for the `errorCauses` object, and deny the user's registration attempt through the `commands` object in your response to Okta, the following generic message appears to the end user (with no inline error messages): "We found some errors. Please review the form and make corrections."
-* If you don't return an `error` object at all and the registration is denied, the following generic message appears to the end user: "Registration denied."
+* If you don't return a value for the `errorCauses` object, and deny the user's registration attempt through the `commands` object in your response to Okta, the following generic message appears to the end user (with no inline error messages):</br>
+      `We found some errors. Please review the form and make corrections.`
+* If you don't return an `error` object at all and the registration is denied, the following generic message appears to the end user:</br>
+      `Registration denied.`
 
 ## Timeout behavior
 

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -169,7 +169,7 @@ For the Registration Inline Hook, the `error` object provides a way of displayin
 
 * If you don't return a value for the `errorCauses` object, and deny the user's registration attempt through the `commands` object in your response to Okta, one of the following generic message appears to the end user:</br></br>
       `Registration cannot be completed at this time.`</br></br>
-      `We found some errors. Please review the form and make corrections.`<ApiLifecycle access="ie" />
+      `We found some errors. Please review the form and make corrections.` <ApiLifecycle access="ie" />
 
 * If you don't return an `error` object at all and the registration is denied, the following generic message appears to the end user:</br>
       `Registration denied.`

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -160,11 +160,13 @@ Registrations are allowed by default, so setting a value of `ALLOW` for the `act
 
 See [error](/docs/concepts/inline-hooks/#error) for general information on the structure to use for the `error` object.
 
-For the Registration Inline Hook, the `error` object provides a way of displaying an error message to the end user who is trying to register. If you're using the Okta Sign-In Widget for Profile Enrollment, and have not customized its error handling behavior, only the `errorSummary` of the first `errorCauses` object that your external service returns appears to the end user.
+For the Registration Inline Hook, the `error` object provides a way of displaying an error message to the end user who is trying to register.
 
-If you don't return any value for that `errorCauses` object and deny the user's registration attempt through the `commands` object in your response to Okta, the following generic message appears to the end user: "Registration cannot be completed at this time".
-
-If you don't return an `error` object at all and the registration is denied, the following generic message appears to the end user: "Registration denied".
+* If you're using the Okta Sign-In Widget for Profile Enrollment, only the `errorSummary` messages of the `errorCauses` objects that your external service returns appear as inline errors, given the following:
+   * You haven't customized the error handling behavior of the Widget.
+   * The attributes are in the correct location of the `errorCauses` object.
+* If you don't return any value for that `errorCauses` object and deny the user's registration attempt through the `commands` object in your response to Okta, the following generic message appears to the end user (with no inline error messages): "We found some errors. Please review the form and make corrections."
+* If you don't return an `error` object at all and the registration is denied, the following generic message appears to the end user: "Registration denied."
 
 > **Note:** If you include an error object in your response, no commands will be executed and the registration will fail. This holds true even if the top-level `errorSummary` and the `errorCauses` objects are omitted.
 

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -214,23 +214,31 @@ If there is a response timeout after receiving the Okta request, the Okta proces
 ## Sample JSON payload of response
 
 ```json
-{ "commands":[
-                          { "type":"com.okta.action.update",
-                            "value":{ "registration": "DENY"} } 
-                                   ],
-                         "error": {
-                          "errorSummary":"Incorrect email address. Please contact your admin.",
-                          "errorCauses":[
-                             {
-                                "errorSummary":"Only example.com emails can register.",
-                                "reason":"INVALID_EMAIL_DOMAIN",
-                                "locationType":"body",
-                                "location":"data.userProfile.login",
-                                "domain":"end-user"
-                             }
-                                        ]
-                         }
+{
+   "commands":[
+      {
+         "type":"com.okta.action.update",
+         "value":{
+            "registration":"DENY"
+         }
       }
+   ]
+}
+
+{
+   "error":{
+      "errorSummary":"Errors were found in the user profile",
+      "errorCauses":[
+         {
+            "errorSummary":"You specified an invalid email domain",
+            "reason":"INVALID_EMAIL_DOMAIN",
+            "locationType":"body",
+            "location":"data.userProfile.login",
+            "domain":"end-user"
+         }
+      ]
+   }
+}
 ```
 
 ## Enable a Registration Inline Hook for Profile Enrollment in Okta Identity Engine

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -167,7 +167,7 @@ For the Registration Inline Hook, the `error` object provides a way of displayin
 * If you're using the Okta Sign-In Widget for Profile Enrollment, only the `errorSummary` messages of the `errorCauses` objects that your external service returns appear as inline errors, given the following:
 
    * You don't customize the error handling behavior of the Widget.
-   * The attributes are in the correct location of the `errorCauses` object.
+   * The attributes are in the correct location of the `errorCauses` object. See the [sample JSON payload of the request](#sample-json-payload-of-request).
 
 * If you don't return a value for the `errorCauses` object, and deny the user's registration attempt through the `commands` object in your response to Okta, the following generic message appears to the end user (with no inline error messages):</br>
       `We found some errors. Please review the form and make corrections.`
@@ -214,31 +214,23 @@ If there is a response timeout after receiving the Okta request, the Okta proces
 ## Sample JSON payload of response
 
 ```json
-{
-   "commands":[
-      {
-         "type":"com.okta.action.update",
-         "value":{
-            "registration":"DENY"
-         }
+{ "commands":[
+                          { "type":"com.okta.action.update",
+                            "value":{ "registration": "DENY"} } 
+                                   ],
+                         "error": {
+                          "errorSummary":"Incorrect email address. Please contact your admin.",
+                          "errorCauses":[
+                             {
+                                "errorSummary":"Only example.com emails can register.",
+                                "reason":"INVALID_EMAIL_DOMAIN",
+                                "locationType":"body",
+                                "location":"data.userProfile.login",
+                                "domain":"end-user"
+                             }
+                                        ]
+                         }
       }
-   ]
-}
-
-{
-   "error":{
-      "errorSummary":"Errors were found in the user profile",
-      "errorCauses":[
-         {
-            "errorSummary":"You specified an invalid email domain",
-            "reason":"INVALID_EMAIL_DOMAIN",
-            "locationType":"body",
-            "location":"data.userProfile.login",
-            "domain":"end-user"
-         }
-      ]
-   }
-}
 ```
 
 ## Enable a Registration Inline Hook for Profile Enrollment in Okta Identity Engine

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -169,8 +169,7 @@ For the Registration Inline Hook, the `error` object provides a way of displayin
 
 * If you don't return a value for the `errorCauses` object, and deny the user's registration attempt through the `commands` object in your response to Okta, one of the following generic message appears to the end user:</br></br>
       `Registration cannot be completed at this time.`</br></br>
-      `We found some errors. Please review the form and make corrections.`</br>
-      <ApiLifecycle access="ie" />
+      `We found some errors. Please review the form and make corrections.`<ApiLifecycle access="ie" />
 
 * If you don't return an `error` object at all and the registration is denied, the following generic message appears to the end user:</br>
       `Registration denied.`

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -167,7 +167,7 @@ For the Registration Inline Hook, the `error` object provides a way of displayin
    * You don't customize the error handling behavior of the Widget.
    * The `errorSummary` attributes are in the correct location of the `errorCauses` object. See [Sample JSON payload of the response](#sample-json-payload-of-response).
 
-* If you don't return a value for the `errorCauses` object, and deny the user's registration attempt through the `commands` object in your response to Okta, one of the following generic message appears to the end user:</br></br>
+* If you don't return a value for the `errorCauses` object, and deny the user's registration attempt through the `commands` object in your response to Okta, one of the following generic messages appears to the end user:</br></br>
       `Registration cannot be completed at this time.`</br></br>
       `We found some errors. Please review the form and make corrections.` <ApiLifecycle access="ie" />
 

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -168,7 +168,10 @@ For the Registration Inline Hook, the `error` object provides a way of displayin
    * The `errorSummary` attributes are in the correct location of the `errorCauses` object. See [Sample JSON payload of the response](#sample-json-payload-of-response).
 
 * If you don't return a value for the `errorCauses` object, and deny the user's registration attempt through the `commands` object in your response to Okta, the following generic message appears to the end user (with no inline error messages):</br>
-      `We found some errors. Please review the form and make corrections.`
+      `We found some errors. Please review the form and make corrections.`</br>
+      `Registration cannot be completed at this time.`
+      <ApiLifecycle access="ie" />
+
 * If you don't return an `error` object at all and the registration is denied, the following generic message appears to the end user:</br>
       `Registration denied.`
 

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -167,8 +167,8 @@ For the Registration Inline Hook, the `error` object provides a way of displayin
    * You don't customize the error handling behavior of the Widget.
    * The `errorSummary` attributes are in the correct location of the `errorCauses` object. See [Sample JSON payload of the response](#sample-json-payload-of-response).
 
-* If you don't return a value for the `errorCauses` object, and deny the user's registration attempt through the `commands` object in your response to Okta, one of the following generic message appears to the end user:</br>
-      `Registration cannot be completed at this time.`
+* If you don't return a value for the `errorCauses` object, and deny the user's registration attempt through the `commands` object in your response to Okta, one of the following generic message appears to the end user:</br></br>
+      `Registration cannot be completed at this time.`</br></br>
       `We found some errors. Please review the form and make corrections.`</br>
       <ApiLifecycle access="ie" />
 

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -214,7 +214,6 @@ If there is a response timeout after receiving the Okta request, the Okta proces
 ## Sample JSON payload of response
 
 ```json
-{ "commands":[
 {
   "commands": [
     {
@@ -237,21 +236,6 @@ If there is a response timeout after receiving the Okta request, the Okta proces
     ]
   }
 }
-                            "value":{ "registration": "DENY"} }
-                                   ],
-                         "error": {
-                          "errorSummary":"Incorrect email address. Please contact your admin.",
-                          "errorCauses":[
-                             {
-                                "errorSummary":"Only example.com emails can register.",
-                                "reason":"INVALID_EMAIL_DOMAIN",
-                                "locationType":"body",
-                                "location":"data.userProfile.login",
-                                "domain":"end-user"
-                             }
-                                        ]
-                         }
-      }
 ```
 
 ## Enable a Registration Inline Hook for Profile Enrollment in Okta Identity Engine

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -167,9 +167,9 @@ For the Registration Inline Hook, the `error` object provides a way of displayin
    * You don't customize the error handling behavior of the Widget.
    * The `errorSummary` attributes are in the correct location of the `errorCauses` object. See [Sample JSON payload of the response](#sample-json-payload-of-response).
 
-* If you don't return a value for the `errorCauses` object, and deny the user's registration attempt through the `commands` object in your response to Okta, the following generic message appears to the end user (with no inline error messages):</br>
-      `We found some errors. Please review the form and make corrections.`</br>
+* If you don't return a value for the `errorCauses` object, and deny the user's registration attempt through the `commands` object in your response to Okta, one of the following generic message appears to the end user:</br>
       `Registration cannot be completed at this time.`
+      `We found some errors. Please review the form and make corrections.`</br>
       <ApiLifecycle access="ie" />
 
 * If you don't return an `error` object at all and the registration is denied, the following generic message appears to the end user:</br>

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -165,7 +165,7 @@ For the Registration Inline Hook, the `error` object provides a way of displayin
 * If you're using the Okta Sign-In Widget for Profile Enrollment, only the `errorSummary` messages of the `errorCauses` objects that your external service returns appear as inline errors, given the following:
 
    * You don't customize the error handling behavior of the widget.
-   * The `location` of `errorSummary` in the `errorCauses` object specifies the correct attribute. See [JSON response payload objects - error](/docs/concepts/inline-hooks/#error).
+   * The `location` of `errorSummary` in the `errorCauses` object specifies the request object's user profile attribute. See [JSON response payload objects - error](/docs/concepts/inline-hooks/#error).
 
 * If you don't return a value for the `errorCauses` object, and deny the user's registration attempt through the `commands` object in your response to Okta, one of the following generic messages appears to the end user:</br></br>
       `Registration cannot be completed at this time.`</br></br>

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -164,7 +164,7 @@ For the Registration Inline Hook, the `error` object provides a way of displayin
 
 * If you're using the Okta Sign-In Widget for Profile Enrollment, only the `errorSummary` messages of the `errorCauses` objects that your external service returns appear as inline errors, given the following:
 
-   * You don't customize the error handling behavior of the Widget.
+   * You don't customize the error handling behavior of the widget.
    * The `location` of `errorSummary` in the `errorCauses` object specifies the correct attribute. See [JSON response payload objects - error](/docs/concepts/inline-hooks/#error).
 
 * If you don't return a value for the `errorCauses` object, and deny the user's registration attempt through the `commands` object in your response to Okta, one of the following generic messages appears to the end user:</br></br>

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -215,7 +215,28 @@ If there is a response timeout after receiving the Okta request, the Okta proces
 
 ```json
 { "commands":[
-                          { "type":"com.okta.action.update",
+{
+  "commands": [
+    {
+      "type": "com.okta.action.update",
+      "value": {
+        "registration": "DENY"
+      }
+    }
+  ],
+  "error": {
+    "errorSummary": "Incorrect email address. Please contact your admin.",
+    "errorCauses": [
+      {
+        "errorSummary": "Only example.com emails can register.",
+        "reason": "INVALID_EMAIL_DOMAIN",
+        "locationType": "body",
+        "location": "data.userProfile.login",
+        "domain": "end-user"
+      }
+    ]
+  }
+}
                             "value":{ "registration": "DENY"} }
                                    ],
                          "error": {


### PR DESCRIPTION
## Description
- **What's changed?** Update description of behaviour of error object for inline registration hook. Update format of sample JSON response.
- **Is this PR related to a Monolith release?** Yes. 2022.03.2

### Netlify links:

- **March 14:** https://622fbae83da6a4284cc6b021--reverent-murdock-829d24.netlify.app/docs/reference/registration-hook/#error
- **March 11:** https://622bc67e4317985eeca3d2bb--reverent-murdock-829d24.netlify.app/docs/reference/registration-hook/#error
- **March 10:** https://622ab93f5798c83b1068ccd0--reverent-murdock-829d24.netlify.app/docs/reference/registration-hook/#error

### Resolves:
- [OKTA-477959](https://oktainc.atlassian.net/browse/OKTA-477959)
