### PR TITLE
TBS OKTA-474759 Add user.status note to EL docs

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language-in-identity-engine/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language-in-identity-engine/index.md
@@ -36,6 +36,8 @@ The following operators and functionality offered by SpEL aren't supported in Ok
 
 When you create an Okta expression, you can reference any property that exists in an Okta User Profile in addition to some top-level User properties.
 
+> **Note:** You can't use `user.status` with group rules. See [Group rule operations](/docs/reference/api/groups/#group-rule-operations) and [Create group rules](https://help.okta.com/okta_help.htm?id=ext-okta-method-creategrouprule).
+
 | Syntax                             | Definitions                                                                              | Examples                                                       |
 | --------                           | ----------                                                                               | ------------                                                   |
 | `user.$property`                  | `user` - references the Okta user<br>`property` - top-level property variable name<br>Values: `id`, `status`, `created`, `lastUpdated`, `passwordChanged`, `lastLogin`   | `user.id`<br>`user.status`<br>`user.created`   |

--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language-in-identity-engine/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language-in-identity-engine/index.md
@@ -36,7 +36,7 @@ The following operators and functionality offered by SpEL aren't supported in Ok
 
 When you create an Okta expression, you can reference any property that exists in an Okta User Profile in addition to some top-level User properties.
 
-> **Note:** You can't use `user.status` with group rules. See [Group rule operations](/docs/reference/api/groups/#group-rule-operations) and [Create group rules](https://help.okta.com/okta_help.htm?id=ext-okta-method-creategrouprule).
+> **Note:** You can't use `user.status` with group rules. See [Group rule operations](/docs/reference/api/groups/#group-rule-operations) and [Create group rules](https://help.okta.com/okta_help.htm?type=wf&id=ext-okta-method-creategrouprule).
 
 | Syntax                             | Definitions                                                                              | Examples                                                       |
 | --------                           | ----------                                                                               | ------------                                                   |

--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language-in-identity-engine/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language-in-identity-engine/index.md
@@ -36,7 +36,7 @@ The following operators and functionality offered by SpEL aren't supported in Ok
 
 When you create an Okta expression, you can reference any property that exists in an Okta User Profile in addition to some top-level User properties.
 
-> **Note:** You can't use `user.status` with group rules. See [Group rule operations](/docs/reference/api/groups/#group-rule-operations) and [Create group rules](https://help.okta.com/okta_help.htm?type=wf&id=ext-okta-method-creategrouprule).
+> **Note:** You can't use the `user.status` expression with group rules. See [Group rule operations](/docs/reference/api/groups/#group-rule-operations) and [Create group rules](https://help.okta.com/okta_help.htm?type=wf&id=ext-okta-method-creategrouprule).
 
 | Syntax                             | Definitions                                                                              | Examples                                                       |
 | --------                           | ----------                                                                               | ------------                                                   |


### PR DESCRIPTION
## Description

- **What's changed?** Adds a note that `user.status` doesn't work with group rules.
- **Is this PR related to a Monolith release?** No.

### Netlify builds:
- https://6233b93713f2c10f34d932e2--reverent-murdock-829d24.netlify.app/docs/reference/okta-expression-language-in-identity-engine/#okta-user-profile

### Resolves:

* [OKTA-474759](https://oktainc.atlassian.net/browse/OKTA-474759)
