### PR TITLE
Edit developer doc to use multiOptionalFactorEnroll in recovery flow

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
@@ -6506,6 +6506,16 @@ Validates a [recovery token](#recovery-token) that was distributed to the end us
 | Parameter     | Description                                                                                                    | Param Type | DataType | Required |
 | ------------- | ----------------------------------------------------------------------------------------------------------     | ---------- | -------- | -------- |
 | recoveryToken | [Recovery token](#recovery-token) that was distributed to the end user via out-of-band mechanism such as email | Body       | String   | TRUE     |
+| options                                        | Opt-in features for the authentication transaction                                                               | Body       | [Options object](#options-object) | FALSE    |    
+
+##### Options object
+
+The authentication transaction [state machine](#transaction-state) can be modified via the following opt-in features:
+
+| Property                   | Description                                                                                                                                                | DataType | Nullable | Unique | Readonly |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------- | ------ | -------- |
+| multiOptionalFactorEnroll  | Transitions transaction back to `MFA_ENROLL` state after successful Factor enrollment when additional optional factors are available for enrollment        | Boolean  | TRUE     | FALSE  | FALSE    |
+
 
 ##### Response parameters for verify recovery token
 

--- a/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
@@ -6510,7 +6510,7 @@ Validates a [recovery token](#recovery-token) that was distributed to the end us
 
 ##### Options object
 
-The authentication transaction [state machine](#transaction-state) can be modified via the following opt-in features:
+You can modify the authentication transaction [state machine](#transaction-state) through the following opt-in features:
 
 | Property                   | Description                                                                                                                                                | DataType | Nullable | Unique | Readonly |
 | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------- | ------ | -------- |


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- Authn recovery flow `/api/v1/authn/recovery/token` can use parameter multiOptionalFactorEnroll in options like `/api/v1/authn`.
![Screen Shot 2022-03-21 at 10 37 29 AM](https://user-images.githubusercontent.com/52258355/159331909-c5aeea32-283d-42fb-920b-068f5e553826.png)


- Monthly release: 2022.04.0
- Ticket to GA FF `ENG_HONOR_MULTI_OPTIONAL_FACTOR_ENROLL` for all preview orgs: https://oktainc.atlassian.net/browse/OKTA-473102

### Resolves:

* [OKTA-473105](https://oktainc.atlassian.net/browse/OKTA-473105)
