### PR TITLE
reposition get set up guides

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/index.md
@@ -1,6 +1,6 @@
 ---
-title: Download and set up the SDK, Sign-In Widget, and sample app
-excerpt: Download and set up the SDK, Sign-In Widget, and sample app
+title: Download and set up the SDK, Sign-In Widget, and sample apps
+excerpt: Download and set up the SDK, Sign-In Widget, and sample apps
 layout: Guides
 sections:
  - main

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-download-setup-app/main/index.md
@@ -1,5 +1,5 @@
 ---
-title: Download and set up the SDK, Sign-In Widget, and sample app
+title: Download and set up the SDK, Sign-In Widget, and sample apps
 ---
 
 <ApiLifecycle access="ie" />

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-org-setup/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-org-setup/index.md
@@ -1,5 +1,5 @@
 ---
-title: Get set up
+title: Set up your Okta org
 excerpt: Create and set up your Okta org for embedded authentication
 layout: Guides
 sections:

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-org-setup/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-org-setup/main/index.md
@@ -1,10 +1,10 @@
 ---
-title: Get set up
+title: Set up your Okta org
 ---
 
 <ApiLifecycle access="ie" />
 
-This guide covers how to create and set up your Okta org before you can run the provided sample apps or integrate the SDK or Widget into your own app.
+This guide covers how to create and set up your Okta org before you can [run the Identity Engine sample apps](/docs/guides/oie-embedded-common-run-samples/) or [integrate the SDK or Widget](/docs/guides/oie-embedded-common-download-setup-app/) into your own app.
 
 ---
 

--- a/packages/@okta/vuepress-theme-prose/const/navbar.const.js
+++ b/packages/@okta/vuepress-theme-prose/const/navbar.const.js
@@ -131,23 +131,6 @@ export const guides = [
         subLinks: [
           { title: "Overview", guideName: "sign-in-overview" },
           {
-            title: "Set up to run Identity Engine sample apps",
-            subLinks: [
-              {
-                title: "Get set up",
-                guideName: "oie-embedded-common-org-setup",
-              },
-              {
-                title: "Download and set up the sample app",
-                guideName: "oie-embedded-common-download-setup-app",
-              },
-              {
-                title: "Run the sample apps",
-                guideName: "oie-embedded-common-run-samples",
-              },
-            ]
-          },
-          {
             title: "Redirect authentication",
             subLinks: [
               {
@@ -175,6 +158,23 @@ export const guides = [
           {
             title: "Embedded authentication",
             subLinks: [
+              {
+                title: "Get set up",
+                subLinks: [
+                  {
+                    title: "Set up your Okta org",
+                    guideName: "oie-embedded-common-org-setup",
+                  },
+                  {
+                    title: "Download and set up the SDK, Sign-In Widget, and sample apps",
+                    guideName: "oie-embedded-common-download-setup-app",
+                  },
+                  {
+                    title: "Run the sample apps",
+                    guideName: "oie-embedded-common-run-samples",
+                  },
+                ]
+              },
               {
                 title: "Auth JS fundamentals",
                 guideName: "auth-js"


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** The “Get set up to run Identity Engine sample apps“ section of “Sign users in“ is confusingly positioned, and the flow doesn't work very well. This PR aims to fix that.
  - Netlify deploy available at https://6239ed9c2fc59825fe5dc1b2--reverent-murdock-829d24.netlify.app/docs/guides/oie-embedded-common-org-setup/android/main/  
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-481536](https://oktainc.atlassian.net/browse/OKTA-481536)
