### PR TITLE
OKTA-482458 Remove H.O.C links with /en/prod and /en/oie, and replace with aliases

### DIFF
--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -338,7 +338,7 @@ redirects:
   - from: /docs/guides/add_mfa.html
     to: /docs/guides/mfa/index.html
   - from: /use_cases/mobile/okta_mobile_connect/index.html
-    to: https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Okta_Mobile_Connect
+    to: https://help.okta.com/okta_help.htm?id=ext_Okta_Mobile_Connect
   - from: /docs/api/reference/apps.html
     to: /docs/reference/api/apps/
   - from: /docs/reference/api/users.html
@@ -374,7 +374,7 @@ redirects:
   - from: /docs/reference/api/sessions.html
     to: /docs/reference/api/sessions/
   - from: /docs/guides/okta_mobile_connect
-    to: https://help.okta.com/en/prod/okta_help_CSH.htm#ext_Okta_Mobile_Connect
+    to: https://help.okta.com/okta_help.htm?id=ext_Okta_Mobile_Connect
   - from: /docs/reference/okta-expression-language/index
     to: /docs/reference/okta-expression-language/
   - from: /docs/reference/api-overview/getting_a_token/index.html
@@ -2280,9 +2280,9 @@ redirects:
   - from: /docs/reference/api/oie-policy-types/index.html
     to: /docs/reference/api/policy/
   - from: /docs/concepts/ie-intro/index.html
-    to: https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie/
+    to: https://help.okta.com/okta_help.htm?type=oie&id=ext-get-started-oie
   - from: /docs/concepts/ie-intro
-    to: https://help.okta.com/en/oie/okta_help_CSH.htm#ext-get-started-oie/
+    to: https://help.okta.com/okta_help.htm?type=oie&id=ext-get-started-oie
   - from: /docs/guides/sign-into-web-app-remediation/-/before-you-begin/index.html
     to: /docs/guides/oie-embedded-sdk-use-cases/oie-embedded-sdk-use-case-overview/
   - from: /docs/guides/sign-into-web-app-remediation/-/configure-packages/index.html

--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/authcode/flow-diagram.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/authcode/flow-diagram.md
@@ -32,7 +32,7 @@ At a high-level, this flow has the following steps:
 3. The user authenticates.
 
     For Okta to authenticate the user credentials, Okta needs user profile data.
-    See [Add a user using Console](https://help.okta.com/en/prod/Content/Topics/users-groups-profiles/usgp-add-users.htm), [Import Users](/docs/guides/password-import-inline-hook/), and the [Users API](/docs/reference/api/users/). Alternatively, you can [set up self-service registration](/docs/guides/set-up-self-service-registration/) to allow users to register their membership with the app.
+    See [Add a user using Console](https://help.okta.com/okta_help.htm?id=ext-usgp-add-users), [Import Users](/docs/guides/password-import-inline-hook/), and the [Users API](/docs/reference/api/users/). Alternatively, you can [set up self-service registration](/docs/guides/set-up-self-service-registration/) to allow users to register their membership with the app.
 
 4. After the user is authenticated, the browser receives an authorization code from the Auth Server (Okta). The authorization code is passed to your app.
 5. Your app sends this code and the client secret to Okta. See [Exchange the code for tokens](#exchange-the-code-for-tokens).

--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/authcodepkce/flow-diagram.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/authcodepkce/flow-diagram.md
@@ -37,7 +37,7 @@ app -> client: Response
 4. The user authenticates.
 
     For Okta to authenticate the user credentials, Okta needs user profile data.
-    See [Add a user using Console](https://help.okta.com/en/prod/Content/Topics/users-groups-profiles/usgp-add-users.htm), [Import Users](/docs/guides/password-import-inline-hook/), and the [Users API](/docs/reference/api/users/). Alternatively, you can [set up self-service registration](/docs/guides/set-up-self-service-registration/) to allow users to register their membership with the app.
+    See [Add a user using Console](https://help.okta.com/okta_help.htm?id=ext-usgp-add-users), [Import Users](/docs/guides/password-import-inline-hook/), and the [Users API](/docs/reference/api/users/). Alternatively, you can [set up self-service registration](/docs/guides/set-up-self-service-registration/) to allow users to register their membership with the app.
 
 5. Okta redirects back to your native application with an authorization code.
 6. Your application sends this code, along with the code verifier, to Okta. See [Exchange the code for tokens](#exchange-the-code-for-tokens).

--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/implicit/flow-diagram.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/implicit/flow-diagram.md
@@ -30,7 +30,7 @@ The Implicit flow contains the following interaction steps:
 3. User authenticates with the Auth Server (Okta) and provides consent.
 
     For Okta to authenticate the user credentials, Okta needs user profile data.
-    See [Add a user using Console](https://help.okta.com/en/prod/Content/Topics/users-groups-profiles/usgp-add-users.htm), [Import Users](/docs/guides/password-import-inline-hook/, and the [Users API](/docs/reference/api/users/). Alternatively, you can [set up self-service registration](/docs/guides/set-up-self-service-registration/) to allow users to register their membership with the app.
+    See [Add a user using Console](https://help.okta.com/okta_help.htm?id=ext-usgp-add-users), [Import Users](/docs/guides/password-import-inline-hook/, and the [Users API](/docs/reference/api/users/). Alternatively, you can [set up self-service registration](/docs/guides/set-up-self-service-registration/) to allow users to register their membership with the app.
 
 4. Okta redirects the browser back to the specified redirect URI, along with access and ID tokens as a hash fragment in the URI.
 


### PR DESCRIPTION
## Description:
- **What's changed?** Remove Product doc (H.O.C.) links with `/en/prod/` and '/en/oie` and replace with alias links.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-482458](https://oktainc.atlassian.net/browse/OKTA-482458)
