### PR TITLE
Correcting 2 examples for null and blank

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
@@ -339,10 +339,10 @@ To catch User attributes that are null or blank, use the following valid conditi
 `user.employeeNumber != "" AND user.employeeNumber != null ? user.employeeNumber : user.nonEmployeeNumber`
 
 If a Profile attribute has never been populated, catch it with the following expression:<br>
-`user.employeeNumber != null`
+`user.employeeNumber == null`
 
 If a Profile attribute was populated in the past but the content is removed, it's no longer `null` but an empty string. To catch these empty strings, use the following expression:<br>
-`user.employeeNumber != ""`
+`user.employeeNumber == ""`
 
 ## Popular expressions
 


### PR DESCRIPTION
The 2 examples for checking for null and blank attributes are wrong because they use the inequality ("!=") instead of the equality ("==") operators. 
This PR fixes the two examples.

<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
  - The 2 examples for checking for null and blank attributes are wrong because they use the inequality ("!=") instead of the equality ("==") operators. 
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->
  Unsure
### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
