### PR TITLE
remove inappropriate instruction about contacting rep

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/session-cookie/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/session-cookie/main/index.md
@@ -26,7 +26,7 @@ Okta uses an HTTP session cookie to provide access to your Okta org and apps acr
 
 Okta sessions are created and managed with the [Session API](/docs/reference/api/sessions/). A session token is sent as part of a request, contained in a `sessionToken` parameter. If the request is successful, the session cookie is set by a `Set-Cookie` header in the response.
 
-> **Important**: By default, Okta Classic orgs ignore the `sessionToken` in a request if there is already a session cookie set in the browser. If required, you can change this default behavior for a specific org. Contact your Okta rep for more information.
+> **Important**: By default, Okta Classic orgs ignore the `sessionToken` in a request if there is already a session cookie set in the browser.
 
 ## Retrieve a session cookie through the OpenID Connect authorization endpoint
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Originally I filed https://github.com/okta/okta-developer-docs/pull/3159 to add a note about session cookies being preferred over sessionTokens. However, we included some information about contacting your Okta rep if you wanted to reverse this behavior, but this caused a different set of problems because it was not supposed to be a general option open to all customers. This PR removes that part. 
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-477991](https://oktainc.atlassian.net/browse/OKTA-477991)
