### PR TITLE
mark update application policy reference as OIE-only

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -3681,6 +3681,8 @@ Content-Type: application/json
 
 ### Update application policy
 
+<ApiLifecycle access="ie" />
+
 <ApiOperation method="put" url="/api/v1/apps/${applicationId}/policies/${policyId}" />
 
 Assign an application to a specific policy. This un-assigns the application from its currently assigned policy.


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Ram from dev support informed me that the [update application policy](https://developer.okta.com/docs/reference/api/apps/#update-application-policy) feature of the `/apps` API is OIE-only. This PR marks it with an Identity Engine banner.
- **Is this PR related to a Monolith release?** No