### PR TITLE
Updates to Groups API - MinMax length of Group Rule names

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
@@ -1141,15 +1141,15 @@ Creates a Group rule to dynamically add users to the specified Group if they mat
 ##### Request parameters
 
 
-| Parameter                           | Description                                             | ParamType | DataType                          | Required | Default |
-| ----------------------------------- | ------------------------------------------------------- | --------- | --------------------------------- | -------- | ------- |
-| name                                | name of the Group rule                                   | Body      | String                            | TRUE     |         |
-| type                                | `group_rule`                                            | Body      | String                            | TRUE     |         |
-| conditions.expression.value         | Okta expression that would result in a boolean value    | Body      | String                            | TRUE     |         |
-| conditions.expression.type          | `urn:okta:expression:1.0`                               | Body      | String                            | TRUE     |         |
-| conditions.people.users.exclude     | userIds that would be excluded when rules are processed | Body      | String                            | FALSE    |         |
-| conditions.people.groups.exclude    | currently not supported                                 | Body      | String                            | FALSE    |         |
-| actions.assignUserToGroups.groupIds | Array of groupIds to which users would be added.        | Body      | String                            | TRUE     |         |
+| Parameter                           | Description                                             | ParamType | DataType                          | Required | 
+| ----------------------------------- | ------------------------------------------------------- | --------- | --------------------------------- | -------- | 
+| name                                | name of the Group rule (min character 1; max characters 50)                                  | Body      | String                            | TRUE     |         |
+| type                                | `group_rule`                                            | Body      | String                            | TRUE     | 
+| conditions.expression.value         | Okta expression that would result in a boolean value    | Body      | String                            | TRUE     | 
+| conditions.expression.type          | `urn:okta:expression:1.0`                               | Body      | String                            | TRUE     | 
+| conditions.people.users.exclude     | userIds that would be excluded when rules are processed | Body      | String                            | FALSE    | 
+| conditions.people.groups.exclude    | currently not supported                                 | Body      | String                            | FALSE    | 
+| actions.assignUserToGroups.groupIds | Array of groupIds to which users would be added.        | Body      | String                            | TRUE     |
 
 ##### Response parameters
 
@@ -1241,15 +1241,15 @@ You can't currently update the action section.
 ##### Request parameters
 
 
-| Parameter                           | Description                                    | ParamType | DataType                          | Required | Default |
-| ----------------------------------- | ---------------------------------------------- | --------- | --------------------------------- | -------- | ------- |
-| actions.assignUserToGroups.groupIds | Array of groupIds to which users would be added| Body      | String                            | TRUE     |         |
-| conditions.expression.type           | `urn:okta:expression:1.0 `                     | Body      | String                            | TRUE     |         |
-| conditions.expression.value          | okta expression that would result in a boolean value | Body      | String                     | TRUE     |         |
-| conditions.people.groups.exclude     | currently not supported                        | Body      | String                            | FALSE    |         |
+| Parameter                           | Description                                    | ParamType | DataType                          | Required | 
+| ----------------------------------- | ---------------------------------------------- | --------- | --------------------------------- | -------- | 
+| actions.assignUserToGroups.groupIds | Array of groupIds to which users would be added| Body      | String                            | TRUE     | 
+| conditions.expression.type           | `urn:okta:expression:1.0 `                     | Body      | String                            | TRUE     |
+| conditions.expression.value          | okta expression that would result in a boolean value | Body      | String                     | TRUE     | 
+| conditions.people.groups.exclude     | currently not supported                        | Body      | String                            | FALSE    | 
 | conditions.people.users.exclude      | userIds that would be excluded when rules are processed | Body      | String                   | FALSE    |         |
-| id                                  | ID of the rule to be updated                   | URL       | String                            | TRUE     |         |
-| name                                | name of the Group                              | Body      | String                            | TRUE     |         |
+| id                                  | ID of the rule to be updated                   | URL       | String                            | TRUE     | 
+| name                                | name of the Group rule (min character 1; max characters 50)                              | Body      | String                            | TRUE     | 
 
 ##### Response parameters
 


### PR DESCRIPTION
## Description:
- **What's changed?** Updated two tables that referenced the group rule name parameter and description (Create a Group Rule Name and Update a Group Rule Name) to add that names can be a minimum of 1 character and a maximum of 50 characters. Tested with Admin Console and Postman.

Also deleted a redundant "Default" column in both tables.

- **Is this PR related to a Monolith release?** n/a

### Resolves:

* [OKTA-480451](https://oktainc.atlassian.net/browse/OKTA-480451)
