### PR TITLE
OKTA-488222: Clarify timestamp attribute unit to be milliseconds.

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/csi-delauth-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/csi-delauth-hook/index.md
@@ -36,8 +36,8 @@ The following sections describe each of these operations and the objects in thei
 To support user lifecycle and credential lifecycle operations, we expect the external source to provide certain attributes:
 
 - `status`: The status of the user, with a value of ACTIVE or DISABLED
-- `passwordExpiryTime`: The time when the user's password expires, in the form of Epoch time
-- `lastUpdate`: When the user's profile was last updated in the external source, in the form of Epoch time
+- `passwordExpiryTime`: The time when the user's password expires, in the form of Epoch time as milliseconds
+- `lastUpdate`: When the user's profile was last updated in the external source, in the form of Epoch time as milliseconds
 
 ## Delegated authentication request
 


### PR DESCRIPTION
Resolves: OKTA-488222

<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Added text to clarify the unit for two timestamp attributes for external users.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-488222](https://oktainc.atlassian.net/browse/OKTA-488222)
