### PR TITLE
Correct prompt describing how system log event fields are tokenized and matched against q param values.

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
@@ -705,7 +705,7 @@ The following are examples of common keyword filtering:
 * Events that mention a specific URL: `q=interestingURI.com`
 * Events that mention a specific person: `q=firstName lastName`
 
-> **Note:** When hyphens are present in an event instance's attribute value, they are split and added to the list of matching candidates, in addition to the full hyphenated value. Therefore, events that contain the text `XOxBw-2JIRnCFd0gG0GjHAAABjY` can be matched with a `q` value of `XOxBw`, `2JIRnCFd0gG0GjHAAABjY`, or `XOxBw-2JIRnCFd0gG0GjHAAABjY`.
+> **Note:** When hyphens are present in an event instance's attribute value, they are split and added to the list of matching candidates, in addition to the full hyphenated value. Therefore, events that contain the text `XOxBw-2JIRnCFd0gG0GjHAAABjY` are matched with a `q` value of `XOxBw`, `2JIRnCFd0gG0GjHAAABjY`, or `XOxBw-2JIRnCFd0gG0GjHAAABjY`.
 
 ###### Datetime filter
 

--- a/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
@@ -705,7 +705,7 @@ The following are examples of common keyword filtering:
 * Events that mention a specific URL: `q=interestingURI.com`
 * Events that mention a specific person: `q=firstName lastName`
 
-> **Note:** When hyphens are present in an event instance's attribute value, they are split and added to the list of matching candidates, in addition to the full hyphenated value. Therefore, a `q` value of `XOxBw-2JIRnCFd0gG0GjHAAABjY` matches events that contain the text `XOxBw`, `2JIRnCFd0gG0GjHAAABjY`, or `XOxBw-2JIRnCFd0gG0GjHAAABjY`.
+> **Note:** When hyphens are present in an event instance's attribute value, they are split and added to the list of matching candidates, in addition to the full hyphenated value. Therefore, events that contain the text `XOxBw-2JIRnCFd0gG0GjHAAABjY` can be matched with a `q` value of `XOxBw`, `2JIRnCFd0gG0GjHAAABjY`, or `XOxBw-2JIRnCFd0gG0GjHAAABjY`.
 
 ###### Datetime filter
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Correct **`Note`** describing how system log event fields are tokenized and matched against `q` param values. 
- **Is this PR related to a Monolith release?** Nope

### Resolves:

* [OKTA-480452](https://oktainc.atlassian.net/browse/OKTA-480452)
