### PR TITLE
OKTA-490299 Update Github IdP mapping variables appuser.id and idpuser.id variables

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/social-login/main/github/noemail.md
+++ b/packages/@okta/vuepress-site/docs/guides/social-login/main/github/noemail.md
@@ -1,6 +1,6 @@
 ## Handle users without email addresses
 
-GitHub doesn’t always provide email addresses for users that it authenticates, such as when the GitHub setting for **Keep email addresses private** is enabled. However, Okta requires an email address for its users to be able to sign in. You can support users who don't have email addresses by using information from GitHub to generate email addresses for them.
+GitHub doesn’t always provide email addresses for users that it authenticates, such as when the GitHub setting **Keep email addresses private** is enabled. However, Okta requires an email address for its users to be able to sign in. You can support users who don't have email addresses by using information from GitHub to generate email addresses for them.
 
 For example, you might generate email addresses using the `example.com` domain. This ensures that your GitHub users have email addresses that Okta can use, but can be easily identified as invalid should you ever want to replace them with valid email addresses. They're guaranteed to be invalid as `example.com` is a reserved domain. See [Reserved Top Level DNS Names (RFC2606)](https://datatracker.ietf.org/doc/html/rfc2606) for more information on reserved domains.
 

--- a/packages/@okta/vuepress-site/docs/guides/social-login/main/github/noemail.md
+++ b/packages/@okta/vuepress-site/docs/guides/social-login/main/github/noemail.md
@@ -20,12 +20,12 @@ To generate user login values and email addresses for GitHub users, do the follo
 
 1. Set the expression that maps to the Okta user's `login` value to:
    ```
-   appuser.email == null ? appuser.id + '@github.example.com' : appuser.email
+   appuser.email == null ? appuser.github_id + '@github.example.com' : appuser.email
    ```
 
 1. Set the expression that maps to the Okta user's `email` value to:
    ```
-   appuser.email == null ? appuser.id + '@github.example.com' : appuser.email
+   appuser.email == null ? appuser.github_id + '@github.example.com' : appuser.email
    ```
 
 1. Click **Save Mappings**
@@ -38,9 +38,9 @@ Similarly, you can map the IdP username by doing the following:
 
 1. Locate GitHub in the list of providers, and then click **Configure** > **Configure Identity Provider**.
 
-1. Set the expression for **IdP Username** to: 
-```
-   idpuser.email == null ? idpuser.id + '@github.example.com' : idpuser.email
-```
+1. Set the expression for **IdP Username** to:
+   ```
+   idpuser.email == null ? idpuser.github_id + '@github.example.com' : idpuser.email
+   ```
 
 1. Click **Update Identity Provider**

--- a/packages/@okta/vuepress-site/docs/guides/social-login/main/github/noemail.md
+++ b/packages/@okta/vuepress-site/docs/guides/social-login/main/github/noemail.md
@@ -1,6 +1,6 @@
 ## Handle users without email addresses
 
-GitHub doesn’t always provide email addresses for users that it authenticates, but Okta requires an email address for its users to be able to sign in. You can support users who don't have email addresses by using information from GitHub to generate email addresses for them.
+GitHub doesn’t always provide email addresses for users that it authenticates, such as when the GitHub setting for **Keep email addresses private** is enabled. However, Okta requires an email address for its users to be able to sign in. You can support users who don't have email addresses by using information from GitHub to generate email addresses for them.
 
 For example, you might generate email addresses using the `example.com` domain. This ensures that your GitHub users have email addresses that Okta can use, but can be easily identified as invalid should you ever want to replace them with valid email addresses. They're guaranteed to be invalid as `example.com` is a reserved domain. See [Reserved Top Level DNS Names (RFC2606)](https://datatracker.ietf.org/doc/html/rfc2606) for more information on reserved domains.
 


### PR DESCRIPTION
## Description:
- **What's changed?** Updated GitHub variable mappings (`appuser.id` and `idpuser.id`) variables to align with changes in OKTA-460058.
- **Is this PR related to a Monolith release?** Yes, 2022.05.0
- 

### Resolves:

* [OKTA-490299](https://oktainc.atlassian.net/browse/OKTA-490299)
