### PR TITLE
OKTA-492199 Fix Access token code block in Customize tokens returned ... guide

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/customize-tokens-groups-claim/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-tokens-groups-claim/main/index.md
@@ -98,7 +98,7 @@ To test the full authentication flow that returns an ID token or an access token
     **Access token**
 
     ```bash
-https://yourRedirectUriHere.com#access_token=eyJraWQiOiIxLVN5M2w2dFl2VTR4MXBSLXR5cVZQWERX[...]YNXrsr1gTzD6C60h0UfLiLUhA&token_type=Bearer&expires_in=3600&scope=openid&state=myState
+    https://yourRedirectUriHere.com#access_token=eyJraWQiOiIxLVN5M2w2dFl2VTR4MXBSLXR5cVZQWERX[...]YNXrsr1gTzD6C60h0UfLiLUhA&token_type=Bearer&expires_in=3600&scope=openid&state=myState
     ```
 
 5. To check the returned ID token or access token payload, you can copy the value and paste it into any JWT decoder (for example: <https://token.dev>). Using a JWT decoder, confirm that the token contains all of the claims that you are expecting, including the custom one. If you specified a nonce, that is also included.


### PR DESCRIPTION
## Description:
- **What's changed?** Fix Access token code block in Customize tokens returned from Okta with a Group claims > Request a token that contains the custom claim > step 4 (tab was added)
- **Is this PR related to a Monolith release?** No
### Resolves:

* [OKTA-492199](https://oktainc.atlassian.net/browse/OKTA-492199)
