### PR TITLE
Refresh Tokens for SPAs (refresh token rotation) is now GA

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/index.md
@@ -189,8 +189,6 @@ On your back-end (the API), make sure that you check for valid tokens in incomin
 
 To enable access token renewal you must obtain a refresh token. See [Get a refresh token with the code flow](/docs/guides/refresh-tokens/main/#get-a-refresh-token-with-the-code-flow).
 
-> **Note:** Using a refresh token with a SPA is an [Early Access](/docs/reference/releases-at-okta/#early-access-ea) feature. To enable it, contact [Support](https://support.okta.com/help/open_case).
-
 Alternatively, you can renew tokens by hitting the `/authorize` endpoint. See [Get a new access token/ID token silently for your SPA ](/docs/guides/refresh-tokens/main/#renew-access-and-id-tokens-with-spas).
 
 ## Next steps


### PR DESCRIPTION
## Description:
- **What's changed?** This PR is a duplicate of PR 3232 (currently non-responsive). It removes the EA note for refresh tokens.
- **Is this PR related to a Monolith release?** No

### Resolves:

* PR 3232 (branch askouras:patch-10)
