### PR TITLE
Update to the Okta email authenticator guide - May 4th publish

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/authenticators-okta-email/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-okta-email/main/index.md
@@ -93,10 +93,9 @@ Out of the box, the Embedded SDK solution supports the Email Magic Link feature 
 | ----------------------------| ------------------|------------------------|-------------|-------------------------|
 | Email Challenge             | Sign-in with email - challenge                           | Email challenge   | [Magic link](#integrate-email-challenge-with-magic-links), OTP  | No
 | Forgot Password             | Self-service password recovery                           | Email challenge   | [Magic link](#integrate-email-challenge-with-magic-links), OTP  | Yes, add `otp` and `state` parameters. See <StackSnippet snippet="custompwdguide" inline />.
-| Email Factor Verification   | Self-service registration, Sign-in with email - enroll   | Email enrollment  | [OTP](#integrate-email-enrollment-with-otp)              | Yes, remove magic link
+| Email Factor Verification   | Self-service registration, Sign-in with email - enroll   | Email enrollment  | Magic link, [OTP](#integrate-email-enrollment-with-otp)              | No
 
 > **Note:** This guide uses the sign-in with email use cases to describe how to integrate email enrollment and challenge.
-
 
 ## Update configurations
 


### PR DESCRIPTION
## Description:
Updated Email Factor Verification template row in matrix to show support for Magic Link and OTP

**THIS PR NEEDS TO BE PUBLISHED ON MAY 4th**

### Resolves:

* [OKTA-491148](https://oktainc.atlassian.net/browse/OKTA-491148)

Deploy link:
https://626b4da56e25f410a0334198--reverent-murdock-829d24.netlify.app/docs/guides/authenticators-okta-email/aspnet/main/#know-which-use-cases-support-magic-link-and-otp