### PR TITLE
TBS OKTA-489038 Updates language in Linked Objects API doc

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/linked-objects/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/linked-objects/index.md
@@ -47,7 +47,7 @@ Thus, you can create chains of relationships (Jane > Bob > Joe > Frank) or termi
 
 Then, if you create another Linked Object relationship for scrum team membership, you could assign relationships to the same four users:
 
-* Bob is the scrum master for the Identity Scrum team.
+* Bob is the scrum lead for the Identity Scrum team.
 * Joe and Frank are both contributors to the team.
 
 Bob can be the `primary` for a Manager:Subordinate, an `associated` user for that same Linked Object definition, and also the `primary` for the Scrummaster:Contributor Linked Object definition.


### PR DESCRIPTION
## Description
- **What's changed?** Updates "scrum master" to "scrum lead".
- **Is this PR related to a Monolith release?** No.

### Resolves:

* [OKTA-489038](https://oktainc.atlassian.net/browse/OKTA-489038)
