### PR TITLE
OKTA-496425 Add redirect for /docs/guides/build-provisioning-integration/-/overview/

### DIFF
--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -1895,6 +1895,8 @@ redirects:
     to: /docs/guides/submit-app/-/main/#understand-the-submission-process
   - from: /docs/guides/build-provisioning-integration/test-scim-server/index.html
     to: /docs/guides/scim-provisioning-integration-prepare/main/#test-your-scim-api
+  - from: /docs/guides/build-provisioning-integration/-/overview/
+    to: /docs/guides/scim-provisioning-integration-overview/
   - from: /docs/guides/build-sso-integration/integrate/index.html
     to: /docs/guides/build-sso-integration/openidconnect/main/#create-your-integration
   - from: /docs/guides/build-sso-integration/get-help/index.html

--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -1895,7 +1895,9 @@ redirects:
     to: /docs/guides/submit-app/-/main/#understand-the-submission-process
   - from: /docs/guides/build-provisioning-integration/test-scim-server/index.html
     to: /docs/guides/scim-provisioning-integration-prepare/main/#test-your-scim-api
-  - from: /docs/guides/build-provisioning-integration/-/overview/
+  - from: /docs/guides/build-provisioning-integration/-/overview/index.html
+    to: /docs/guides/scim-provisioning-integration-overview/
+  - from: /docs/guides/build-provisioning-integration/-/overview
     to: /docs/guides/scim-provisioning-integration-overview/
   - from: /docs/guides/build-sso-integration/integrate/index.html
     to: /docs/guides/build-sso-integration/openidconnect/main/#create-your-integration


### PR DESCRIPTION
## Description:
- **What's changed?** Add redirect for /docs/guides/build-provisioning-integration/-/overview/. This link is coming in from https://www.okta.com/integrate/ > Start building > step 2
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-496425](https://oktainc.atlassian.net/browse/OKTA-496425)
