### PR TITLE
OKTA-493049 Add new social idPs to the IdPs API

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
@@ -7,20 +7,11 @@ category: management
 
 The Okta Identity Providers API provides operations to manage federations with external Identity Providers (IdP). For example, your app can support signing in with credentials from Apple, Facebook, Google, LinkedIn, Microsoft, an enterprise IdP using SAML 2.0, or an IdP using the OpenID Connect (`OIDC`) protocol.
 
+See [Add and external Identity Provider](/docs/guides/identity-providers/) for detailed IdP set up guides.
+
 ## Get started
 
 Explore the Identity Providers API: [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/2635b07ecc5dc2435ade)
-
-## Setup guides
-
-Each IdP requires some setup. Use the Okta setup guide for your IdP:
-
-* [Apple](/docs/guides/add-an-external-idp/apple/main/)
-* [Facebook](/docs/guides/add-an-external-idp/facebook/main/)
-* [Google](/docs/guides/add-an-external-idp/google/main/)
-* [LinkedIn](/docs/guides/add-an-external-idp/linkedin/main/)
-* [Microsoft](/docs/guides/add-an-external-idp/microsoft/main/)
-* [Generic OIDC Identity Providers](/docs/guides/add-an-external-idp/openidconnect/main/)
 
 ## Identity Provider operations
 

--- a/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
@@ -4711,17 +4711,17 @@ Okta supports the following enterprise and social Identity Provider types:
 | ------------ | ------------ | ---------------------- | ----------------------------- |
 | `AMAZON`      | [Sign in with Amazon](https://developer.apple.com/documentation/sign_in_with_apple) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `profile`, `profile:user_id`|
 | `APPLE`      | [Sign in with Apple](https://developer.apple.com/documentation/sign_in_with_apple) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `names`, `email`, `openid` |
-| `DISCORD`     | [Discord](https://discord.com/login) as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `xxx` |
-| `FACEBOOK`   | [Facebook Sign In](https://developers.facebook.com/docs/facebook-login/overview/) | [OAuth 2.0](#oauth-2-0-protocol) | `public_profile`, `email` |
+| `DISCORD`     | [Discord](https://discord.com/login) as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `identify`, `email` |
+| `FACEBOOK`   | [Facebook Sign In](https://developers.facebook.com/docs/facebook-login/overview/) as the Identity Provider | [OAuth 2.0](#oauth-2-0-protocol) | `public_profile`, `email` |
 | `GITHUB`     | [GitHub](https://github.com) as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `user` |
 | `GITLAB`     | [GitLab](https://gitlab.com/users/sign_in) as the Identity Provider| [OpenID Connect](#openid-connect-protocol) | `openid`, `read_user`, `profile`, `email` |
-| `GOOGLE`     | [Google Sign In with OpenID Connect](https://developers.google.com/identity/protocols/OpenIDConnect) | [OpenID Connect](#openid-connect-protocol) | |
-| `LINKEDIN`   | [Sign In with LinkedIn](https://developer.linkedin.com/docs/signin-with-linkedin) | [OAuth 2.0](#oauth-2-0-protocol) | |
-| `MICROSOFT`  | [Microsoft Enterprise SSO](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/what-is-single-sign-on) | [OpenID Connect](#openid-connect-protocol) | |
-| `OIDC`       | IdP provider that supports [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html) | [OpenID Connect](#openid-connect-protocol) | |
-| `PAYPAL`     | [Paypal](https://www.paypal.com/signin) as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `xxx` |
-| `PAYPAL_SANDBOX`     | [Paypal Sandbox](https://developer.paypal.com/tools/sandbox/) as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `xxx` |
-| `SALESFORCE`     | [SalesForce](https://login.salesforce.com/) as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `xxx` |
+| `GOOGLE`     | [Google Sign In with OpenID Connect](https://developers.google.com/identity/protocols/OpenIDConnect) | [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
+| `LINKEDIN`   | [Sign In with LinkedIn](https://developer.linkedin.com/docs/signin-with-linkedin) | [OAuth 2.0](#oauth-2-0-protocol) | `r_emailaddress`, `r_liteprofile` |
+| `MICROSOFT`  | [Microsoft Enterprise SSO](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/what-is-single-sign-on) | [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile`, `https://graph.microsoft.com/User.Read` |
+| `OIDC`       | IdP provider that supports [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html) | [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
+| `PAYPAL`     | [Paypal](https://www.paypal.com/signin) as the Identity Provider| [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
+| `PAYPAL_SANDBOX`     | [Paypal Sandbox](https://developer.paypal.com/tools/sandbox/) as the Identity Provider| [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
+| `SALESFORCE`     | [SalesForce](https://login.salesforce.com/) as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `id`, `email`, `profile` |
 | `SAML2`      | Enterprise IdP provider that supports the [SAML 2.0 Web Browser SSO Profile](https://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf) | [SAML 2.0](#saml-2-0-protocol)  | |
 | `SPOTIFY`      | [Spotify](https://developer.spotify.com/dashboard/) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `user-read-email`, `user-read-private` |
 | `X509`       | [Smart Card IdP](https://tools.ietf.org/html/rfc5280) | [Mutual TLS](#mtls-protocol) | |

--- a/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
@@ -4704,20 +4704,21 @@ All Identity Providers have the following properties:
 
 ### Identity Provider type
 
-The Identity Provider object's `type` property identifies the social or enterprise Identity Provider used for authentication. Each Identity Provider uses a specific protocol, therefore the `protocol` property must correspond with the IdP `type`. If the protocol is OAuth 2.0-based, the Protocol object's `scopes` property must also correspond with the scopes supported by the IdP `type`.
+The Identity Provider object's `type` property identifies the social or enterprise Identity Provider used for authentication. Each Identity Provider uses a specific protocol, therefore the `protocol` property must correspond with the IdP `type`. If the protocol is OAuth 2.0-based, the Protocol object's `scopes` property must also correspond with the scopes supported by the IdP `type`. For policy actions supported by each IdP type, see [IdP type policy actions](#idp-type-policy-actions).
+
 Okta supports the following enterprise and social Identity Provider types:
 
 | Type         | Description  | Corresponding protocol | Corresponding protocol scopes |
 | ------------ | ------------ | ---------------------- | ----------------------------- |
-| `AMAZON`      | [Sign in with Amazon](https://developer.apple.com/documentation/sign_in_with_apple) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `profile`, `profile:user_id`|
-| `APPLE`      | [Sign in with Apple](https://developer.apple.com/documentation/sign_in_with_apple) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `names`, `email`, `openid` |
+| `AMAZON`      | [Amazon](https://developer.apple.com/documentation/sign_in_with_apple) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `profile`, `profile:user_id`|
+| `APPLE`      | [Apple](https://developer.apple.com/documentation/sign_in_with_apple) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `names`, `email`, `openid` |
 | `DISCORD`     | [Discord](https://discord.com/login) as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `identify`, `email` |
-| `FACEBOOK`   | [Facebook Sign In](https://developers.facebook.com/docs/facebook-login/overview/) as the Identity Provider | [OAuth 2.0](#oauth-2-0-protocol) | `public_profile`, `email` |
+| `FACEBOOK`   | [Facebook](https://developers.facebook.com/docs/facebook-login/overview/) as the Identity Provider | [OAuth 2.0](#oauth-2-0-protocol) | `public_profile`, `email` |
 | `GITHUB`     | [GitHub](https://github.com) as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `user` |
 | `GITLAB`     | [GitLab](https://gitlab.com/users/sign_in) as the Identity Provider| [OpenID Connect](#openid-connect-protocol) | `openid`, `read_user`, `profile`, `email` |
-| `GOOGLE`     | [Google Sign In with OpenID Connect](https://developers.google.com/identity/protocols/OpenIDConnect) | [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
-| `LINKEDIN`   | [Sign In with LinkedIn](https://developer.linkedin.com/docs/signin-with-linkedin) | [OAuth 2.0](#oauth-2-0-protocol) | `r_emailaddress`, `r_liteprofile` |
-| `MICROSOFT`  | [Microsoft Enterprise SSO](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/what-is-single-sign-on) | [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile`, `https://graph.microsoft.com/User.Read` |
+| `GOOGLE`     | [Google](https://developers.google.com/identity/protocols/OpenIDConnect) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
+| `LINKEDIN`   | [LinkedIn](https://developer.linkedin.com/docs/signin-with-linkedin) as the Identity Provider | [OAuth 2.0](#oauth-2-0-protocol) | `r_emailaddress`, `r_liteprofile` |
+| `MICROSOFT`  | [Microsoft Enterprise SSO](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/what-is-single-sign-on) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile`, `https://graph.microsoft.com/User.Read` |
 | `OIDC`       | IdP provider that supports [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html) | [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
 | `PAYPAL`     | [Paypal](https://www.paypal.com/signin) as the Identity Provider| [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
 | `PAYPAL_SANDBOX`     | [Paypal Sandbox](https://developer.paypal.com/tools/sandbox/) as the Identity Provider| [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
@@ -5531,11 +5532,13 @@ Certificate chain description for verifying assertions from the Smart Card.
 
 | IdP Type         | User Provisioning Actions     | Group Provisioning Actions            | Account Link Actions          | Account Link Filters  |
 | ------------ | ----------------------------- | ------------------------------------- | ----------------------------- | --------------------  |
-| `GOOGLE`     | `AUTO`, `DISABLED` | `NONE` or `ASSIGN`                    | `AUTO`, `DISABLED` | `groups`              |
+| [[all social IdP types *]](#social-idp-type-policy-actions)   | `AUTO`, `DISABLED` | `NONE` or `ASSIGN`                    | `AUTO`, `DISABLED` | `groups`              |
 | `SAML2`      | `AUTO` or `DISABLED`          | `NONE`, `ASSIGN`, `APPEND`, or `SYNC` | `AUTO`, `DISABLED`            | `groups`              |
 | `X509`       | `DISABLED`                    | No support for JIT provisioning       |                               |                       |
 
-> **Note:** All social IdPs (such as `FACEBOOK`, `LINKEDIN`, and so on) use the same User Provisioning Actions, Group Provisioning Actions, Account Link Actions, and Account Link Filters as the `GOOGLE` IdP type.
+##### Social IdP type policy actions *
+
+All social IdPs (such as `FACEBOOK`, `LINKEDIN`, `GOOGLE`, and so on) support the same User Provisioning Actions, Group Provisioning Actions, Account Link Actions, and Account Link Filters.
 
 #### Provisioning Policy object
 
@@ -5584,7 +5587,7 @@ The follow provisioning actions are supported by each IdP provider:
 | `SAML2`      | `AUTO` or `DISABLED`          | `NONE`, `ASSIGN`, `APPEND`, or `SYNC` |
 | `X509`       | `DISABLED`                    | No support for JIT provisioning       |
 
-> **Note:** All social IdPs (such as `FACEBOOK`, `LINKEDIN`, and so on) use the same User and Group Provisioning Actions as the `GOOGLE` IdP type.
+> **Note:** All social IdPs (such as `FACEBOOK`, `LINKEDIN`, and so on) support the same User and Group Provisioning Actions as the `GOOGLE` IdP type.
 
 ##### User provisioning action type
 
@@ -5786,7 +5789,7 @@ The following Account Link actions are supported by each IdP provider:
 | `OIDC`       | `AUTO`                        |                      |
 | `SAML2`      | `AUTO`                        |                      |
 
-> **Note:** All social IdPs (such as `FACEBOOK`, `LINKEDIN`, and so on) use the same Account Link Actions and Filters as the `GOOGLE` IdP type.
+> **Note:** All social IdPs (such as `FACEBOOK`, `LINKEDIN`, and so on) support the same Account Link Actions and Filters as the `GOOGLE` IdP type.
 
 ##### Account Link action type
 

--- a/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
@@ -7,9 +7,9 @@ category: management
 
 The Okta Identity Providers API provides operations to manage federations with external Identity Providers (IdP). For example, your app can support signing in with credentials from Apple, Facebook, Google, LinkedIn, Microsoft, an enterprise IdP using SAML 2.0, or an IdP using the OpenID Connect (`OIDC`) protocol.
 
-See [Add and external Identity Provider](/docs/guides/identity-providers/) for detailed IdP set up guides.
-
 ## Get started
+
+See [Add and external Identity Provider](/docs/guides/identity-providers/) for detailed IdP set up guides.
 
 Explore the Identity Providers API: [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/2635b07ecc5dc2435ade)
 
@@ -4712,15 +4712,15 @@ Okta supports the following enterprise and social Identity Provider types:
 
 | Type         | Description  | Corresponding protocol | Corresponding protocol scopes |
 | ------------ | ------------ | ---------------------- | ----------------------------- |
-| `AMAZON`      | [Amazon](https://developer.apple.com/documentation/sign_in_with_apple)&nbsp;as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `profile`, `profile:user_id`|
-| `APPLE`      | [Apple](https://developer.apple.com/documentation/sign_in_with_apple)&nbsp;as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `names`, `email`, `openid` |
+| `AMAZON`      | [Amazon](https://developer.amazon.com/settings/console/registration?return_to=/)&nbsp;as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `profile`, `profile:user_id`|
+| `APPLE`      | [Apple](https://developer.apple.com/sign-in-with-apple/)&nbsp;as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `names`, `email`, `openid` |
 | `DISCORD`     | [Discord](https://discord.com/login)&nbsp;as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `identify`, `email` |
-| `FACEBOOK`   | [Facebook](https://developers.facebook.com/docs/facebook-login/overview/)&nbsp;as the Identity Provider | [OAuth 2.0](#oauth-2-0-protocol) | `public_profile`, `email` |
-| `GITHUB`     | [GitHub](https://github.com)&nbsp;as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `user` |
+| `FACEBOOK`   | [Facebook](https://developers.facebook.com)&nbsp;as the Identity Provider | [OAuth 2.0](#oauth-2-0-protocol) | `public_profile`, `email` |
+| `GITHUB`     | [GitHub](https://github.com/join)&nbsp;as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `user` |
 | `GITLAB`     | [GitLab](https://gitlab.com/users/sign_in)&nbsp;as the Identity Provider| [OpenID Connect](#openid-connect-protocol) | `openid`, `read_user`, `profile`, `email` |
-| `GOOGLE`     | [Google](https://developers.google.com/identity/protocols/OpenIDConnect)&nbsp;as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
-| `LINKEDIN`   | [LinkedIn](https://developer.linkedin.com/docs/signin-with-linkedin)&nbsp;as the Identity Provider | [OAuth 2.0](#oauth-2-0-protocol) | `r_emailaddress`, `r_liteprofile` |
-| `MICROSOFT`  | [Microsoft Enterprise SSO](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/what-is-single-sign-on)&nbsp;as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile`, `https://graph.microsoft.com/User.Read` |
+| `GOOGLE`     | [Google](https://accounts.google.com/signup)&nbsp;as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
+| `LINKEDIN`   | [LinkedIn](https://developer.linkedin.com/)&nbsp;as the Identity Provider | [OAuth 2.0](#oauth-2-0-protocol) | `r_emailaddress`, `r_liteprofile` |
+| `MICROSOFT`  | [Microsoft Enterprise SSO](https://azure.microsoft.com/)&nbsp;as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile`, `https://graph.microsoft.com/User.Read` |
 | `OIDC`       | IdP provider that supports [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html) | [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
 | `PAYPAL`     | [Paypal](https://www.paypal.com/signin)&nbsp;as the Identity Provider| [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
 | `PAYPAL_SANDBOX`     | [Paypal Sandbox](https://developer.paypal.com/tools/sandbox/)&nbsp;as the Identity Provider| [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
@@ -5534,13 +5534,13 @@ Certificate chain description for verifying assertions from the Smart Card.
 
 | IdP Type         | User Provisioning Actions     | Group Provisioning Actions            | Account Link Actions          | Account Link Filters  |
 | ------------ | ----------------------------- | ------------------------------------- | ----------------------------- | --------------------  |
-| [[all social IdP types *]](#social-idp-type-policy-actions)   | `AUTO`, `DISABLED` | `NONE` or `ASSIGN`                    | `AUTO`, `DISABLED` | `groups`              |
 | `SAML2`      | `AUTO` or `DISABLED`          | `NONE`, `ASSIGN`, `APPEND`, or `SYNC` | `AUTO`, `DISABLED`            | `groups`              |
 | `X509`       | `DISABLED`                    | No support for JIT provisioning       |                               |                       |
+| [[all social IdP types *]](#social-idp-type-policy-actions)   | `AUTO`, `DISABLED` | `NONE` or `ASSIGN`                    | `AUTO`, `DISABLED` | `groups`              |
 
 ##### Social IdP type policy actions *
 
-All social IdPs (such as `FACEBOOK`, `LINKEDIN`, `GOOGLE`, and so on) support the same User Provisioning Actions, Group Provisioning Actions, Account Link Actions, and Account Link Filters.
+All social IdP types (any IdP type that is not `SAML2` or `X509`) support the same User Provisioning Actions, Group Provisioning Actions, Account Link Actions, and Account Link Filters.
 
 #### Provisioning Policy object
 
@@ -5585,11 +5585,14 @@ The follow provisioning actions are supported by each IdP provider:
 
 | Type         | User Provisioning Actions     | Group Provisioning Actions            |
 | ------------ | ----------------------------- | ------------------------------------- |
-| `GOOGLE`     | `AUTO`, `DISABLED` | `NONE` or `ASSIGN`                    |
 | `SAML2`      | `AUTO` or `DISABLED`          | `NONE`, `ASSIGN`, `APPEND`, or `SYNC` |
 | `X509`       | `DISABLED`                    | No support for JIT provisioning       |
+| [[all social IdP types *]](#social-idp-type-provisioning-policy-actions)     | `AUTO`, `DISABLED` | `NONE` or `ASSIGN`                    |
 
-> **Note:** All social IdPs (such as `FACEBOOK`, `LINKEDIN`, and so on) support the same User and Group Provisioning Actions as the `GOOGLE` IdP type.
+##### Social IdP type provisioning policy actions
+
+All social IdP types (any IdP type that is not `SAML2` or `X509`) support the same User and Group Provisioning Actions.
+
 
 ##### User provisioning action type
 
@@ -5787,11 +5790,13 @@ The following Account Link actions are supported by each IdP provider:
 
 | Type         | Account Link Actions          | Account Link Filters |
 | ------------ | ----------------------------- | -------------------- |
-| `GOOGLE`     | `AUTO`, `DISABLED` | `groups`             |
 | `OIDC`       | `AUTO`                        |                      |
 | `SAML2`      | `AUTO`                        |                      |
+| [[all social IdP types *]](#social-idp-type-account-link-policy-actions) | `AUTO`, `DISABLED` | `groups`             |
 
-> **Note:** All social IdPs (such as `FACEBOOK`, `LINKEDIN`, and so on) support the same Account Link Actions and Filters as the `GOOGLE` IdP type.
+##### Social IdP type Account Link policy actions *
+
+All social IdP types (any IdP type that is not `SAML2` or `X509`) support the same Account Link Actions and Filters.
 
 ##### Account Link action type
 

--- a/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
@@ -21,15 +21,6 @@ Explore the Identity Providers API: [![Run in Postman](https://run.pstmn.io/butt
 
 Adds a new IdP to your organization
 
-- [Add Generic OIDC Identity Provider](#add-generic-openid-connect-identity-provider)
-- [Add SAML 2.0 Identity Provider](#add-saml-2-0-identity-provider)
-- [Add Apple Identity Provider](#add-apple-identity-provider)
-- [Add Facebook Identity Provider](#add-facebook-identity-provider)
-- [Add Google Identity Provider](#add-google-identity-provider)
-- [Add LinkedIn Identity Provider](#add-linkedin-identity-provider)
-- [Add Microsoft Identity Provider](#add-microsoft-identity-provider)
-- [Add Smart Card Identity Provider](#add-smart-card-identity-provider)
-
 ##### Request parameters
 
 | Parameter | Description       | Param Type | DataType                                      | Required |
@@ -39,6 +30,17 @@ Adds a new IdP to your organization
 ##### Response parameters
 
 The created [Identity Provider](#identity-provider-object)
+
+##### Request examples
+
+- [Add Generic OIDC Identity Provider](#add-generic-openid-connect-identity-provider)
+- [Add SAML 2.0 Identity Provider](#add-saml-2-0-identity-provider)
+- [Add Apple Identity Provider](#add-apple-identity-provider)
+- [Add Facebook Identity Provider](#add-facebook-identity-provider)
+- [Add Google Identity Provider](#add-google-identity-provider)
+- [Add LinkedIn Identity Provider](#add-linkedin-identity-provider)
+- [Add Microsoft Identity Provider](#add-microsoft-identity-provider)
+- [Add Smart Card Identity Provider](#add-smart-card-identity-provider)
 
 #### Add Generic OpenID Connect Identity Provider
 

--- a/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
@@ -4730,7 +4730,7 @@ Okta supports the following enterprise and social Identity Provider types:
 | `X509`       | [Smart Card IdP](https://tools.ietf.org/html/rfc5280) | [Mutual TLS](#mtls-protocol) | |
 | `XERO`      | [Xero](https://www.xero.com/us/signup/api/)&nbsp;as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `profile`, `email` |
 | `YAHOO`      | [Yahoo](https://login.yahoo.com/)&nbsp;as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `profile`, `email` |
-| `YAHOOJP`      | [Yahoo Japan](https://login.yahoo.co.jp/config/login)&nbsp;as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `profile`, `email` |                             |
+| `YAHOOJP`      | [Yahoo Japan](https://login.yahoo.co.jp/config/login)&nbsp;as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `profile`, `email` |
 
 ### Protocol object
 

--- a/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
@@ -15,6 +15,12 @@ Explore the Identity Providers API: [![Run in Postman](https://run.pstmn.io/butt
 
 ## Identity Provider operations
 
+- [Add an Identity Provider](#add-identity-provider)
+- [Get an Identity Provider](#get-identity-provider)
+- [List Identity Providers](#list-identity-providers)
+- [Update an Identity Provider](#update-identity-provider)
+- [Delete an Identity Provider](#delete-identity-provider)
+
 ### Add Identity Provider
 
 <ApiOperation method="post" url="/api/v1/idps" />

--- a/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
@@ -9,9 +9,9 @@ The Okta Identity Providers API provides operations to manage federations with e
 
 ## Get started
 
-See [Add and external Identity Provider](/docs/guides/identity-providers/) for detailed IdP set up guides.
-
 Explore the Identity Providers API: [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/2635b07ecc5dc2435ade)
+
+See [Add and external Identity Provider](/docs/guides/identity-providers/) for detailed IdP set up guides using the Admin Console.
 
 ## Identity Provider operations
 
@@ -2374,7 +2374,7 @@ curl -v -X PUT \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
 -d '{
-}' "https://${yourOktaDomain}/api/v1/idps/your-idps-id"
+}' "https://${yourOktaDomain}/api/v1/idps/${yourIdpId}"
 ```
 
 ##### Response example
@@ -2519,7 +2519,7 @@ curl -v -X DELETE \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
 -d '{
-}' "https://${yourOktaDomain}/api/v1/idps/your-idps-id"
+}' "https://${yourOktaDomain}/api/v1/idps/${yourIdpId}"
 ```
 
 ##### Response example
@@ -2554,7 +2554,7 @@ curl -v -X POST \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
 -d '{
-}' "https://${yourOktaDomain}/api/v1/idps/your-idps-id/lifecycle/activate"
+}' "https://${yourOktaDomain}/api/v1/idps/${yourIdpId}/lifecycle/activate"
 ```
 
 ##### Response example
@@ -2668,7 +2668,7 @@ curl -v -X POST \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
 -d '{
-}' "https://${yourOktaDomain}/api/v1/idps/your-idps-id/lifecycle/deactivate"
+}' "https://${yourOktaDomain}/api/v1/idps/${yourIdpId}/lifecycle/deactivate"
 ```
 
 ##### Response example

--- a/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
@@ -4700,35 +4700,43 @@ All Identity Providers have the following properties:
 
   After you enable the Custom URL Domain feature, all new social IdPs use the `CUSTOM_URL` by default. All existing social IdPs continue to use the `ORG_URL` so that existing integrations with the social IdP continue to work after the feature is enabled. You can change this value in any social IdP through the API or Admin Console.
 
+* The [Protocol object](#protocol-object) (`protocol`) and [Policy object](#policy-object) (`policy`) are dependent on the specific [type](#identity-provider-type) (`type`) of IdP used.
+
 ### Identity Provider type
 
-Okta supports the following enterprise and social providers:
+The Identity Provider object's `type` property identifies the social or enterprise Identity Provider used for authentication. Each Identity Provider uses a specific protocol, therefore the `protocol` property must correspond with the IdP `type`. If the protocol is OAuth 2.0-based, the Protocol object's `scopes` property must also correspond with the scopes supported by the IdP `type`.
+Okta supports the following enterprise and social Identity Provider types:
 
-| Type         | Description                                                                                                                                           |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `APPLE`      | [Apple Sign In](https://developer.apple.com/documentation/sign_in_with_apple)                                                                       |
-| `FACEBOOK`   | [Facebook Sign In](https://developers.facebook.com/docs/facebook-login/overview/)                                                                       |
-| `GOOGLE`     | [Google Sign In with OpenID Connect](https://developers.google.com/identity/protocols/OpenIDConnect)                                                  |
-| `LINKEDIN`   | [Sign In with LinkedIn](https://developer.linkedin.com/docs/signin-with-linkedin)                                                                     |
-| `MICROSOFT`  | [Microsoft Enterprise SSO](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/what-is-single-sign-on)                                |
-| `OIDC`       | IdP provider that supports [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html)                                                    |
-| `SAML2`      | Enterprise IdP provider that supports the [SAML 2.0 Web Browser SSO Profile](https://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf) |
-| `X509`       | [Smart Card IdP](https://tools.ietf.org/html/rfc5280)                                |
+| Type         | Description  | Corresponding protocol | Corresponding protocol scopes |
+| ------------ | ------------ | ---------------------- | ----------------------------- |
+| `AMAZON`      | [Sign in with Amazon](https://developer.apple.com/documentation/sign_in_with_apple) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `profile`, `profile:user_id`|
+| `APPLE`      | [Sign in with Apple](https://developer.apple.com/documentation/sign_in_with_apple) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `names`, `email`, `openid` |
+| `DISCORD`     | [Discord](https://discord.com/login) as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `xxx` |
+| `FACEBOOK`   | [Facebook Sign In](https://developers.facebook.com/docs/facebook-login/overview/) | [OAuth 2.0](#oauth-2-0-protocol) | `public_profile`, `email` |
+| `GITHUB`     | [GitHub](https://github.com) as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `user` |
+| `GITLAB`     | [GitLab](https://gitlab.com/users/sign_in) as the Identity Provider| [OpenID Connect](#openid-connect-protocol) | `openid`, `read_user`, `profile`, `email` |
+| `GOOGLE`     | [Google Sign In with OpenID Connect](https://developers.google.com/identity/protocols/OpenIDConnect) | [OpenID Connect](#openid-connect-protocol) | |
+| `LINKEDIN`   | [Sign In with LinkedIn](https://developer.linkedin.com/docs/signin-with-linkedin) | [OAuth 2.0](#oauth-2-0-protocol) | |
+| `MICROSOFT`  | [Microsoft Enterprise SSO](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/what-is-single-sign-on) | [OpenID Connect](#openid-connect-protocol) | |
+| `OIDC`       | IdP provider that supports [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html) | [OpenID Connect](#openid-connect-protocol) | |
+| `PAYPAL`     | [Paypal](https://www.paypal.com/signin) as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `xxx` |
+| `PAYPAL_SANDBOX`     | [Paypal Sandbox](https://developer.paypal.com/tools/sandbox/) as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `xxx` |
+| `SALESFORCE`     | [SalesForce](https://login.salesforce.com/) as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `xxx` |
+| `SAML2`      | Enterprise IdP provider that supports the [SAML 2.0 Web Browser SSO Profile](https://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf) | [SAML 2.0](#saml-2-0-protocol)  | |
+| `SPOTIFY`      | [Spotify](https://developer.spotify.com/dashboard/) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `user-read-email`, `user-read-private` |
+| `X509`       | [Smart Card IdP](https://tools.ietf.org/html/rfc5280) | [Mutual TLS](#mtls-protocol) | |
+| `XERO`      | [Xero](https://www.xero.com/us/signup/api/) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `profile`, `email` |
+| `YAHOO`      | [Yahoo](https://login.yahoo.com/) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `profile`, `email` |
+| `YAHOOJP`      | [Yahoo Japan](https://login.yahoo.co.jp/config/login) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `profile`, `email` |                             |
 
 ### Protocol object
 
-The Protocol object contains IdP-specific protocol settings for endpoints, bindings, and algorithms used to connect with the IdP and validate messages.
+The Protocol object contains IdP-specific protocol settings for endpoints, bindings, and algorithms used to connect with the IdP and validate messages. The following are the supported Protocol objects:
 
-| Provider     | Protocol                                   |
-| ------------ | -----------------------------------------  |
-| `APPLE`      | [OpenID Connect](#openid-connect-protocol) |
-| `FACEBOOK`   | [OAuth 2.0](#oauth-2-0-protocol)            |
-| `GOOGLE`     | [OpenID Connect](#openid-connect-protocol) |
-| `LINKEDIN`   | [OAuth 2.0](#oauth-2-0-protocol)            |
-| `MICROSOFT`  | [OpenID Connect](#openid-connect-protocol) |
-| `OIDC`       | [OpenID Connect](#openid-connect-protocol) |
-| `SAML2`      | [SAML 2.0](#saml-2-0-protocol)              |
-| `MTLS`  | [Mutual TLS](#mtls-protocol) |
+* [SAML 2.0](#saml-2-0-protocol)
+* [OAuth 2.0](#oauth-2-0-protocol)
+* [OpenID Connect](#openid-connect-protocol)
+* [Mutual TLS](#mtls-protocol)
 
 #### SAML 2.0 Protocol
 
@@ -5095,7 +5103,7 @@ Protocol settings for authentication using the [OAuth 2.0 Authorization Code flo
 | scopes      | IdP-defined permission bundles to request delegated access from the User                                                            | Array of String                                                              | FALSE    | FALSE    | 1         |
 | type        | [OAuth 2.0 Authorization Code flow](https://tools.ietf.org/html/rfc6749#section-4.1)                                            | `OAUTH2`                                                                     | FALSE    | TRUE     |           |
 
-> **Note:** The [OAuth 2.0 Setup Guide](#setup-guides) lists the scopes that are supported [per-IdP provider](#identity-provider-type).
+> **Note:** The [Identity Provider type](#identity-provider-type) table lists the scopes that are supported for each Identity Provider.
 
 ```json
 {
@@ -5137,7 +5145,7 @@ Protocol settings for authentication using the [OpenID Connect Protocol](http://
 | scopes      | OpenID Connect and IdP-defined permission bundles to request delegated access from the User                                         | Array of String                                                              | FALSE | FALSE | 1 |
 | type        | [OpenID Connect Authorization Code flow](http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth)                     | `OIDC`                                                                       | FALSE | TRUE  |   |
 
-> **Note:** The [IdP setup guides](#setup-guides) list the scopes that are supported [per-IdP provider](#identity-provider-type). The base `openid` scope is always required.
+> **Note:** The [Identity Provider type](#identity-provider-type) table lists the scopes that are supported for each Identity Provider. The base `openid` scope is always required.
 
 ```json
 {
@@ -5377,6 +5385,7 @@ The information is used to generate the secret JSON Web Token for the token requ
   }
 }
 ```
+
 > **Note:** The key is truncated for brevity.
 
 
@@ -5520,15 +5529,13 @@ Certificate chain description for verifying assertions from the Smart Card.
 
 #### IdP type policy actions
 
-| Type         | User Provisioning Actions     | Group Provisioning Actions            | Account Link Actions          | Account Link Filters  |
+| IdP Type         | User Provisioning Actions     | Group Provisioning Actions            | Account Link Actions          | Account Link Filters  |
 | ------------ | ----------------------------- | ------------------------------------- | ----------------------------- | --------------------  |
-| `FACEBOOK`   | `AUTO`, `CALLOUT`, `DISABLED` | `NONE` or `ASSIGN`                    | `AUTO`, `CALLOUT`, `DISABLED` | `groups`              |
-| `GOOGLE`     | `AUTO`, `CALLOUT`, `DISABLED` | `NONE` or `ASSIGN`                    | `AUTO`, `CALLOUT`, `DISABLED` | `groups`              |
-| `LINKEDIN`   | `AUTO`, `CALLOUT`, `DISABLED` | `NONE` or `ASSIGN`                    | `AUTO`, `CALLOUT`, `DISABLED` | `groups`              |
+| `GOOGLE`     | `AUTO`, `DISABLED` | `NONE` or `ASSIGN`                    | `AUTO`, `DISABLED` | `groups`              |
 | `SAML2`      | `AUTO` or `DISABLED`          | `NONE`, `ASSIGN`, `APPEND`, or `SYNC` | `AUTO`, `DISABLED`            | `groups`              |
 | `X509`       | `DISABLED`                    | No support for JIT provisioning       |                               |                       |
 
-> **Note:** `CALLOUT` is a <ApiLifecycle access="deprecated" /> User provisioning action and Account Link action.
+> **Note:** All social IdPs (such as `FACEBOOK`, `LINKEDIN`, and so on) use the same User Provisioning Actions, Group Provisioning Actions, Account Link Actions, and Account Link Filters as the `GOOGLE` IdP type.
 
 #### Provisioning Policy object
 
@@ -5573,13 +5580,11 @@ The follow provisioning actions are supported by each IdP provider:
 
 | Type         | User Provisioning Actions     | Group Provisioning Actions            |
 | ------------ | ----------------------------- | ------------------------------------- |
-| `FACEBOOK`   | `AUTO`, `CALLOUT`, `DISABLED` | `NONE` or `ASSIGN`                    |
-| `GOOGLE`     | `AUTO`, `CALLOUT`, `DISABLED` | `NONE` or `ASSIGN`                    |
-| `LINKEDIN`   | `AUTO`, `CALLOUT`, `DISABLED` | `NONE` or `ASSIGN`                    |
+| `GOOGLE`     | `AUTO`, `DISABLED` | `NONE` or `ASSIGN`                    |
 | `SAML2`      | `AUTO` or `DISABLED`          | `NONE`, `ASSIGN`, `APPEND`, or `SYNC` |
 | `X509`       | `DISABLED`                    | No support for JIT provisioning       |
 
-> **Note:** `CALLOUT` is a <ApiLifecycle access="deprecated" /> User provisioning action.
+> **Note:** All social IdPs (such as `FACEBOOK`, `LINKEDIN`, and so on) use the same User and Group Provisioning Actions as the `GOOGLE` IdP type.
 
 ##### User provisioning action type
 
@@ -5777,13 +5782,11 @@ The following Account Link actions are supported by each IdP provider:
 
 | Type         | Account Link Actions          | Account Link Filters |
 | ------------ | ----------------------------- | -------------------- |
-| `FACEBOOK`   | `AUTO`, `CALLOUT`, `DISABLED` | `groups`             |
-| `GOOGLE`     | `AUTO`, `CALLOUT`, `DISABLED` | `groups`             |
-| `LINKEDIN`   | `AUTO`, `CALLOUT`, `DISABLED` | `groups`             |
+| `GOOGLE`     | `AUTO`, `DISABLED` | `groups`             |
 | `OIDC`       | `AUTO`                        |                      |
 | `SAML2`      | `AUTO`                        |                      |
 
-> **Note:** `CALLOUT` is a <ApiLifecycle access="deprecated" /> account link action.
+> **Note:** All social IdPs (such as `FACEBOOK`, `LINKEDIN`, and so on) use the same Account Link Actions and Filters as the `GOOGLE` IdP type.
 
 ##### Account Link action type
 

--- a/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
@@ -25,7 +25,7 @@ Explore the Identity Providers API: [![Run in Postman](https://run.pstmn.io/butt
 
 <ApiOperation method="post" url="/api/v1/idps" />
 
-Adds a new IdP to your organization
+Adds a new IdP to your organization. See [Identity Provider type](#identity-provider-type) for the list of supported external IdPs.
 
 ##### Request parameters
 
@@ -47,6 +47,8 @@ The created [Identity Provider](#identity-provider-object)
 - [Add LinkedIn Identity Provider](#add-linkedin-identity-provider)
 - [Add Microsoft Identity Provider](#add-microsoft-identity-provider)
 - [Add Smart Card Identity Provider](#add-smart-card-identity-provider)
+
+See [Identity Provider type](#identity-provider-type) for a list of all the supported external IdPs.
 
 #### Add Generic OpenID Connect Identity Provider
 
@@ -4710,25 +4712,25 @@ Okta supports the following enterprise and social Identity Provider types:
 
 | Type         | Description  | Corresponding protocol | Corresponding protocol scopes |
 | ------------ | ------------ | ---------------------- | ----------------------------- |
-| `AMAZON`      | [Amazon](https://developer.apple.com/documentation/sign_in_with_apple) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `profile`, `profile:user_id`|
-| `APPLE`      | [Apple](https://developer.apple.com/documentation/sign_in_with_apple) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `names`, `email`, `openid` |
-| `DISCORD`     | [Discord](https://discord.com/login) as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `identify`, `email` |
-| `FACEBOOK`   | [Facebook](https://developers.facebook.com/docs/facebook-login/overview/) as the Identity Provider | [OAuth 2.0](#oauth-2-0-protocol) | `public_profile`, `email` |
-| `GITHUB`     | [GitHub](https://github.com) as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `user` |
-| `GITLAB`     | [GitLab](https://gitlab.com/users/sign_in) as the Identity Provider| [OpenID Connect](#openid-connect-protocol) | `openid`, `read_user`, `profile`, `email` |
-| `GOOGLE`     | [Google](https://developers.google.com/identity/protocols/OpenIDConnect) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
-| `LINKEDIN`   | [LinkedIn](https://developer.linkedin.com/docs/signin-with-linkedin) as the Identity Provider | [OAuth 2.0](#oauth-2-0-protocol) | `r_emailaddress`, `r_liteprofile` |
-| `MICROSOFT`  | [Microsoft Enterprise SSO](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/what-is-single-sign-on) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile`, `https://graph.microsoft.com/User.Read` |
+| `AMAZON`      | [Amazon](https://developer.apple.com/documentation/sign_in_with_apple)&nbsp;as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `profile`, `profile:user_id`|
+| `APPLE`      | [Apple](https://developer.apple.com/documentation/sign_in_with_apple)&nbsp;as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `names`, `email`, `openid` |
+| `DISCORD`     | [Discord](https://discord.com/login)&nbsp;as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `identify`, `email` |
+| `FACEBOOK`   | [Facebook](https://developers.facebook.com/docs/facebook-login/overview/)&nbsp;as the Identity Provider | [OAuth 2.0](#oauth-2-0-protocol) | `public_profile`, `email` |
+| `GITHUB`     | [GitHub](https://github.com)&nbsp;as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `user` |
+| `GITLAB`     | [GitLab](https://gitlab.com/users/sign_in)&nbsp;as the Identity Provider| [OpenID Connect](#openid-connect-protocol) | `openid`, `read_user`, `profile`, `email` |
+| `GOOGLE`     | [Google](https://developers.google.com/identity/protocols/OpenIDConnect)&nbsp;as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
+| `LINKEDIN`   | [LinkedIn](https://developer.linkedin.com/docs/signin-with-linkedin)&nbsp;as the Identity Provider | [OAuth 2.0](#oauth-2-0-protocol) | `r_emailaddress`, `r_liteprofile` |
+| `MICROSOFT`  | [Microsoft Enterprise SSO](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/what-is-single-sign-on)&nbsp;as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile`, `https://graph.microsoft.com/User.Read` |
 | `OIDC`       | IdP provider that supports [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html) | [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
-| `PAYPAL`     | [Paypal](https://www.paypal.com/signin) as the Identity Provider| [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
-| `PAYPAL_SANDBOX`     | [Paypal Sandbox](https://developer.paypal.com/tools/sandbox/) as the Identity Provider| [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
-| `SALESFORCE`     | [SalesForce](https://login.salesforce.com/) as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `id`, `email`, `profile` |
+| `PAYPAL`     | [Paypal](https://www.paypal.com/signin)&nbsp;as the Identity Provider| [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
+| `PAYPAL_SANDBOX`     | [Paypal Sandbox](https://developer.paypal.com/tools/sandbox/)&nbsp;as the Identity Provider| [OpenID Connect](#openid-connect-protocol) | `openid`, `email`, `profile` |
+| `SALESFORCE`     | [SalesForce](https://login.salesforce.com/)&nbsp;as the Identity Provider| [OAuth 2.0](#oauth-2-0-protocol) | `id`, `email`, `profile` |
 | `SAML2`      | Enterprise IdP provider that supports the [SAML 2.0 Web Browser SSO Profile](https://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf) | [SAML 2.0](#saml-2-0-protocol)  | |
-| `SPOTIFY`      | [Spotify](https://developer.spotify.com/dashboard/) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `user-read-email`, `user-read-private` |
+| `SPOTIFY`      | [Spotify](https://developer.spotify.com/dashboard/)&nbsp;as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `user-read-email`, `user-read-private` |
 | `X509`       | [Smart Card IdP](https://tools.ietf.org/html/rfc5280) | [Mutual TLS](#mtls-protocol) | |
-| `XERO`      | [Xero](https://www.xero.com/us/signup/api/) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `profile`, `email` |
-| `YAHOO`      | [Yahoo](https://login.yahoo.com/) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `profile`, `email` |
-| `YAHOOJP`      | [Yahoo Japan](https://login.yahoo.co.jp/config/login) as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `profile`, `email` |                             |
+| `XERO`      | [Xero](https://www.xero.com/us/signup/api/)&nbsp;as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `profile`, `email` |
+| `YAHOO`      | [Yahoo](https://login.yahoo.com/)&nbsp;as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `profile`, `email` |
+| `YAHOOJP`      | [Yahoo Japan](https://login.yahoo.co.jp/config/login)&nbsp;as the Identity Provider | [OpenID Connect](#openid-connect-protocol) | `openid`, `profile`, `email` |                             |
 
 ### Protocol object
 


### PR DESCRIPTION
## Description:
- **What's changed?** IdPs API reference page: updated Identity Provider `type` property and associated sub-structures with new social IdPs.
- **Is this PR related to a Monolith release?** No

### Preview: 
* May 13: https://627d7b6ecfa2be00bc06cb92--reverent-murdock-829d24.netlify.app/docs/reference/api/idps/
* May 12: https://627d53e51fcaa10fded2e42b--reverent-murdock-829d24.netlify.app/docs/reference/api/idps/

### Resolves:

* [OKTA-493049](https://oktainc.atlassian.net/browse/OKTA-493049)
