### PR TITLE
reduce brands/brand confusion on Brands API docs

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/customize-themes/index.md
@@ -43,17 +43,17 @@ For example, if you update the sign-in page code using the editor and change the
 
 ## Get info about brands and themes
 
-At the top level, Your Okta org contains a brand, which contains a default theme. The default brand is applied to your org's subdomain/[custom domain](/docs/guides/custom-url-domain/) if you have specified one.
+At the top level, Your Okta org contains a single brand, which contains a default theme. The brand is applied to your org's subdomain/[custom domain](/docs/guides/custom-url-domain/) if you have specified one.
 
-> **Note:** Currently, each org can contain only one brand and one theme. However, we are working on a plan to allow multiple themes and multiple brands per org, so stay tuned!
+> **Important:** Despite being called the Brands API (due to conventions around REST API naming), each org can currently contain only one brand and one theme. We will likely allow multiple brands and themes per org at some point in the future, so stay tuned!
 
 ### Get brands
 
-You can return the brands with the following request (**Get brands** in Postman):
+You can return the org's brands with the following request (**Get brands** in Postman):
 
 <ApiOperation method="get" url="/api/v1/brands" />
 
-This returns an array of [brand response objects](/docs/reference/api/brands/#brand-response-object). You can try this in Postman by running the Get brands request.
+This returns an array of [brand response objects](/docs/reference/api/brands/#brand-response-object), which will currently contain one single object only. You can try this in Postman by running the Get brands request.
 
 You can also return a specific brand by running the **Get brand** request. Before you run the request, you'll need to set the `brandId` variable in Postman, which is used in the request, as seen below.
 
@@ -69,7 +69,7 @@ You can return the themes contained in a brand with the following request (**Get
 
 <ApiOperation method="get" url="/api/v1/brands/${brandId}/themes" />
 
-This returns an array of [theme response objects](/docs/reference/api/brands/#theme-response-object).
+This returns an array of [theme response objects](/docs/reference/api/brands/#theme-response-object), which will currently contain one single object only.
 
 Once you've set the `themeId` variable to a specific theme ID, you can return a specific theme response object using the following request (**Get theme** in Postman):
 

--- a/packages/@okta/vuepress-site/docs/reference/api/brands/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/brands/index.md
@@ -9,6 +9,8 @@ The Okta Brands API allows you to customize the look and feel of pages and templ
 
 Each org starts off with Okta's default branding. You can upload your own assets (colors, background image, logo, and favicon) to replace Okta's default brand assets. You can then publish these assets directly to your pages and templates.
 
+> **Important:** Despite being called the Brands API (due to conventions around REST API naming), each org can currently contain only one brand and one theme. We will likely allow multiple brands and themes per org at some point in the future, so stay tuned!
+
 ## Get started
 
 Explore the Brands API: [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/8cc47beb2a20dfe078eb)
@@ -24,17 +26,17 @@ The Brands API has the following CRUD operations:
 
 <ApiOperation method="get" url="/api/v1/brands" />
 
-List all the brands in your org
+List all the brands in your org. 
 
 #### Response body
 
-Array of the [Brand Response](#brand-response-object)
+Array of the [Brand Response](#brand-response-object).
+
+> **Important**: Currently only one Brand per org is supported, therefore this will contain one single object only.
 
 #### Use examples
 
 The following example returns all Brands in the org.
-
-> **Note:** Currently, only one Brand per org is supported.
 
 ##### Request
 
@@ -374,13 +376,13 @@ List all the themes in your brand
 
 Array of the [Theme Response](#theme-response-object)
 
+> **Important**: Currently only one Theme per org is supported, therefore this will contain one single object only.
+
 Passing an invalid `brandId` returns a `404 Not Found` status code with error code `E0000007`.
 
 #### Use examples
 
 The following example returns all Themes in the Brand.
-
-> **Note:** Currently, only one Theme per Brand is supported.
 
 ##### Request
 
@@ -474,7 +476,6 @@ Fetches a Theme for a Brand
 The requested [Theme Response](#theme-response-object)
 
 Passing an invalid `brandId` or an invalid `themeId` returns a `404 Not Found` status code with error code `E0000007`.
-
 
 #### Use examples
 
@@ -831,7 +832,6 @@ Deletes a Theme logo. The org then uses the Okta default logo.
 None.
 
 Passing an invalid `brandId` or an invalid `themeId` returns a `404 Not Found` status code with error code `E0000007`.
-
 
 #### Use examples
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** The PAT team/Jeff Taylor reported some confusion its functionality from customers around the RESTful naming conventions and the functionality of the feature. RESTful naming uses plurals for API resources. So the CRUD on the Okta Brand object would be under /api/v1/brands where you can perform those operations.

   If you read the API path literally, one could assume you can create and manage many brand objects on an org. However, currently we only support one brand and theme object per org. This PR aims to expose this detail more explicitly in appropriate places, and better set customer expectations.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-497710](https://oktainc.atlassian.net/browse/OKTA-497710)
