### PR TITLE
OKTA-497283 - Update User Import Inline Hook Reference

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/import-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/import-hook/index.md
@@ -140,6 +140,10 @@ When using the `com.okta.action.update` command to specify that the user should 
 }
 ```
 
+#### Specifying no action
+
+When you don't want the hook to change the user import operation or update a user profile, return an empty response (or no response at all). The User Import Inline Hook only modifies user imports with a response using one of the [commands](#commands).
+
 ### error
 
 When you return an error object, it should contain an `errorSummary` sub-object:


### PR DESCRIPTION

## Description:
- **What's changed?** Added a small section in the [User Import Inline Hook](https://developer.okta.com/docs/reference/import-hook/) reference in the case when no updates are required by the hook.
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* [OKTA-497283](https://oktainc.atlassian.net/browse/OKTA-497283)
