### PR TITLE
OKTA-494746 Update Okta Expression Language Overview for multiple AD instances

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
@@ -237,7 +237,7 @@ The following should be noted about these functions:
 * Be sure to pass the correct App name for the `managerSource`, `assistantSource`, and `attributeSource` parameters.
 * At this time, `active_directory` is the only supported value for `managerSource` and `assistantSource`.
 * Calling the `getManagerUser("active_directory")` function doesn't trigger a user profile update after the manager is changed.
-* The manager and assistant functions are not supported for user profiles sourced from multiple Active Directory instances.
+* The manager and assistant functions aren't supported for user profiles sourced from multiple Active Directory instances.
 
 ### Directory and Workday functions
 

--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
@@ -237,6 +237,7 @@ The following should be noted about these functions:
 * Be sure to pass the correct App name for the `managerSource`, `assistantSource`, and `attributeSource` parameters.
 * At this time, `active_directory` is the only supported value for `managerSource` and `assistantSource`.
 * Calling the `getManagerUser("active_directory")` function doesn't trigger a user profile update after the manager is changed.
+* The manager and assistant functions are not supported for user profiles sourced from multiple Active Directory instances.
 
 ### Directory and Workday functions
 


### PR DESCRIPTION

## Description:
- **What's changed?** In the [Manager/Assistant functions](https://developer.okta.com/docs/reference/okta-expression-language/#manager-assistant-functions) section of the Okta Expression Language overview, added a bullet point that these functions are not supported for multiple AD instances.
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* [OKTA-494746](https://oktainc.atlassian.net/browse/OKTA-494746)
