### PR TITLE
OKTA-499415 Replace github_id with externalId for GitHub IdP

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/social-login/main/github/noemail.md
+++ b/packages/@okta/vuepress-site/docs/guides/social-login/main/github/noemail.md
@@ -20,12 +20,12 @@ To generate user login values and email addresses for GitHub users, do the follo
 
 1. Set the expression that maps to the Okta user's `login` value to:
    ```
-   appuser.email == null ? appuser.github_id + '@github.example.com' : appuser.email
+   appuser.email == null ? appuser.externalId + '@github.example.com' : appuser.email
    ```
 
 1. Set the expression that maps to the Okta user's `email` value to:
    ```
-   appuser.email == null ? appuser.github_id + '@github.example.com' : appuser.email
+   appuser.email == null ? appuser.externalId + '@github.example.com' : appuser.email
    ```
 
 1. Click **Save Mappings**
@@ -40,7 +40,7 @@ Similarly, you can map the IdP username by doing the following:
 
 1. Set the expression for **IdP Username** to:
    ```
-   idpuser.email == null ? idpuser.github_id + '@github.example.com' : idpuser.email
+   idpuser.email == null ? idpuser.externalId + '@github.example.com' : idpuser.email
    ```
 
 1. Click **Update Identity Provider**


### PR DESCRIPTION
## Description:
- **What's changed?** Replace github_id with externalId for GitHub IdP based on info in OKTA-498510.
- **Is this PR related to a Monolith release?** No
- Target release: 2022-05-31 (verify with @colekurashige-okta)

### Resolves:

* [OKTA-499415](https://oktainc.atlassian.net/browse/OKTA-499415)
