### PR TITLE
TBS Add generic timeout message for Progressive Enrollment

### DIFF
--- a/packages/@okta/vuepress-site/docs/concepts/inline-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/inline-hooks/index.md
@@ -162,7 +162,7 @@ In the case of an Inline Hook timeout or failure, the Okta process flow either c
 | Inline Hook        | Inline Hook Failure Behavior                             |
 |--------------------------------| ---------------------------------------------------------|
 | Password Import Inline Hook | Okta process flow stops and user can't sign in. The password is not imported. Future attempts to sign in triggers the Inline Hook again. |
-| Registration Inline Hook | Okta process flow stops and registration is denied. The user receives the following default UI message: "There was an error creating your account. Please try registering again". |
+| Registration Inline Hook | Okta process flow stops and registration or the profile update is denied. The user receives one of the following default UI message:<ul><li>"There was an error creating your account. Please try registering again".</li><li>"There was an error updating your profile. Please try again later."</li></ul> |
 | SAML Assertion Inline Hook | Okta process flow continues with original SAML assertion returned. |
 | Telephony Inline Hook <ApiLifecycle access="ea" /> | Okta process to deliver the OTP continues and the OTP is sent using Okta’s providers. |
 | Token Inline Hook | Okta process flow continues with original token returned. |

--- a/packages/@okta/vuepress-site/docs/concepts/inline-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/inline-hooks/index.md
@@ -162,7 +162,7 @@ In the case of an Inline Hook timeout or failure, the Okta process flow either c
 | Inline Hook        | Inline Hook Failure Behavior                             |
 |--------------------------------| ---------------------------------------------------------|
 | Password Import Inline Hook | Okta process flow stops and user can't sign in. The password is not imported. Future attempts to sign in triggers the Inline Hook again. |
-| Registration Inline Hook | Okta process flow stops and registration or the profile update is denied. The user receives one of the following default UI message:<ul><li>"There was an error creating your account. Please try registering again".</li><li>"There was an error updating your profile. Please try again later."</li></ul> |
+| Registration Inline Hook | Okta process flow stops and the registration or the profile update is denied. The user receives one of the following default UI messages:<ul><li>"There was an error creating your account. Please try registering again". (SSR)</li><li>"There was an error updating your profile. Please try again later." (Progressive Enrollment)</li></ul> |
 | SAML Assertion Inline Hook | Okta process flow continues with original SAML assertion returned. |
 | Telephony Inline Hook <ApiLifecycle access="ea" /> | Okta process to deliver the OTP continues and the OTP is sent using Okta’s providers. |
 | Token Inline Hook | Okta process flow continues with original token returned. |

--- a/packages/@okta/vuepress-site/docs/guides/registration-inline-hook/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/registration-inline-hook/main/index.md
@@ -156,7 +156,7 @@ In our sample Glitch project, you can see this response in the [server.js](https
 See the [response properties](/docs/reference/registration-hook/#response-objects-that-you-send) of a Registration Inline Hook for full details.
 
 ```javascript
-// Registration Inline Hook code to parse the incoming Okta request 
+// Registration Inline Hook code to parse the incoming Okta request
 
 app.post('/registrationHook', async (request, response) => {
   console.log();

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -28,7 +28,7 @@ For an example implementation of this Inline Hook, see [Registration Inline Hook
 The Okta Registration Inline Hook allows you to integrate your own custom code into Okta's [Profile Enrollment](https://help.okta.com/okta_help.htm?type=oie&id=ext-create-profile-enrollment) flow. The hook is triggered after Okta receives the registration or profile update request. Your custom code can:
 
 - Allow or deny the registration attempt, based on your own validation of the information the user has submitted
-- Set or override the values that will be populated in attributes of the user's Okta profile
+- Set or override the values that are populated in attributes of the user's Okta profile
 
 > **Note:** Profile Enrollment and self-service registration (SSR) Inline Hooks only work with the [Okta Sign-In Widget](/code/javascript/okta_sign-in_widget/) version 4.5 or later.
 

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -224,7 +224,7 @@ For the Registration Inline Hook, the `error` object provides a way of displayin
 If there is a response timeout after receiving the Okta request, the Okta process flow stops. Depending on the request, either the self-service registration or the profile update is denied. One of the following default UI messages appears:
 
 * "There was an error creating your account. Please try registering again." (SSR)
-* "There was an error updating your profile. Please try again later." (Profile Enrollment)
+* "Your profile couldn't be updated at this time. Please try again later." (Profile Enrollment)
 
 ## Sample SSR request
 

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -198,29 +198,33 @@ Registrations are allowed by default, so setting a value of `ALLOW` for the `act
 
 See [error](/docs/concepts/inline-hooks/#error) for general information about the structure to use for the `error` object.
 
-For the Registration Inline Hook, the `error` object provides a way of displaying an error message to the end user who is trying to register.
+For the Registration Inline Hook, the `error` object provides a way of displaying an error message to the end user who is trying to register or update their profile.
+
+> **Note:** Generic Progressive Enrollment error messages are only available in the Identity Engine.
 
 * If you're using the Okta Sign-In Widget for Profile Enrollment, only the `errorSummary` messages of the `errorCauses` objects that your external service returns appear as inline errors, given the following:
 
    * You don't customize the error handling behavior of the widget.
    * The `location` of `errorSummary` in the `errorCauses` object specifies the request object's user profile attribute.
 
-* If you don't return a value for the `errorCauses` object, and deny the user's registration attempt through the `commands` object in your response to Okta, one of the following generic messages appears to the end user:</br></br>
-   * `Registration cannot be completed at this time.` (SSR)</br></br>
-   * `We found some errors. Please review the form and make corrections.` (Progressive Enrollment)
+* If you don't return a value for the `errorCauses` object, and deny the user's registration attempt through the `commands` object in your response to Okta, one of the following generic messages appears to the end user:
 
-* If you don't return an `error` object at all and the registration is denied, the following generic message appears to the end user:</br></br>
-   * `Registration denied.`(SSR)</br></br>
-   * `Profile update denied.` (Progressive Enrollment)
+   * "Registration cannot be completed at this time." (SSR)
+   * "We found some errors. Please review the form and make corrections." (Progressive Enrollment)
+
+* If you don't return an `error` object at all and the registration is denied, the following generic message appears to the end user:
+
+   * "Registration denied." (SSR)
+   * "Profile update denied." (Progressive Enrollment)
 
 > **Note:** If you include an error object in your response, no commands are executed and the registration fails. This holds true even if the top-level `errorSummary` and the `errorCauses` objects are omitted.
 
 ## Timeout behavior
 
-If there is a response timeout after receiving the Okta request, the Okta process flow stops. Depending on the request, either the self-service registration or the profile update is denied. One of the following messages appears:
+If there is a response timeout after receiving the Okta request, the Okta process flow stops. Depending on the request, either the self-service registration or the profile update is denied. One of the following default UI messages appears:
 
-* `There was an error creating your account. Please try registering again.` (SSR)
-* `There was an error updating your profile. Please try again later.` (Profile Enrollment)
+* "There was an error creating your account. Please try registering again." (SSR)
+* "There was an error updating your profile. Please try again later." (Profile Enrollment)
 
 ## Sample JSON payload of request
 

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -19,18 +19,18 @@ For a general introduction to Okta Inline Hooks, see [Inline Hooks](/docs/concep
 
 For information on the API for registering external service endpoints with Okta, see [Inline Hooks Management API](/docs/reference/api/inline-hooks/).
 
-For steps to enable this Inline Hook, see [Enabling a Registration Inline Hook](#enable-a-registration-inline-hook-in-okta-identity-engine). <ApiLifecycle access="ie" /><br>
+For steps to enable this Inline Hook, see [Enabling a Registration Inline Hook](/docs/guides/registration-inline-hook/nodejs/main/#enable-the-registration-inline-hook).
 
 For an example implementation of this Inline Hook, see [Registration Inline Hook](/docs/guides/registration-inline-hook/nodejs/main/).
 
 ## About
 
-The Okta Registration Inline Hook allows you to integrate your own custom code into Okta's [Profile Enrollment](https://help.okta.com/okta_help.htm?type=oie&id=ext-create-profile-enrollment) flow. The hook is triggered after Okta receives the registration request but before the user is created. Your custom code can:
+The Okta Registration Inline Hook allows you to integrate your own custom code into Okta's [Profile Enrollment](https://help.okta.com/okta_help.htm?type=oie&id=ext-create-profile-enrollment) flow. The hook is triggered after Okta receives the registration or profile update request. Your custom code can:
 
-- Set or override the values that will be populated in attributes of the user's Okta profile
 - Allow or deny the registration attempt, based on your own validation of the information the user has submitted
+- Set or override the values that will be populated in attributes of the user's Okta profile
 
-> **Note:** Profile Enrollment and Registration Inline Hooks only work with the [Okta Sign-In Widget](/code/javascript/okta_sign-in_widget/) version 4.5 or later.
+> **Note:** Profile Enrollment and self-service registration (SSR) Inline Hooks only work with the [Okta Sign-In Widget](/code/javascript/okta_sign-in_widget/) version 4.5 or later.
 
 ## Objects in the Request from Okta
 
@@ -44,7 +44,7 @@ Values for `requestType` are one of the following:
 
 | Enum Value | Associated Okta Event |
 |----------|-------------------------------------------------------|
-| `self.service.registration` | self-service registration |
+| `self.service.registration` | self-service registration (SSR) |
 | `progressive.profile` | Progressive Enrollment |
 
 ### data.userProfile
@@ -91,11 +91,11 @@ The action is `ALLOW` by default (in practice, `DENY` will never be sent to your
 
 Using the `com.okta.action.update` [command](#supported-commands) in your response, you can change the action that Okta will take.
 
+<!-- Need to clarify if we need to include this in the docs. right now, it has no content. in the context of the registration inline hook guide, it allows customers to include the object in the console.log().
+
 ### data.context.user
 
-<ApiLifecycle access="ie" /><br>
-
-
+<ApiLifecycle access="ie" /><br> -->
 
 ## Response objects that you send
 
@@ -203,21 +203,24 @@ For the Registration Inline Hook, the `error` object provides a way of displayin
 * If you're using the Okta Sign-In Widget for Profile Enrollment, only the `errorSummary` messages of the `errorCauses` objects that your external service returns appear as inline errors, given the following:
 
    * You don't customize the error handling behavior of the widget.
-   * The `location` of `errorSummary` in the `errorCauses` object specifies the request object's user profile attribute. See [JSON response payload objects - error](/docs/concepts/inline-hooks/#error).
+   * The `location` of `errorSummary` in the `errorCauses` object specifies the request object's user profile attribute.
 
 * If you don't return a value for the `errorCauses` object, and deny the user's registration attempt through the `commands` object in your response to Okta, one of the following generic messages appears to the end user:</br></br>
-      `Registration cannot be completed at this time.`</br></br>
-      `We found some errors. Please review the form and make corrections.` <ApiLifecycle access="ie" />
+   * `Registration cannot be completed at this time.` (SSR)</br></br>
+   * `We found some errors. Please review the form and make corrections.` (Progressive Enrollment)
 
 * If you don't return an `error` object at all and the registration is denied, the following generic message appears to the end user:</br></br>
-      `Registration denied.`</br></br>
-      `Profile update denied.` <ApiLifecycle access="ie" />
+   * `Registration denied.`(SSR)</br></br>
+   * `Profile update denied.` (Progressive Enrollment)
 
 > **Note:** If you include an error object in your response, no commands are executed and the registration fails. This holds true even if the top-level `errorSummary` and the `errorCauses` objects are omitted.
 
 ## Timeout behavior
 
-If there is a response timeout after receiving the Okta request, the Okta process flow stops and registration is denied. The following message appears: "There was an error creating your account. Please try registering again".
+If there is a response timeout after receiving the Okta request, the Okta process flow stops. Depending on the request, either the self-service registration or the profile update is denied. One of the following messages appears:
+
+* `There was an error creating your account. Please try registering again.` (SSR)
+* `There was an error updating your profile. Please try again later.` (Profile Enrollment)
 
 ## Sample JSON payload of request
 


### PR DESCRIPTION
## Description
- **What's changed?** Adds the new timeout error for Progressive Enrollment using Registration Inline Hooks. Tweaks the formatting of the existing content. Also, while under the hood, updates the sample requests/response in the ref doc (based on what's already published in the registration inline hook guide).
- **Is this PR related to a Monolith release?** Yes. 2022.05.3

### Netlify link:
https://6286edc0f1c2e26d8beb8ce9--reverent-murdock-829d24.netlify.app/docs/reference/registration-hook/#timeout-behavior

### Resolves:
* [OKTA-499896](https://oktainc.atlassian.net/browse/OKTA-499896)
