### PR TITLE
Patch 1

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language-in-identity-engine/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language-in-identity-engine/index.md
@@ -92,9 +92,9 @@ Okta offers a variety of functions to manipulate properties to generate a desire
 | `$string_object.toLowerCase`            | -                                             | String      | `'TEST'.toLowerCase()`                           | "test"           |
 | `$string_object.substring`              | (int startIndex)                              | String      | `'test.substring(1)'`                            | "est"            |
 | `$string_object.substring`              | (int startIndex, int endIndex)                | String      | `user.profile.firstName.substring(1,3)`          | "oh"             |
-| `$string_object.replace`                | (String match, String replacement)            | String      | `'hello'.replace('l', 'p')`                      | "heppo"          |
+| `$string_object.replace`                | (String match, String replacement)            | String      | `'hello'.replace('l', 'p')`                      | "heplo"          |
 |                                         |                                               |             | `user.profile.firstName.replace('ohn', 'ames')`  | "James"          |
-| `$string_object.replaceFirst`           | (String match, String replacement)            | String      | `'hello'.replaceFirst('l', 'p')`                 | "helpo"          |
+| `$string_object.replaceFirst`           | (String match, String replacement)            | String      | `'hello'.replaceFirst('l', 'p')`                 | "heplo"          |
 | `$string_object.length`                 | -                                             | Integer     | `'test'.length()`                                | 4                |
 | `$string_object.removeSpaces`           | -                                             | String      | `'This is a test'.removeSpaces()`                | "Thisisatest"    |
 | `$string_object.contains`               | (String searchString)                         | Boolean     | `'This is a test'.contains('test')`              | True             |

--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language-in-identity-engine/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language-in-identity-engine/index.md
@@ -92,7 +92,7 @@ Okta offers a variety of functions to manipulate properties to generate a desire
 | `$string_object.toLowerCase`            | -                                             | String      | `'TEST'.toLowerCase()`                           | "test"           |
 | `$string_object.substring`              | (int startIndex)                              | String      | `'test.substring(1)'`                            | "est"            |
 | `$string_object.substring`              | (int startIndex, int endIndex)                | String      | `user.profile.firstName.substring(1,3)`          | "oh"             |
-| `$string_object.replace`                | (String match, String replacement)            | String      | `'hello'.replace('l', 'p')`                      | "heplo"          |
+| `$string_object.replace`                | (String match, String replacement)            | String      | `'hello'.replace('l', 'p')`                      | "heppo"          |
 |                                         |                                               |             | `user.profile.firstName.replace('ohn', 'ames')`  | "James"          |
 | `$string_object.replaceFirst`           | (String match, String replacement)            | String      | `'hello'.replaceFirst('l', 'p')`                 | "heplo"          |
 | `$string_object.length`                 | -                                             | Integer     | `'test'.length()`                                | 4                |


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Corrected the example for replaceFirst "'hello'.replaceFirst('l', 'p')".  The example previously replaced the second L in hello instead of the first.
- **Is this PR related to a Monolith release?** no

### Resolves:

* NA
