### PR TITLE
Samples for Okta React/Vue SDKs - start OktaAuth manually

### DIFF
--- a/packages/@okta/vuepress-site/code/react/okta_react/index.md
+++ b/packages/@okta/vuepress-site/code/react/okta_react/index.md
@@ -372,26 +372,26 @@ import Home from './Home';
 import SignIn from './SignIn';
 import Protected from './Protected';
 
+const oktaAuth = new OktaAuth({
+  issuer: 'https://${yourOktaDomain}/oauth2/default',
+  clientId: '${clientId}',
+  redirectUri: window.location.origin + '/login/callback',
+  pkce: true
+});
+oktaAuth.start();
+
 const AppWithRouterAccess = () => {
   const history = useHistory();
   const onAuthRequired = () => {
     history.push('/login');
   };
 
-  const oktaAuth = new OktaAuth({
-    issuer: 'https://${yourOktaDomain}/oauth2/default',
-    clientId: '${clientId}',
-    redirectUri: window.location.origin + '/login/callback',
-    onAuthRequired: onAuthRequired,
-    pkce: true
-  });
-
   const restoreOriginalUri = async (_oktaAuth, originalUri) => {
     history.replace(toRelativeUrl(originalUri, window.location.origin));
   };
 
   return (
-    <Security oktaAuth={oktaAuth} restoreOriginalUri={restoreOriginalUri}>
+    <Security oktaAuth={oktaAuth} restoreOriginalUri={restoreOriginalUri} onAuthRequired={onAuthRequired}>
       <Route path='/' exact={true} component={Home} />
       <SecureRoute path='/protected' component={Protected} />
       <Route path='/login' render={() => <SignIn />} />
@@ -442,6 +442,7 @@ export default withRouter(class AppWithRouterAccess extends Component {
       onAuthRequired: this.onAuthRequired,
       pkce: true
     });
+    this.oktaAuth.start();
   }
 
   onAuthRequired() {

--- a/packages/@okta/vuepress-site/code/react/okta_react_sign-in_widget/index.md
+++ b/packages/@okta/vuepress-site/code/react/okta_react_sign-in_widget/index.md
@@ -260,6 +260,7 @@ import Protected from './Protected';
 import { oktaAuthConfig, oktaSignInConfig } from './config';
 
 const oktaAuth = new OktaAuth(oktaAuthConfig);
+oktaAuth.start();
 
 const AppWithRouterAccess = () => {
   const history = useHistory();

--- a/packages/@okta/vuepress-site/code/vue/okta_vue/index.md
+++ b/packages/@okta/vuepress-site/code/vue/okta_vue/index.md
@@ -88,6 +88,7 @@ const authClient = new OktaAuth({
   scopes: ['openid', 'email', 'profile'],
   redirectUri: window.location.origin + '/login/callback'
 })
+authClient.start();
 
 export default {
   login (email, pass, cb) {

--- a/packages/@okta/vuepress-site/code/vue/okta_vue_sign-in_widget/index.md
+++ b/packages/@okta/vuepress-site/code/vue/okta_vue_sign-in_widget/index.md
@@ -102,6 +102,7 @@ const oktaAuth = new OktaAuth({
   redirectUri: window.location.origin + '/login/callback',
   scopes: ['openid', 'profile', 'email']
 })
+oktaAuth.start();
 
 export { oktaAuth, oktaSignIn };
 ```

--- a/packages/@okta/vuepress-site/docs/guides/archive-sign-in-to-spa-authjs/main/react/guide.md
+++ b/packages/@okta/vuepress-site/docs/guides/archive-sign-in-to-spa-authjs/main/react/guide.md
@@ -374,26 +374,26 @@ import Home from './Home';
 import SignIn from './SignIn';
 import Protected from './Protected';
 
+const oktaAuth = new OktaAuth({
+  issuer: 'https://${yourOktaDomain}/oauth2/default',
+  clientId: '${clientId}',
+  redirectUri: window.location.origin + '/login/callback',
+  pkce: true
+});
+oktaAuth.start();
+
 const AppWithRouterAccess = () => {
   const history = useHistory();
   const onAuthRequired = () => {
     history.push('/login');
   };
 
-  const oktaAuth = new OktaAuth({
-    issuer: 'https://${yourOktaDomain}/oauth2/default',
-    clientId: '${clientId}',
-    redirectUri: window.location.origin + '/login/callback',
-    onAuthRequired: onAuthRequired,
-    pkce: true
-  });
-
   const restoreOriginalUri = async (_oktaAuth, originalUri) => {
     history.replace(toRelativeUrl(originalUri, window.location.origin));
   };
 
   return (
-    <Security oktaAuth={oktaAuth} restoreOriginalUri={restoreOriginalUri}>
+    <Security oktaAuth={oktaAuth} restoreOriginalUri={restoreOriginalUri} onAuthRequired={onAuthRequired}>
       <Route path='/' exact={true} component={Home} />
       <SecureRoute path='/protected' component={Protected} />
       <Route path='/login' render={() => <SignIn />} />
@@ -444,6 +444,7 @@ export default withRouter(class AppWithRouterAccess extends Component {
       onAuthRequired: this.onAuthRequired,
       pkce: true
     });
+    this.oktaAuth.start();
   }
 
   onAuthRequired() {

--- a/packages/@okta/vuepress-site/docs/guides/archive-sign-in-to-spa-authjs/main/vue/guide.md
+++ b/packages/@okta/vuepress-site/docs/guides/archive-sign-in-to-spa-authjs/main/vue/guide.md
@@ -90,6 +90,7 @@ const authClient = new OktaAuth({
   scopes: ['openid', 'email', 'profile'],
   redirectUri: window.location.origin + '/login/callback'
 })
+authClient.start()
 
 export default {
   login (email, pass, cb) {

--- a/packages/@okta/vuepress-site/docs/guides/archive-sign-in-to-spa-embedded-widget/main/react/guide.md
+++ b/packages/@okta/vuepress-site/docs/guides/archive-sign-in-to-spa-embedded-widget/main/react/guide.md
@@ -262,6 +262,7 @@ import Protected from './Protected';
 import { oktaAuthConfig, oktaSignInConfig } from './config';
 
 const oktaAuth = new OktaAuth(oktaAuthConfig);
+oktaAuth.start();
 
 const AppWithRouterAccess = () => {
   const history = useHistory();

--- a/packages/@okta/vuepress-site/docs/guides/archive-sign-in-to-spa-embedded-widget/main/vue/guide.md
+++ b/packages/@okta/vuepress-site/docs/guides/archive-sign-in-to-spa-embedded-widget/main/vue/guide.md
@@ -104,6 +104,7 @@ const oktaAuth = new OktaAuth({
   redirectUri: window.location.origin + '/login/callback',
   scopes: ['openid', 'profile', 'email']
 })
+oktaAuth.start()
 
 export { oktaAuth, oktaSignIn };
 ```

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/basic-sign-in.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/basic-sign-in.md
@@ -40,6 +40,7 @@ function createOktaAuthInstance() {
 }
 
 const oktaAuth = createOktaAuthInstance();
+oktaAuth.start();
 
 ...
 ```

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/vue/sign-in-form.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/vue/sign-in-form.md
@@ -152,6 +152,7 @@ import OktaVue from '@okta/okta-vue'
 import sampleConfig from '@/config'
 
 const oktaAuth = new OktaAuth(sampleConfig.oidc)
+oktaAuth.start();
 
 createApp(App)
 .directive('focus', {

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/react/basic-sign-in.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/react/basic-sign-in.md
@@ -155,6 +155,7 @@ import logo from './logo.svg';
 import './App.css';
 
 const oktaAuth = new OktaAuth(config.oidc);
+oktaAuth.start();
 
 const App = () => {
   const history = useHistory();

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/vue/load-app.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/vue/load-app.md
@@ -40,6 +40,7 @@ import OktaVue from '@okta/okta-vue'
 import sampleConfig from '@/config'
 
 const oktaAuth = new OktaAuth(sampleConfig.oidc)
+oktaAuth.start();
 
 createApp(App)
   .use(router)

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/react/configmid.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/react/configmid.md
@@ -14,6 +14,7 @@ The Okta React SDK requires an instance of an `OktaAuth` object with configurati
      clientId: '${yourClientID}',
      redirectUri: window.location.origin + '/login/callback'
    });
+   oktaAuth.start();
 
    class App extends Component {
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/vue/loginredirect.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/vue/loginredirect.md
@@ -10,6 +10,7 @@
    import sampleConfig from '@/config'
 
    const oktaAuth = new OktaAuth(sampleConfig.oidc)
+   oktaAuth.start()
 
    createApp(App)
      .use(router)


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** In `okta-react` and `okta-vue` samples `oktaAuth.start()` should be called manually as `start/stop` are no longer called inside lifecycle methods of components these SDKs provide
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-492710](https://oktainc.atlassian.net/browse/OKTA-492710)
* [OKTA-492711](https://oktainc.atlassian.net/browse/OKTA-492711)
