### PR TITLE
Remove AnnouncementBanner from home page

### DIFF
--- a/packages/@okta/vuepress-theme-prose/components/Home.vue
+++ b/packages/@okta/vuepress-theme-prose/components/Home.vue
@@ -5,11 +5,6 @@
         <Sidebar />
       </div>
       <div class="width-adjuster">
-        <AnnouncementBanner>
-          <template v-slot:description>
-            For more information and frequently asked questions regarding the January 2022 security incident, <a href="https://support.okta.com/help/s/article/Frequently-Asked-Questions-Regarding-January-2022-Compromise?language=en_US#" target="_blank" rel="noopener noreferrer">read more</a>.
-          </template>
-        </AnnouncementBanner>
         <div class="justify-content-center">
           <div class="homepage--elevated">
             <div class="homepage--top-section homepage--section-margins">
@@ -172,7 +167,6 @@ export default {
     FrontPageCodeMirror: () => import("../components/FrontPageCodeMirror"),
     CompanyLogos: () => import("../components/CompanyLogos"),
     SmartLink: () => import("../components/SmartLink"),
-    AnnouncementBanner: () => import("../global-components/AnnouncementBanner")
   },
 
   data() {


### PR DESCRIPTION
## Description:
- **What's changed?**
- Remove `AnnouncementBanner` instance from `home.vue`. The component remains available for future messages.

### Resolves:
* [OKTA-499183](https://oktainc.atlassian.net/browse/OKTA-499183)