### PR TITLE
pkce_required parameter on apps api

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -1328,6 +1328,7 @@ Adds an OAuth 2.0 client application. This application is only available to the 
 | client_id                    | Unique identifier for the client application. **Note:** When not specified, `client_id` and application `id` are the same. You can specify a `client_id`, if necessary. See the [OAuth Credential object](#oauth-credential-object) section for more details.   | String     |                       |
 | client_secret                | OAuth 2.0 client secret string (used for confidential clients)                                                                                      | String     |                       |
 | token_endpoint_auth_method   | Requested authentication method for the token endpoint. Valid values: `none`, `client_secret_post`, `client_secret_basic`, `client_secret_jwt`, or `private_key_jwt`   | String     | `client_secret_basic` |
+| pkce_required                | Require Proof Key for Code Exchange (PKCE) for additional verification | Boolean  | `true` for `browser` and `native` application types |
 
 ##### Settings
 
@@ -7994,6 +7995,7 @@ Determines how to authenticate the OAuth 2.0 client
 | client_id                  | Unique identifier for the OAuth 2.0 client application                           | String   | TRUE     |
 | client_secret              | OAuth 2.0 client secret string                                                   | String   | TRUE     |
 | token_endpoint_auth_method | Requested authentication method for the token endpoint                           | String   | FALSE    |
+| pkce_required              | Require Proof Key for Code Exchange (PKCE) for additional verification           | Boolean  | TRUE     |
 
 * When you create an OAuth 2.0 client application, you can specify the `client_id`, or Okta sets it as the same value as the application ID. Thereafter, the `client_id` is immutable.
 
@@ -8003,13 +8005,16 @@ Determines how to authenticate the OAuth 2.0 client
 
 * If `autoKeyRotation` isn't specified, the client automatically opts in for Okta's [key rotation](/docs/concepts/key-rotation/). You can update this property via the API or via the administrator UI.
 
+* `pkce_required` can be used to opt in/out to require PKCE for their confidential clients using [Authorization Code flow](/docs/guides/implement-grant-type/authcodepkce/main/). If `token_endpoint_auth_method` is `none`, `pkce_required` needs to be `true`. If `pkce_required` isn't specified when adding a new application, Okta will set it to `true` by default for `browser` and `native` application types.
+
 ```json
 {
   "oauthClient": {
     "autoKeyRotation": false,
     "client_id": "0oa1hm4POxgJM6CPu0g4",
     "client_secret": "5jVbn2W72FOAWeQCg7-s_PA0aLqHWjHvUCt2xk-z",
-    "token_endpoint_auth_method": "client_secret_post"
+    "token_endpoint_auth_method": "client_secret_post",
+    "pkce_required": true
   }
 }
 ```

--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -8005,7 +8005,7 @@ Determines how to authenticate the OAuth 2.0 client
 
 * If `autoKeyRotation` isn't specified, the client automatically opts in for Okta's [key rotation](/docs/concepts/key-rotation/). You can update this property via the API or via the administrator UI.
 
-* `pkce_required` can be used to opt in/out to require PKCE for their confidential clients using [Authorization Code flow](/docs/guides/implement-grant-type/authcodepkce/main/). If `token_endpoint_auth_method` is `none`, `pkce_required` needs to be `true`. If `pkce_required` isn't specified when adding a new application, Okta will set it to `true` by default for `browser` and `native` application types.
+* Use `pkce_required` to require PKCE for your confidential clients using [Authorization Code flow](/docs/guides/implement-grant-type/authcodepkce/main/). If `token_endpoint_auth_method` is `none`, `pkce_required` needs to be `true`. If `pkce_required` isn't specified when adding a new application, Okta sets it to `true` by default for `browser` and `native` application types.
 
 ```json
 {


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. --> Customers can choose to opt in/out to require PKCE for their confidential clients. For this purpose add a new boolean parameter called `pkce_required` on `Credentials` object on apps API. 
https://developer.okta.com/docs/reference/api/apps/#oauth-credential-object
- **Is this PR related to a Monolith release?** <!-- If so, which one? --> Yes `2022.06.0`

### Resolves:

* [OKTA-500152](https://oktainc.atlassian.net/browse/OKTA-500152)
