### PR TITLE
OKTA-470845 Minor update to Administrator Roles API reference

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/roles/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/roles/index.md
@@ -3114,7 +3114,7 @@ The following are the supported resources.
 |                         | A specific Group                                                    | `orn:${partition}:directory:${yourOrgId}:groups:${groupId}`                           | [`https://${yourOktaDomain}/api/v1/groups/${groupId}`](/docs/reference/api/groups/#get-group)                                                           |
 |                         | All Users within a specific Group                                   | `orn:${partition}:directory:${yourOrgId}:groups:${groupId}:contained_resources`       | [`https://${yourOktaDomain}/api/v1/groups/${groupId}/users`](/docs/reference/api/groups/#list-group-members)                                            |
 | Identity Provider       | All Apps                                                            | `orn:${partition}:idp:${yourOrgId}:apps`                                              | [`https://${yourOktaDomain}/api/v1/apps`](/docs/reference/api/apps/#list-applications)                                                                  |
-|                         | All Apps of a specific type                                         | `orn:${partition}:idp:${yourOrgId}:apps:${appType}`                                   | [`https://${yourOktaDomain}/api/v1/apps/?filter=name+eq+\"${targetAppType}\"`](/docs/reference/api/apps/#list-apps-by-name)                             |
+|                         | All Apps of a specific type                                         | `orn:${partition}:idp:${yourOrgId}:apps:${appType}`                                   | [`https://${yourOktaDomain}/api/v1/apps/?filter=name+eq+%22${targetAppType}%22`](/docs/reference/api/apps/#list-apps-by-name)                             |
 |                         | A specific App                                                      | `orn:${partition}:idp:${yourOrgId}:apps:${appType}:${appId}`                          | [`https://${yourOktaDomain}/api/v1/apps/${appId}`](/docs/reference/api/apps/#get-application)                                                           |
 |                         | All Authorization Servers         <br><ApiLifecycle access="ea" />  | `orn:${partition}:idp:${yourOrgId}:authorization_servers`                             | [`https://${yourOktaDomain}/api/v1/authorizationServers`](/docs/reference/api/authorization-servers/#list-authorization-servers)                        |
 |                         | A specific Authorization Server   <br><ApiLifecycle access="ea" />  | `orn:${partition}:idp:${yourOrgId}:authorization_servers:${authorizationServerId}`    | [`https://${yourOktaDomain}/api/v1/authorizationServers/${authorizationServerId}`](/docs/reference/api/authorization-servers/#get-authorization-server) |
@@ -3208,7 +3208,7 @@ The ID of a resource is unique to the Resource Set, whereas the link that points
       "lastUpdated": "2021-02-06T16:20:57.000Z",
       "_links": {
         "apps": {
-          "href": "https://{yourOktaDomain}/api/v1/apps?filter=name+eq+\"workday\""
+          "href": "https://{yourOktaDomain}/api/v1/apps?filter=name+eq+%22workday%22"
         }
       }
     }


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Updated [supported resources](https://developer.okta.com/docs/reference/api/roles/#supported-resources) table to add URL encoding to one REST URL.

I also have a question about the response example for this particular API. The response example ([All apps of the same type of resource](https://developer.okta.com/docs/reference/api/roles/#all-apps-of-the-same-type-as-resource)) includes a filter and escaped character in the response, but calling the API brings back only individual apps. I believe the given example is incorrect. Can you verify? 

ie: `"https://{yourOktaDomain}/api/v1/apps?filter=name+eq+\"workday\""` , I think, should look like:

`"https://{yourOktaDomain}/home/{targetAppType}/0oa1gjh63g214q0Hq0g4`

(Also, I see the property `_links.apps` but the calls I made return `_links.appLinks`. Do these examples need to be updated?). See this [Google doc](https://docs.google.com/document/d/1c3sOhKZq9HXZnduIrn12oe0alOnC2ElfGnlq6EyeWvY/edit?usp=sharing) for my brief testing.

- **Is this PR related to a Monolith release?** n/a

### Resolves:

* [OKTA-470845](https://oktainc.atlassian.net/browse/OKTA-470845)
