### PR TITLE
OKTA-502738 - Fix typo in Devices API

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/devices/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/devices/index.md
@@ -801,7 +801,7 @@ Content-Type: application/json
 #### Error responses
 
 * Passing an invalid `id` returns a `404 Not Found` status code with error code `E0000007`.
-* Passing an `id` that is not in the `ACTIVE` or `SUSPENEDED` status returns a `400 Bad Request` status code with error code `E0000001`.
+* Passing an `id` that is not in the `ACTIVE` or `SUSPENDED` status returns a `400 Bad Request` status code with the error code `E0000001`.
 
 ### Suspend Device
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Fixed type in error responses section of the [Deactivate Device](https://developer.okta.com/docs/reference/api/devices/#deactivate-device) section. (`SUSPENEDED`)
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* [OKTA-502738](https://oktainc.atlassian.net/browse/OKTA-502738)
