### PR TITLE
Comment out Sign-in Widget on Home page

### DIFF
--- a/packages/@okta/vuepress-theme-prose/components/Home.vue
+++ b/packages/@okta/vuepress-theme-prose/components/Home.vue
@@ -141,7 +141,11 @@
                 </div>
               </div>
             </div> -->
-
+            <div>
+            <br>
+            <br>
+            <!-- empty div for spacing  -->
+            </div>
             <div
               class="homepage--partners-block-margin homepage--section-margins"
             >

--- a/packages/@okta/vuepress-theme-prose/components/Home.vue
+++ b/packages/@okta/vuepress-theme-prose/components/Home.vue
@@ -54,7 +54,7 @@
                 </div>
               </div>
             </div>
-            <div
+           <!-- <div
               class="homepage--customize-your-app-margin homepage--section-margins"
             >
               <h2
@@ -140,7 +140,7 @@
                   </div>
                 </div>
               </div>
-            </div>
+            </div> -->
 
             <div
               class="homepage--partners-block-margin homepage--section-margins"


### PR DESCRIPTION
## Description:
- **What's changed?** Removing the out-dated widget on the developer.okta.com [home page](https://developer.okta.com/) (Scroll down to Customize your sign-in)

- **Is this PR related to a Monolith release?** n/a

### Resolves:

* as per Slack conversation of June 6, 2022
* [OKTA-479073](https://oktainc.atlassian.net/browse/OKTA-479073)