### PR TITLE
Add doc messaging for device context issue

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/authenticators-okta-verify/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-okta-verify/main/index.md
@@ -2,7 +2,7 @@
 title: Okta Verify (Push/OTP) integration guide
 ---
 
-> **Note:** The expected behavior of Okta Verify is to reflect the context of the original client request when receiving a Push Notification. This behavior is not honored in proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers. Specifically, the Okta Verify push notification always displays the server's IP Address and user agent regardless of any passed in request context. As a result, Okta Verify will be unavailable for server-side applications using the Embedded SDK until we find a solution to this issue.
+> **Note:** The expected behavior of Okta Verify is to reflect the context of the original client request when receiving a Push Notification. This behavior is not honored in proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers. Specifically, the Okta Verify push notification always displays the server's IP Address and user agent regardless of any passed-in request context. As a result, Okta Verify will be unavailable for server-side applications using the Embedded SDK until we find a solution to this issue.
 
 <!--
 

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-okta-verify/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-okta-verify/main/index.md
@@ -2,6 +2,10 @@
 title: Okta Verify (Push/OTP) integration guide
 ---
 
+> **Note:** The expected behavior of Okta Verify is to reflect the context of the original client request when receiving a Push Notification. This behavior is not honored in proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers. Specifically, the Okta Verify push notification always displays the server's IP Address and user agent regardless of any passed in request context. As a result, Okta Verify will be unavailable for server-side applications using the Embedded SDK until we find a solution to this issue.
+
+<!--
+
 <div class="oie-embedded-sdk">
 
 <ApiLifecycle access="ie" /><br>
@@ -9,6 +13,7 @@ title: Okta Verify (Push/OTP) integration guide
 Learn how to integrate Okta Verify into your app using the embedded SDK.
 
 ---
+
 **Learning outcomes**
 
 * Understand the Okta Verify enrollment and challenge flows
@@ -168,3 +173,4 @@ The following diagram summarizes this flow.
 <StackSnippet snippet="relatedusecases" />
 
 </div>
+-->

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/index.md
@@ -24,6 +24,8 @@ Understand how to implement basic sign-in using Okta Identity Engine.
 
 ---
 
+> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
+
 ## Configuration updates
 
 The basic user sign-in use case requires the password factor.

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/index.md
@@ -4,6 +4,8 @@ title: Basic sign-in flow using the password factor
 
 <ApiLifecycle access="ie" />
 
+> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
+
 This guide covers a basic user sign-in request, which is the simplest of all use cases and is the first use case that you should try after you install the SDK. The flow diagram and steps describe how to build a simple sign-in form and how to authenticate the credentials.
 
 ---
@@ -23,8 +25,6 @@ Understand how to implement basic sign-in using Okta Identity Engine.
 <StackSnippet snippet="samplecode" />
 
 ---
-
-> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
 
 ## Configuration updates
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-new-user-activation/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-new-user-activation/main/index.md
@@ -6,6 +6,8 @@ title: New user activation
 
 <ApiLifecycle access="ie" /><br>
 
+> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
+
 Learn how to use the Embedded SDK to integrate user activation with self-service registration
 
 **Learning outcomes**
@@ -23,8 +25,6 @@ Learn how to use the Embedded SDK to integrate user activation with self-service
 <StackSnippet snippet="samplecode" />
 
 ---
-
-> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
 
 ## Overview
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-new-user-activation/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-new-user-activation/main/index.md
@@ -24,6 +24,8 @@ Learn how to use the Embedded SDK to integrate user activation with self-service
 
 ---
 
+> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
+
 ## Overview
 
 User activation is the final step in self-service registration, where a user proves ownership of the email they've used during registration. After the email is verified, their account status changes to active and they are allowed to sign in to your app. How you integrate user activation depends on how you've implemented self-service registration. With the Embedded SDK, Okta supports two main self-service registration architectures: registration with the Embedded SDK or with the Okta API and Embedded SDK. Each architecture supports a unique way to integrate a user activation.

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-pwd-recovery-mfa/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-pwd-recovery-mfa/main/index.md
@@ -6,6 +6,8 @@ title: User password recovery
 
 <ApiLifecycle access="ie" />
 
+> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
+
 This use case describes how to integrate a password recovery flow into your app using an Okta SDK. The flow includes an email factor step that the user needs to verify before updating their password.
 
 ---
@@ -26,8 +28,6 @@ This use case describes how to integrate a password recovery flow into your app 
 <StackSnippet snippet="samplecode" />
 
 ---
-
-> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
 
 ## Configuration updates
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-pwd-recovery-mfa/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-pwd-recovery-mfa/main/index.md
@@ -27,6 +27,8 @@ This use case describes how to integrate a password recovery flow into your app 
 
 ---
 
+> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
+
 ## Configuration updates
 
 The password recovery use case requires the **password** and **email** factors.

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-self-reg/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-self-reg/main/index.md
@@ -26,6 +26,8 @@ This guide covers self-service registration, which allows users to sign up for t
 
 ---
 
+> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
+
 ## Configuration updates
 
 Before you can build the self-registration flow in your app, you must configure the Okta org to accept self-registration with the password, email, and/or phone factors. See [Set up your Okta org for a multifactor use case](/docs/guides/oie-embedded-common-org-setup/-/main/#set-up-your-okta-org-for-a-multifactor-use-case) to set up the password, email, and phone factors in your Okta org.

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-self-reg/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-self-reg/main/index.md
@@ -4,6 +4,8 @@ title: Self-service registration
 
 <ApiLifecycle access="ie" />
 
+> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
+
 This guide covers self-service registration, which allows users to sign up for the app themselves. In this use case, the user must register with a password, email, and/or phone factors. You must first enable the self-service registration option for your app in the Okta org and then build the self-service registration flow in your app.
 
 ---
@@ -25,8 +27,6 @@ This guide covers self-service registration, which allows users to sign up for t
 <StackSnippet snippet="samplecode" />
 
 ---
-
-> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
 
 ## Configuration updates
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/main/index.md
@@ -24,6 +24,8 @@ Understand how to implement a user sign-in flow with password and email factors.
 
 ---
 
+> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
+
 ## Configuration updates
 
 This use case requires the password and email factors.

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/main/index.md
@@ -4,6 +4,8 @@ title: Sign in with password and email factors
 
 <ApiLifecycle access="ie" />
 
+> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
+
 This guide covers the use case for a user sign-in flow with password and email factors, and provides a flow diagram and a sequence of integration steps.
 
 ---
@@ -23,8 +25,6 @@ Understand how to implement a user sign-in flow with password and email factors.
 <StackSnippet snippet="samplecode" />
 
 ---
-
-> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
 
 ## Configuration updates
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/main/index.md
@@ -24,6 +24,8 @@ Understand how to implement a user sign-in flow with password and phone factors.
 
 ---
 
+> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
+
 ## Configuration updates
 
 This sign-in use case requires the password and phone factors.

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/main/index.md
@@ -4,6 +4,8 @@ title: Sign in with password and phone factors
 
 <ApiLifecycle access="ie" />
 
+> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
+
 This guide covers the use case for a user sign-in flow with password and phone factors.
 
 ---
@@ -23,8 +25,6 @@ Understand how to implement a user sign-in flow with password and phone factors.
 <StackSnippet snippet="samplecode" />
 
 ---
-
-> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
 
 ## Configuration updates
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-soc-idp/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-soc-idp/main/index.md
@@ -24,6 +24,8 @@ Set up your Okta org and app to support sign-in with Facebook IdP use cases.
 
 ---
 
+> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
+
 ## Configuration updates
 
 Before you build the Facebook IdP sign-in flow, ensure that you've [set up your app for a password factor only use case](/docs/guides/oie-embedded-common-org-setup/-/main/#set-up-your-okta-org-for-a-password-factor-only-use-case) and [set up your Okta org for a social IdP use case](/docs/guides/oie-embedded-common-org-setup/-/main/#set-up-your-okta-org-for-a-social-idp-use-case).

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-soc-idp/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-soc-idp/main/index.md
@@ -4,6 +4,8 @@ title: Sign in with Facebook
 
 <ApiLifecycle access="ie" />
 
+> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
+
 This guide covers a sequence of steps that you can follow to build an app that allows users to sign in with the Facebook social Identity Provider.
 
 ---
@@ -23,8 +25,6 @@ Set up your Okta org and app to support sign-in with Facebook IdP use cases.
 <StackSnippet snippet="samplecode" />
 
 ---
-
-> **Note:** In proxy model architectures, where a server-side application using the Embedded SDK is used as a proxy between client applications and Okta servers, a request context for the client applications is required. Security enforcement is expected to be based on the client request context’s IP address and user agent. However, since these values are currently being derived from the server application rather than the client, this enforcement is not available. As a result, network zones or behaviors that drive their conditions based on these request context values (geolocation, IP Address, or user agent) will not work until we can find a solution to the issue.
 
 ## Configuration updates
 


### PR DESCRIPTION
## Description:
Add doc messaging for device context issue

### Resolves:
* [OKTA-505593](https://oktainc.atlassian.net/browse/OKTA-505593)

### Deploy links:

Okta Verify: https://62a2b0aa8c939049304103b2--reverent-murdock-829d24.netlify.app/docs/guides/authenticators-okta-verify/aspnet/main/

Basic sign-in flow using the password factor: https://62a2b0aa8c939049304103b2--reverent-murdock-829d24.netlify.app/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/aspnet/main/

Sign in with Facebook: https://62a2b0aa8c939049304103b2--reverent-murdock-829d24.netlify.app/docs/guides/oie-embedded-sdk-use-case-sign-in-soc-idp/aspnet/main/

User password recovery: https://62a2b0aa8c939049304103b2--reverent-murdock-829d24.netlify.app/docs/guides/oie-embedded-sdk-use-case-pwd-recovery-mfa/aspnet/main/

Self-service registration: https://62a2b0aa8c939049304103b2--reverent-murdock-829d24.netlify.app/docs/guides/oie-embedded-sdk-use-case-self-reg/aspnet/main/

New user activation: https://62a2b0aa8c939049304103b2--reverent-murdock-829d24.netlify.app/docs/guides/oie-embedded-sdk-use-case-new-user-activation/nodeexpress/main/

Sign in with password and email factors: https://62a2b0aa8c939049304103b2--reverent-murdock-829d24.netlify.app/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/android/main/

Sign in with password and phone factors: https://62a2b0aa8c939049304103b2--reverent-murdock-829d24.netlify.app/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/android/main/
