### PR TITLE
Updated User Lifecycle Reset Factors to optionally support factor removal for recovery

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/users/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/users/index.md
@@ -2782,6 +2782,7 @@ This operation resets all factors for the specified user. All MFA factor enrollm
 | Parameter    | Description                                                  | Param Type | DataType | Required | Default |
 | ------------ | ------------------------------------------------------------ | ---------- | -------- | -------- | ------- |
 | id           | `id` of user                                                 | URL        | String   | TRUE     |         |
+| removeRecoveryEnrollment       | An optional parameter that allows removal of the the phone factor (SMS/Voice) as both a recovery method and a factor. | QUERY      | Boolean  | FALSE    | FALSE   |
 
 ##### Response parameters
 


### PR DESCRIPTION
## Description:
- **What's changed?**
  - Added new optional request query parameter `removeRecoveryEnrollment` to allow for the removal of a factor for use in recovery when Resetting all Factors.
- **Is this PR related to a Monolith release?**
  - July Monthly Release - ~~2022.070~~ 2022.06.2 as per Slack convo with @susanharper-okta and @scottbermon-okta 

### Resolves:

* [OKTA-506759](https://oktainc.atlassian.net/browse/OKTA-506759)
