### PR TITLE
OKTA-470849 Add URL encoding to curl examples Log Streaming API 

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/log-streaming/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/log-streaming/index.md
@@ -266,7 +266,7 @@ curl -v -X GET \
 -H "Accept: application/json" \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
-"https://${yourOktaDomain}/api/v1/logStreams?filter=type+eq+\"aws_eventbridge\""
+"https://${yourOktaDomain}/api/v1/logStreams?filter=type+eq+%22aws_eventbridge%22"
 ```
 
 ##### Response example
@@ -312,7 +312,7 @@ curl -v -X GET \
 -H "Accept: application/json" \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
-"https://${yourOktaDomain}/api/v1/logStreams?filter=status+eq+\"ACTIVE\""
+"https://${yourOktaDomain}/api/v1/logStreams?filter=status+eq+%22ACTIVE%22"
 ```
 
 ##### Response example


### PR DESCRIPTION

## Description:
- **What's changed?** Updated 2 curl calls in the the following sections of the Log Streaming API reference to use character encoding %22 in place of /" to escape a double quote character:

[Find log streams by type](https://developer.okta.com/docs/reference/api/log-streaming/#find-log-streams-by-type)
[Find log streams by status](https://developer.okta.com/docs/reference/api/log-streaming/#find-log-streams-by-status)

See my [Google Doc](https://docs.google.com/document/d/10sk3c4iRMUCDvnGZfSWZz4SrW04PKPY6LlNbpiClKyk/edit?usp=sharing) for testing details.
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* [OKTA-470849](https://oktainc.atlassian.net/browse/OKTA-470849)
