### PR TITLE
OKTA-507406 Update ext-oie-whats-new alias to ext-oie-upgrade-eligibility alias

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/oie-upgrade-mfa-enroll-policy/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-upgrade-mfa-enroll-policy/main/index.md
@@ -9,7 +9,7 @@ meta:
 
 ## Overview
 
-With Okta Identity Engine, the definition of factors and authenticators have been differentiated to align with industry standards. Identity Engine uses authenticators in its MFA enrollment policy settings, whereas Okta Classic Engine uses factors in its MFA enrollment policy settings. See [Compare Identity Engine and Classic Engine](https://help.okta.com/okta_help.htm?type=oie&id=ext-oie-whats-new).
+With Okta Identity Engine, the definition of factors and authenticators have been differentiated to align with industry standards. Identity Engine uses authenticators in its MFA enrollment policy settings, whereas Okta Classic Engine uses factors in its MFA enrollment policy settings.
 
 After upgrading your org to Identity Engine, new MFA enrollment policies created in the Admin Console are configured using authenticators. Existing MFA enrollment policies, created before upgrading to Identity Engine, are still configured with factors. However, if an existing MFA policy was modified and saved in the Admin Console, the factors in that policy are converted to authenticators. This conversion is seamless to admin users that are managing policies in the Admin Console.
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-upgrade-overview/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-upgrade-overview/main/index.md
@@ -33,7 +33,7 @@ Bear in mind that:
 * The existing Okta-hosted Sign-In Widget works as-is after you upgrade your org.
 * You should upgrade your embedded Sign-In Widget as you would normally do with other updates.
 
-> **Note:** For an overview of the changes in the Admin Console, see [Compare Identity Engine and Classic Engine](https://help.okta.com/okta_help.htm?type=oie&id=ext-oie-whats-new).
+> **Note:** See [Upgrade from Classic Engine](https://help.okta.com/okta_help.htm?type=oie&id=ext-oie-upgrade-eligibility) for feature comparison and considerations before and after you upgrade.
 
 The rest of the upgrade process is defined in the next section. Which steps that you take are related to your deployment model. We have carefully considered how you can break up the upgrade steps to ensure that you maintain the best user experience across your applications. We don’t recommend doing this upgrade all at once, but rather in sections with breaks for testing. This process is designed to be non-disruptive and iterative over a period of time. Make the upgrade steps part of your normal product development process.
 
@@ -53,8 +53,6 @@ For a more detailed look at the upgrade steps, see the [Plan embedded auth appli
     * Make any necessary [updates to the Sign-In Widget styling](/docs/guides/oie-upgrade-sign-in-widget-styling/) and [i18n properties](/docs/guides/oie-upgrade-sign-in-widget-i18n/).
 
     * Check your `config.idps` [settings](https://github.com/okta/okta-signin-widget#openid-connect) for customizations that may not be compatible with Identity Engine.
-
-    > **Note:** See the **Remember me** section of the [Compare Identity Engine and Classic Engine](https://help.okta.com/okta_help.htm?type=oie&id=ext-oie-whats-new) for more information on functionality changes in the Admin Console.
 
     **Are you embedding our Sign-In Widget?**
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-upgrade-plan-embedded-upgrades/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-upgrade-plan-embedded-upgrades/main/index.md
@@ -27,8 +27,6 @@ See [Roll the upgrade out to your users](#roll-the-upgrade-out-to-your-users) fo
 
 When you are redirecting to the Okta-hosted widget, make sure that your user experience is preserved both [visually](/docs/guides/oie-upgrade-sign-in-widget-styling/) and [functionally](/docs/guides/oie-upgrade-sign-in-widget-i18n/). Be sure to check your `config.idps` [settings](https://github.com/okta/okta-signin-widget#openid-connect) for customizations that may not be compatible with Identity Engine.
 
-> **Note:** See the **Remember me** section of the [Compare Identity Engine and Classic Engine](https://help.okta.com/okta_help.htm?type=oie&id=ext-oie-whats-new) for more information on functionality changes in the Admin Console.
-
 ## Update the Embedded Sign-In Widget
 
 When you are embedding the widget, consider and plan for the following steps, depending on your needs:


### PR DESCRIPTION
## Description:
- **What's changed?**The page for `ext-oie-whats-new` alias no long exists. The Product OIE upgrade docs have moved to https://help.okta.com/en/programs/oie/Content/Topics/identity-engine-upgrade/home.htm, but there are no aliases for this guide. Product recommends to use `ext-oie-upgrade-eligibility` alias instead. In some cases, the external product link was removed since the referenced context doesn't exist anymore.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-507406](https://oktainc.atlassian.net/browse/OKTA-507406)
