### PR TITLE
TBS VULN blurbs for 2022.06.1

### DIFF
--- a/packages/@okta/vuepress-site/docs/release-notes/2022-okta-identity-engine/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2022-okta-identity-engine/index.md
@@ -22,6 +22,10 @@ title: Okta Identity Engine API Products release notes 2022
 
 * When token inline hooks were used in embedded flows, the hook request URL didn’t contain the complete path. When token inline hooks were used in redirect flows, the hook request didn't always contain the user object. (OKTA-499597)
 
+* When token inline hooks were used in embedded flows, the hook request URL didn’t contain the complete path. When token inline hooks were used in redirect flows, the hook request didn't always contain the user object. (OKTA-499597)
+
+* Characters in the OAuth 2.0 consent logo URI (`logo_uri`) weren't encoded to prevent interference with HTTP Content Security Policy (CSP) directives. (OKTA-505553)
+
 ### Monthly release 2022.06.0
 
 | Change | Expected in Preview Orgs |

--- a/packages/@okta/vuepress-site/docs/release-notes/2022-okta-identity-engine/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2022-okta-identity-engine/index.md
@@ -22,7 +22,7 @@ title: Okta Identity Engine API Products release notes 2022
 
 * When token inline hooks were used in embedded flows, the hook request URL didn’t contain the complete path. When token inline hooks were used in redirect flows, the hook request didn't always contain the user object. (OKTA-499597)
 
-* When token inline hooks were used in embedded flows, the hook request URL didn’t contain the complete path. When token inline hooks were used in redirect flows, the hook request didn't always contain the user object. (OKTA-499597)
+* End user input values weren’t properly escaped in some fields of the self-service registration form. (OKTA-398717)
 
 * Characters in the OAuth 2.0 consent logo URI (`logo_uri`) weren't encoded to prevent interference with HTTP Content Security Policy (CSP) directives. (OKTA-505553)
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2022/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2022/index.md
@@ -8,11 +8,13 @@ title: Okta API Products release notes 2022
 
 | Change | Expected in Preview Orgs |
 |--------------------------------------------------------------------------|--------------------------|
-| [Bug fixed in 2022.06.1](#bug-fixed-in-2022-06-1) | June 15, 2022 |
+| [Bugs fixed in 2022.06.1](#bugs-fixed-in-2022-06-1) | June 15, 2022 |
 
-#### Bug fixed in 2022.06.1
+#### Bugs fixed in 2022.06.1
 
-Resource Set operations performed with Okta Resource Names (ORNs) that used capital letters returned an HTTP 500 Internal Server Error. (OKTA-501910)
+* Resource Set operations performed with Okta Resource Names (ORNs) that used capital letters returned an HTTP 500 Internal Server Error. (OKTA-501910)
+
+* Characters in the OAuth 2.0 consent logo URI (`logo_uri`) weren't encoded to prevent interference with HTTP Content Security Policy (CSP) directives. (OKTA-505553)
 
 ### Monthly release 2022.06.0
 


### PR DESCRIPTION
## Description:
- **What's changed?** Adds the blurbs for a few VULNs.
- **Is this PR related to a Monolith release?** Yes. 2022.06.1, but only when deployed to all prod cells.

### Resolves:

* [OKTA-505802](https://oktainc.atlassian.net/browse/OKTA-505802)
