### PR TITLE
OKTA-470847 Add URL encoding to curl examples Devices API

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/devices/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/devices/index.md
@@ -191,7 +191,7 @@ Searches for devices based on the properties specified in the `search` parameter
 This operation:
 
 * Supports pagination (to a maximum of 200 results).
-* Requires [URL encoding](http://en.wikipedia.org/wiki/Percent-encoding). For example, `search=profile.displayName eq "Bob"` is encoded as `search=profile.displayName%20eq%20%22Bob%22`. Examples use cURL-style escaping instead of URL encoding to make them easier to read.
+* Requires [URL encoding](http://en.wikipedia.org/wiki/Percent-encoding). For example, `search=profile.displayName eq "Bob"` is encoded as `search=profile.displayName%20eq%20%22Bob%22`.
 
 Searches include all Device profile properties, as well as the Device `id`, `status` and `lastUpdated` properties.
 

--- a/packages/@okta/vuepress-site/docs/reference/api/devices/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/devices/index.md
@@ -376,7 +376,7 @@ curl -v -X GET \
 -H "Accept: application/json" \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
-"https://${yourOktaDomain}/api/v1/devices?search=profile.displayName+sw+\"Eng-dev\"+and+status+eq+\"ACTIVE\""
+"https://${yourOktaDomain}/api/v1/devices?search=profile.displayName+sw+%22Eng-dev%22+and+status+eq+%22ACTIVE%22"
 ```
 
 ##### Bearer token request
@@ -386,7 +386,7 @@ curl -v -X GET \
 -H "Accept: application/json" \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer ${oauth_token}" \
-"https://${yourOktaDomain}/api/v1/devices?search=profile.displayName+sw+\"Eng-dev\"+and+status+eq+\"ACTIVE\""
+"https://${yourOktaDomain}/api/v1/devices?search=profile.displayName+sw+%22Eng-dev%22+and+status+eq+%22ACTIVE%22"
 ```
 
 ##### Response


### PR DESCRIPTION


## Description:
- **What's changed?** Updated 2 curl calls in the the following sections of the Devices reference to use character encoding %22 in place of /" to escape a double quote character:

[Usage Example Search (API Token)](https://developer.okta.com/docs/reference/api/devices/#api-token-request-3)
[Usage Example Search (Bearer token)](https://developer.okta.com/docs/reference/api/devices/#bearer-token-request-4)

See [Google testing doc](https://docs.google.com/document/d/1MxO51OAlEP6HFlGt8DbItPRkT21iu25LFKxyctRtCfw/edit?usp=sharing) for details.

- **Is this PR related to a Monolith release?** n/a

### Resolves:

* [OKTA-470847](https://oktainc.atlassian.net/browse/OKTA-470847)
