### PR TITLE
improving deprecated label experience

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/releases-at-okta/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/releases-at-okta/index.md
@@ -82,7 +82,7 @@ Documentation for features in GA release are not marked with any icons.
 
 ## Deprecation
 
-A feature identified as deprecated is no longer recommended for use and may be removed in the future — generally this means that you shouldn't use it unless you have to. For specific cases, workarounds and recommended paths forward are included in the relevant documentation, libraries, or references. When Okta schedules an end-of-life plan, that information is also included.
+A feature identified as deprecated is no longer recommended for use and may be removed in the future — generally, this means that you shouldn't use it unless you have to. Any workarounds or recommended paths forward are included in the relevant documentation, libraries, or references. When Okta schedules an end-of-service plan, that information is also included.
 
 Documentation for features that have been deprecated are marked with the Deprecated icon: <ApiLifecycle access="deprecated" />
 

--- a/packages/@okta/vuepress-site/docs/reference/releases-at-okta/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/releases-at-okta/index.md
@@ -82,7 +82,7 @@ Documentation for features in GA release are not marked with any icons.
 
 ## Deprecation
 
-A feature identified as deprecated is no longer recommended for use and may be removed in the future — generally, this means that you shouldn't use it unless you have to. Any workarounds or recommended paths forward are included in the relevant documentation, libraries, or references. When Okta schedules an end-of-service plan, that information is also included.
+A feature identified as deprecated is no longer recommended for use and may be removed in the future&mdash;generally, this means that you shouldn't use it unless you have to. Any workarounds or recommended paths forward are included in the relevant documentation, libraries, or references. When Okta schedules an end-of-service plan, that information is also included.
 
 Documentation for features that have been deprecated are marked with the Deprecated icon: <ApiLifecycle access="deprecated" />
 

--- a/packages/@okta/vuepress-site/docs/reference/releases-at-okta/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/releases-at-okta/index.md
@@ -82,9 +82,7 @@ Documentation for features in GA release are not marked with any icons.
 
 ## Deprecation
 
-A feature identified as Deprecated is no longer recommended and may be removed in the future.
-The recommended path forward is included in the relevant documentation, libraries, or references.
-When Okta schedules an end-of-life plan, that information is also included.
+A feature identified as deprecated is no longer recommended for use and may be removed in the future — generally this means that you shouldn't use it unless you have to. For specific cases, workarounds and recommended paths forward are included in the relevant documentation, libraries, or references. When Okta schedules an end-of-life plan, that information is also included.
 
 Documentation for features that have been deprecated are marked with the Deprecated icon: <ApiLifecycle access="deprecated" />
 

--- a/packages/@okta/vuepress-theme-prose/assets/css/abstracts/_colors.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/abstracts/_colors.scss
@@ -31,6 +31,7 @@
   --c-warning-lightest: #feefe2;
   --c-warning-base: #f47c25;
   --c-warning-dark: #cb5500;
+  --c-warning-deprecation: #e97107;
   --c-danger-lightest: #fee6ea;
   --c-danger-base: #dd0744;
   --c-danger-dark: #b80047;
@@ -106,6 +107,7 @@
   --c-code-lightgray: #8c8c96;
   --c-code-green: #00b478;
   --c-warning-base: #b35909;
+  --c-warning-deprecation: #e97107;
   --c-success-base: #0d7855;
   --c-light-gray: #aaaab4;
   --c-leaden: #39393d;
@@ -227,7 +229,8 @@ $colors: (
   "warning": (
     "lightest": var(--c-warning-lightest),
     "base": var(--c-warning-base),
-    "dark": var(--c-warning-dark)
+    "dark": var(--c-warning-dark),
+    "deprecation": var(--c-warning-deprecation)
   ),
   "danger": (
     "lightest": var(--c-danger-lightest),

--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_apiLifecycle.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_apiLifecycle.scss
@@ -33,7 +33,7 @@
 }
 
 .api-label-deprecated {
-  background: cv('warning', 'dark');
+  background: cv('warning', 'deprecation');
   margin-bottom: $base-spacing;
 }
 

--- a/packages/@okta/vuepress-theme-prose/global-components/ApiLifecycle.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/ApiLifecycle.vue
@@ -7,7 +7,7 @@
       <i class="fa fa-flag"></i> Early Access
     </span>
     <span class="api-label api-label-deprecated" v-if="access === labelType.DEPRECATED">
-      <i class="fa fa-fire-extinguisher"></i> Deprecated
+      <i class="fa fa-warning"></i> Deprecated
     </span>
     <span class="api-label api-label-ie" v-if="access === labelType.IDENTITY_ENGINE">
       Identity Engine
@@ -24,6 +24,7 @@
 <script>
 const DEFAULT_LINK = "/docs/reference/releases-at-okta/";
 const IE_LINK = "/docs/guides/oie-intro/";
+const DEPRECATED_LINK = "/docs/reference/releases-at-okta/#deprecation";
 
 export default {
   name: "ApiLifecycle",
@@ -38,9 +39,13 @@ export default {
   },
   computed: {
     link() {
-      return this.access === this.labelType.IDENTITY_ENGINE ||
-             this.access === this.labelType.CLASSIC_ENGINE
-             ? IE_LINK : DEFAULT_LINK;
+      if(this.access === this.labelType.IDENTITY_ENGINE) {
+        return IE_LINK;
+      } else if(this.access === this.labelType.DEPRECATED) {
+        return DEPRECATED_LINK;
+      } else {
+        return DEFAULT_LINK;
+      }
     }
   },
   created() {


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** This PR fixes a number of issues with the deprecated label (see https://developer.okta.com/docs/reference/releases-at-okta/#deprecation):
  - The fire extinguisher icon is weird
  - The color seems to be too "dangerous", and should be something like an orange
  - The wording needs to be better
  - The label should link directly to the deprecated section of the above linked page, not just the top of that page. 
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-493966](https://oktainc.atlassian.net/browse/OKTA-493966)
