### PR TITLE
Clarify SAML assertion array indexing

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/saml-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/saml-hook/index.md
@@ -338,7 +338,7 @@ Specify the location within the assertion where you want to apply your operation
 
 When you perform an `add` op to add a new attribute statement, begin with `/claims/` and follow that with the name of the new attribute that you are adding.
 
-When you modify an existing assertions statement, begin the path with `/subject/`, `/authentication/`, `/conditions/`, or `/claims/`, depending on which part of the assertion you want to modify. You then drill down within the child elements using slash-delimited element names, for example, `/claims/array/attributeValues/1/value`. (The `/1/` in the path indicates the index of the array.)
+When you modify an existing assertions statement, begin the path with `/subject/`, `/authentication/`, `/conditions/`, or `/claims/`, depending on which part of the assertion you want to modify. You then drill down within the child elements using slash-delimited element names, for example, `/claims/array/attributeValues/1/value`. (The `/1/` in the path indicates the index of the array, using zero-based indexing.)
 
 ### URI claims
 


### PR DESCRIPTION
## Description:
- **What's changed?** SAML assertion indexing is zero-based, make that explicit in the docs.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-NONE](https://oktainc.atlassian.net/browse/OKTA-NONE)
