### PR TITLE
Change UV error message title in developer doc

### DIFF
--- a/packages/@okta/vuepress-site/data/error-codes.json
+++ b/packages/@okta/vuepress-site/data/error-codes.json
@@ -1210,7 +1210,7 @@
     "errorSummary" : "Another authenticator with key: {0} is already active.",
     "errorDescription" : null
   }, {
-    "title" : "Non user verification compliance okta verify enrollment exception",
+    "title" : "Non user verification compliance enrollment exception",
     "includesExceptionMessage" : true,
     "statusCode" : 400,
     "statusReasonPhrase" : "Bad Request",


### PR DESCRIPTION
Description: Remove okta verify qualifier for user verification error title since custom push shares error message

<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?**  Removed "okta verify" from a string
Before:
![image](https://user-images.githubusercontent.com/19472516/177224285-4e951c3e-e2bd-4574-a5d2-8adc7961320c.png)

After:
![image](https://user-images.githubusercontent.com/19472516/177224305-fa80e396-a5fe-481f-8008-d5d259f13a62.png)


- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-483024](https://oktainc.atlassian.net/browse/OKTA-483024)
