### PR TITLE
OKTA-500168 Remove 2022.06.2 RN 

### DIFF
--- a/packages/@okta/vuepress-site/docs/release-notes/2022-okta-identity-engine/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2022-okta-identity-engine/index.md
@@ -14,7 +14,7 @@ title: Okta Identity Engine API Products release notes 2022
 
 #### Bug fixed in 2022.06.3
 
-* The mandatory `profileAttributes` parameter wasn't validated and the primary `email` attribute was deleted from a Profile Enrollment policy when an update request was made to the Policy API. (OKTA-473642)
+The mandatory `profileAttributes` parameter wasn't validated and the primary `email` attribute was deleted from a Profile Enrollment policy when an update request was made to the Policy API. (OKTA-473642)
 
 ### Weekly release 2022.06.2
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2022/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2022/index.md
@@ -12,18 +12,17 @@ title: Okta API Products release notes 2022
 
 #### Bug fixed in 2022.06.3
 
-* There was no limit on the number of factor sequences that could be added in a chain through a Policy API update. (OKTA-499259)
+There was no limit on the number of factor sequences that could be added in a chain through a Policy API update. (OKTA-499259)
 
 ### Weekly release 2022.06.2
 
 | Change | Expected in Preview Orgs |
 |--------------------------------------------------------------------------|--------------------------|
-| [Reset Factors endpoint includes a new optional request parameter](#reset-factors-endpoint-includes-a-new-optional-request-parameter)                      | June 23, 2022            |
 | [Bugs fixed in 2022.06.2](#bugs-fixed-in-2022-06-2)                      | June 23, 2022            |
 
-#### Reset Factors endpoint includes a new optional request parameter
+<!-- #### Reset Factors endpoint includes a new optional request parameter
 
-The `/reset_factors` endpoint has a new optional request parameter for the [Reset Factor lifecycle operation](/docs/reference/api/users/#reset-factors). You can now remove the phone factor (for example: SMS/Voice) as both a recovery method and a factor by setting the `removeRecoveryEnrollment` parameter to true when making a POST request to the `/reset_factors` endpoint (`/users/${userId}/lifecycle/reset_factors`). <!--OKTA-500168-->
+The `/reset_factors` endpoint has a new optional request parameter for the [Reset Factor lifecycle operation](/docs/reference/api/users/#reset-factors). You can now remove the phone factor (for example: SMS/Voice) as both a recovery method and a factor by setting the `removeRecoveryEnrollment` parameter to true when making a POST request to the `/reset_factors` endpoint (`/users/${userId}/lifecycle/reset_factors`). <!--OKTA-500168  REMOVED as per Katherine Chan - feature disabled with kill switch June 30, 2022-->
 
 #### Bugs fixed in 2022.06.2
 


### PR DESCRIPTION

## Description:
- **What's changed?** Removed 2022.06.2 Release Note for OKTA-500168 for feature `removeRecoveryEnrollment` parameter, which was disabled in later release.
- **Is this PR related to a Monolith release?** 2022.06.2

### Resolves:

* n/a
