### PR TITLE
OKTA-413958 - Add note regarding password parameter in a SCIM Create User request

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/scim/scim-20/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/scim/scim-20/index.md
@@ -126,6 +126,8 @@ Authorization: <Authorization credentials>
 }
 ```
 
+> **Note:** Okta sends the `password` parameter in a create user request, even if password sync isn't enabled. This parameter acts as a placeholder for legacy provisioning platforms and its value isn't relevant or sensitive in nature.
+
 The response from the SCIM server contains the created User object:
 
 ```http


### PR DESCRIPTION
## Description:
- **What's changed?** Add note regarding password parameter in a SCIM Create User request to avoid confusion.
- **Is this PR related to a Monolith release?** No

### Preview:
- https://62c46e20818c143b1e672212--reverent-murdock-829d24.netlify.app/docs/reference/scim/scim-20/#create-the-user

### Resolves:

* [OKTA-413958](https://oktainc.atlassian.net/browse/OKTA-413958)
