### PR TITLE
Add "users" to tagline on home page

### DIFF
--- a/packages/@okta/vuepress-theme-prose/components/Home.vue
+++ b/packages/@okta/vuepress-theme-prose/components/Home.vue
@@ -17,8 +17,8 @@
                 <div class="col-lg-6 col-md-6 col-sm-12">
                   <h6>Auth for All</h6>
                   <p class="homepage--section-description">
-                    Quickly deploy auth that protects your apps,<br />
-                    APIs, and infrastructure
+                    Quickly deploy auth that protects your users,<br />
+                    apps, APIs, and infrastructure
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Yuliya mentioned to me that she would really like to see "users" added to the tagline on our front page — "...I believe our customers deploy auth to protect users foremost, then apps and infrastructure ... Not mentioning users feels off." I have created this PR to explore what that would look like.
- **Preview URL** https://62de6f890a983d20671f4ca3--reverent-murdock-829d24.netlify.app/
- **Is this PR related to a Monolith release?** No
