### PR TITLE
Replace WebSecurityConfigurerAdapter configuration with SecurityFilterChain bean

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/springboot/configcors.md
+++ b/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/springboot/configcors.md
@@ -1,12 +1,15 @@
-1. To configure CORS in Spring Security, enable it in the `WebSecurityConfigurerAdapter` that you defined in the previous step:
+1. To configure CORS in Spring Security, enable it in the `SecurityFilterChain` that you defined in the previous step:
 
    ```java
-   @Override
-   protected void configure(HttpSecurity http) throws Exception {
-     // previous configuration
-       ...
-     http.cors();
-   }
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                // previous configuration
+                ...
+                .cors(withDefaults())
+                .build();
+    }
+}
    ```
 
 2. Configure individual controllers with `CrossOrigin` annotation. For example:

--- a/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/springboot/reqautheverything.md
+++ b/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/springboot/reqautheverything.md
@@ -1,19 +1,21 @@
-By default, Spring Security requires authentication for all routes. This is equivalent to the following `WebSecurityConfigurerAdapter` implementation:
+By default, Spring Security requires authentication for all routes. This is equivalent to the following `SecurityFilterChain` bean:
 
 ```java
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
-class OktaOAuth2WebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
+class SpringSecurityConfiguration {
 
-  @Override
-  protected void configure(HttpSecurity http) throws Exception {
-    http.authorizeRequests()
-      .anyRequest().authenticated() // All requests require authentication
-      .and()
-      .oauth2ResourceServer().jwt(); // validates access tokens as JWTs
+  @Bean
+  SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    return http
+             .authorizeRequests((authorize) -> authorize.anyRequest().authenticated()) // All requests require authentication
+             .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt) // validates access tokens as JWTs
+             .build();
   }
 }
 ```

--- a/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/springboot/reqauthspecific.md
+++ b/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/springboot/reqauthspecific.md
@@ -1,22 +1,24 @@
-In Spring you can do this using a `WebSecurityConfigurerAdapter` implementation that is similar to the previous one, but with a URL matching pattern specified in ` .antMatchers()`.
+In Spring you can do this using a `SecurityFilterChain` bean that is similar to the previous one, but with a URL matching pattern specified in ` .mvcMatchers()`.
 
 For example, require authentication for the `/api/whoami` route like so:
 
 ```java
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
-class OktaOAuth2WebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
+class SpringSecurityConfiguration {
 
-  @Override
-  protected void configure(HttpSecurity http) throws Exception {
-    http.authorizeRequests()
-      // Require authentication for all requests under /api/private
-      .antMatchers("/api/whoami").authenticated()
-      .and()
-      .oauth2ResourceServer().jwt();
+  @Bean
+  SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    return http
+      // Require authentication for all requests under /api/whoami
+      .authorizeRequests((requests) -> requests.mvcMatchers("/api/whoami").authenticated())
+      .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt) // validates access tokens as JWTs
+      .build();
   }
 }
 ```


### PR DESCRIPTION
This PR replaces the `WebSecurityConfigurerAdapter` configuration in the docs with one that uses 
the `SecurityFilterChain` bean

The `SecurityFitlterChain` bean introduced in Spring Security 5.4 allows a component-based Security configuration
and is [encouraged to be used](https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter) instead of the `WebSecurityConfigurerAdapter`.

The configuration is compatible with Spring Boot 2.6 used throughout the docs  and will be needed anyway with the next Spring Boot version since the `WebSecurityConfigurerAdapter` is marked as [deprecated](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurerAdapter.html) in Spring Security 5.7 bundled with Boot 2.7



