### PR TITLE
chore(SCIM docs): Clarify eq filtering support is required for groups as well

### DIFF
--- a/packages/@okta/vuepress-site/docs/concepts/scim/faqs/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/scim/faqs/index.md
@@ -76,7 +76,7 @@ You should also specify your data requirements in the configuration document tha
 
 **Q: How much support is required for filtering results?**
 
-The filtering capabilities in the SCIM protocol are pretty broad, but the common filtering use case with Okta is quite narrow. Okta determines if a newly created user already exists in your application based on a matching identifier. This means the `eq` (equals) operator is all you really need to support.
+The filtering capabilities in the SCIM protocol are pretty broad, but the common filtering use case with Okta is quite narrow. Okta determines if a newly created user or group already exists in your application based on a matching identifier. This means the `eq` (equals) operator is all you really need to support.
 
 **Q: How do I import users?**
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
Okta uses the `filter=displayName eq <groupName>` query param on the `/Groups` endpoint. Therefore SCIM service providers must implement this, however this is unclear with the current documentation
- **What's changed?** Clarifies documentation
- **Is this PR related to a Monolith release?**No

