### PR TITLE
Add Account Unlock email template to table in EML overview guide

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/email-magic-links-overview/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/email-magic-links-overview/main/index.md
@@ -220,6 +220,7 @@ You can customize four email templates this way. These are listed in the table b
 | Forgot Password | Self-service password recovery | `${resetPasswordUrl}`           | `${oneTimePassword}`   |
 | Registration - Activation | Self-service registration | `${registrationActivationLink}` | `${oneTimePassword}`   |
 | Email factor verification | Sign in with email - enrollment | `${verificationLink}` | `${verificationToken}` |
+| Self-Service Unlock Account | Self-service unlock account| `${unlockAccountLink}` | `${oneTimePassword}` |
 
 When a user clicks the magic link based on a customized email template, their browser is redirected straight to your application's endpoint:
 


### PR DESCRIPTION
## Description:
Add Account Unlock email template to table in EML overview guide.

2022.08.1 release

### Resolves:

* [OKTA-521637](https://oktainc.atlassian.net/browse/OKTA-521637)

### Deploy link: 
https://62ed6ff6ce17ee28e094a761--reverent-murdock-829d24.netlify.app/docs/guides/email-magic-links-overview/aspnet/main/#use-custom-email-templates
