### PR TITLE
Add Password Reset By Admin template not allowed note

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-custom-pwd-recovery-mfa/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-custom-pwd-recovery-mfa/main/index.md
@@ -66,6 +66,8 @@ Okta sends users an email based on the **Forgot Password** template when they st
 | `${request.relayState}` | The current SAML [relaystate](https://developer.okta.com/docs/concepts/saml/#understanding-sp-initiated-sign-in-flow) value |
 | `${resetPasswordLink}` | The Okta-hosted URL that continues the password recovery flow |
 
+> **Note**: The `${oneTimePassword}` and `${request.relayState}` variables are not supported in the **Password Reset by Admin** template. As a result, you cannot use this template in the custom password recovery flow described in this guide.
+
 By default, the magic link in the template is set to `${resetPasswordLink}`. You must update it to an endpoint in your application that expects `${oneTimePassword}` and `${request.relayState}` as query parameters and uses them to continue the password recovery flow:
 
 1. In the Admin Console, go to **Customizations > Emails**.

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-custom-pwd-recovery-mfa/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-custom-pwd-recovery-mfa/main/index.md
@@ -66,7 +66,7 @@ Okta sends users an email based on the **Forgot Password** template when they st
 | `${request.relayState}` | The current SAML [relaystate](https://developer.okta.com/docs/concepts/saml/#understanding-sp-initiated-sign-in-flow) value |
 | `${resetPasswordLink}` | The Okta-hosted URL that continues the password recovery flow |
 
-> **Note**: The `${oneTimePassword}` and `${request.relayState}` variables are not supported in the **Password Reset by Admin** template. As a result, you cannot use this template in the custom password recovery flow described in this guide.
+> **Note**: The `${oneTimePassword}` and `${request.relayState}` variables aren't supported in the **Password Reset by Admin** template. As a result, you can't use this template in the custom password recovery flow described in this guide.
 
 By default, the magic link in the template is set to `${resetPasswordLink}`. You must update it to an endpoint in your application that expects `${oneTimePassword}` and `${request.relayState}` as query parameters and uses them to continue the password recovery flow:
 


### PR DESCRIPTION
## Description:
Add **Password Reset By Admin template not allowed** note to the password recovery guide.

2022.08.1

### Resolves:

* [OKTA-521731](https://oktainc.atlassian.net/browse/OKTA-521731)

### Deploy link:
https://62ed82098e5c0c3ddbe19a18--reverent-murdock-829d24.netlify.app/docs/guides/oie-embedded-sdk-use-case-custom-pwd-recovery-mfa/nodeexpress/main/#update-the-forgot-password-email-template
