### PR TITLE
OKTA-524057 Updated config.js file with updated link to 2022 Developer Days

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/config.js
+++ b/packages/@okta/vuepress-site/.vuepress/config.js
@@ -170,7 +170,7 @@ module.exports = ctx => ({
         children: [
           { text: 'Forum', link: 'https://devforum.okta.com' },
           { text: 'Toolkit', link: 'https://toolkit.okta.com/' },
-          { text: 'Developer Day', link: 'https://www.okta.com/developerday/' },
+          { text: 'Developer Days', link: 'https://regionalevents.okta.com/DeveloperDays2022' },
           { type: 'divider' },
           { type: 'icons',
             icons: [


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Updated the home page **Community** dropdown menu to replace "Developer Day" with "Developer Days" and the link to the latest: https://regionalevents.okta.com/DeveloperDays2022
- **Is this PR related to a Monolith release?**n/a
### Resolves:

* [OKTA-524057](https://oktainc.atlassian.net/browse/OKTA-524057)
