### PR TITLE
Updates to hard-coded event-hook-eligible queries

### DIFF
--- a/packages/@okta/vuepress-site/docs/concepts/event-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/event-hooks/index.md
@@ -25,7 +25,7 @@ You can have a maximum of 10 active and verified event hooks set up in your org 
 
 During the initial configuration procedure for an event hook, you specify which event types you want the event hook to deliver. The event types that can be specified are a subset of the event types that the Okta System Log captures.
 
-To see the list of event types currently eligible for use in event hooks, see the [Event Types catalog](/docs/reference/api/event-types/#catalog) and search with the parameter `event-hook-eligible`.
+To see the list of event types currently eligible for use in event hooks, use the [Event Types catalog](/docs/reference/api/event-types/#catalog) and search with the parameter `event-hook-eligible`.
 
 For general information on how Okta encapsulates events, see the [System Log API](/docs/reference/api/system-log/) documentation.
 

--- a/packages/@okta/vuepress-site/docs/concepts/event-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/event-hooks/index.md
@@ -25,9 +25,7 @@ You can have a maximum of 10 active and verified event hooks set up in your org 
 
 During the initial configuration procedure for an event hook, you specify which event types you want the event hook to deliver. The event types that can be specified are a subset of the event types that the Okta System Log captures.
 
-To see the list of event types currently eligible for use in event hooks, query the Event Types catalog with the query parameter `event-hook-eligible`:
-
-<https://developer.okta.com/docs/reference/api/event-types/?q=event-hook-eligible>
+To see the list of event types currently eligible for use in event hooks, see the [Event Types catalog](/docs/reference/api/event-types/#catalog) and search with the parameter `event-hook-eligible`.
 
 For general information on how Okta encapsulates events, see the [System Log API](/docs/reference/api/system-log/) documentation.
 

--- a/packages/@okta/vuepress-site/docs/concepts/monitor/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/monitor/index.md
@@ -61,7 +61,7 @@ For external integration examples, refer to:
 
 Your organization may have an external web service that performs extra processing for specific Okta events, such as creating or deactivating a user lifecycle event. Okta provides a webhook feature called [event hooks](/docs/concepts/event-hooks/), where you can set up triggers at specific events in Okta to send event payloads to an external web service. Event hooks are asynchronous and do not affect existing Okta workflows.
 
-For a working example of an end-to-end event hook setup, see the [Event hooks guide](/docs/guides/event-hook-implementation/). For a list of events that support event hooks, see [Event hooks eligible event types](/docs/reference/api/event-types/?q=event-hook-eligible).
+For a working example of an end-to-end event hook setup, see the [Event hooks guide](/docs/guides/event-hook-implementation/). For a list of events that support event hooks, see the [Event Types catalog](/docs/reference/api/event-types/#catalog) and search with the parameter `event-hook-eligible`.
 
 ## Monitor Okta with your custom tool
 

--- a/packages/@okta/vuepress-site/docs/reference/api/event-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/event-hooks/index.md
@@ -631,6 +631,4 @@ To use Basic Auth, set `type` to `HEADER`, `key` to `Authorization`, and `value`
 
 ## Supported events for subscription
 
-When you register an event hook, you need to specify what events you want to subscribe to. To see the list of event types currently eligible for use in event hooks, query the Event Types catalog with the query parameter `event-hook-eligible`:
-
-<https://developer.okta.com/docs/reference/api/event-types/?q=event-hook-eligible>
+When you register an event hook, you need to specify what events you want to subscribe to. To see the list of event types currently eligible for use in event hooks, see the [Event Types catalog](/docs/reference/api/event-types/#catalog) and search with the parameter `event-hook-eligible`.

--- a/packages/@okta/vuepress-site/docs/reference/api/event-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/event-hooks/index.md
@@ -631,4 +631,4 @@ To use Basic Auth, set `type` to `HEADER`, `key` to `Authorization`, and `value`
 
 ## Supported events for subscription
 
-When you register an event hook, you need to specify what events you want to subscribe to. To see the list of event types currently eligible for use in event hooks, see the [Event Types catalog](/docs/reference/api/event-types/#catalog) and search with the parameter `event-hook-eligible`.
+When you register an event hook, you need to specify what events you want to subscribe to. To see the list of event types currently eligible for use in event hooks, use the [Event Types catalog](/docs/reference/api/event-types/#catalog) and search with the parameter `event-hook-eligible`.


### PR DESCRIPTION

## Description:
- **What's changed?** As an interim solution, removed the hard-coded links to `event-hook-eligible` Event Types from three separate locations in the guide. Outstanding Developer Platform ticket: [OKTA-525710](https://oktainc.atlassian.net/browse/OKTA-525710) to address this issue.
- **Is this PR related to a Monolith release?** No

### Resolves:

* n/a
