### PR TITLE
OKTA-511103 Add image logo updates: SVG support and 200x200 dimension

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -6675,7 +6675,7 @@ Update the logo for an application.
 | applicationId   | `id` of an [app](#application-object)      | URL              | String     | TRUE     |
 | file            | File containing logo                       | Body             | File       | TRUE     |
 
-The file must be in PNG, JPG, or GIF format, and less than 1 MB in size. For best results use landscape orientation, a transparent background, and a minimum size of 420px by 120px to prevent upscaling.
+The file must be in PNG, JPG, SVG, or GIF format, and less than 1 MB in size. For best results, use an image with a transparent background and a square dimension of 200px by 200px to prevent scaling.
 
 ##### Request example
 

--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -6675,7 +6675,7 @@ Update the logo for an application.
 | applicationId   | `id` of an [app](#application-object)      | URL              | String     | TRUE     |
 | file            | File containing logo                       | Body             | File       | TRUE     |
 
-The file must be in PNG, JPG, SVG, or GIF format, and less than 1 MB in size. For best results, use an image with a transparent background and a square dimension of 200px by 200px to prevent scaling.
+The file must be in PNG, JPG, SVG, or GIF format, and less than 1 MB in size. For best results, use an image with a transparent background and a square dimension of 200px by 200px to prevent upscaling.
 
 ##### Request example
 


### PR DESCRIPTION
## Description:
- **What's changed?** Add image logo updates: SVG support and 200x200 dimension
- **Is this PR related to a Monolith release?**Yes, 2022.09.0

### Resolves:

* [OKTA-511103](https://oktainc.atlassian.net/browse/OKTA-511103)
