### PR TITLE
Fix devices & push providers postman collections to use {{apikey}} as the variable name

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/devices/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/devices/index.md
@@ -28,7 +28,7 @@ See [Device Registration](https://help.okta.com/okta_help.htm?type=oie&id=csh-de
 
 ## Get started
 
-Explore the Devices API: [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/872527-2b8b4196-4613-4950-9ea8-5026ab76baf5)
+Explore the Devices API: [![Run in Postman](https://run.pstmn.io/button.svg)](https://god.postman.co/run-collection/8eeb8dd1bb6e2aa56535?action=collection%2Fimport)
 
 ## Device operations
 

--- a/packages/@okta/vuepress-site/docs/reference/api/push-providers/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/push-providers/index.md
@@ -20,7 +20,7 @@ The Push Providers API supports the following Authorization Schemes:
 
 ## Get started
 
-Explore the Push Providers API: [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/83575c0b5b075783862c)
+Explore the Push Providers API: [![Run in Postman](https://run.pstmn.io/button.svg)](https://god.postman.co/run-collection/7d5fdec8d458540bc745?action=collection%2Fimport)
 
 ## Push Providers operations
 

--- a/packages/@okta/vuepress-site/docs/reference/postman-collections/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/postman-collections/index.md
@@ -22,7 +22,7 @@ Import any Okta API collection for Postman from the following list:
 | CAPTCHAs <ApiLifecycle access="ie" /><ApiLifecycle access="Limited GA" /> | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/c51413d80cc8e88fd101)|
 | Client secret rotation and key management | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/8e9d91cef0d5ab9e9fa7) |
 | Custom Templates                  | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/3f7e83cebd2d31f7d1a7) |
-| Devices                           | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/872527-2b8b4196-4613-4950-9ea8-5026ab76baf5) |
+| Devices                           | [![Run in Postman](https://run.pstmn.io/button.svg)](https://god.postman.co/run-collection/8eeb8dd1bb6e2aa56535?action=collection%2Fimport) |
 | Domains                           | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/96fbe3dea3ccd0602186) |
 | Dynamic Client Registration       | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/b673d146d0974f451e39) |
 | event hooks                       | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/2fdf75c2fb3319ef5e73) |
@@ -38,7 +38,7 @@ Import any Okta API collection for Postman from the following list:
 | OpenID Connect                    | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/9e7ad28ca1c26870a4b0) |
 | Org                               | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/2a73f5511943d1bd6611) |
 | Policy                            | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/f1e0184b7e6b26c558a0) |
-| Push Providers <ApiLifecycle access="ie" /><ApiLifecycle access="ea" />  | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/83575c0b5b075783862c) |
+| Push Providers <ApiLifecycle access="ie" /><ApiLifecycle access="ea" />  | [![Run in Postman](https://run.pstmn.io/button.svg)](https://god.postman.co/run-collection/7d5fdec8d458540bc745?action=collection%2Fimport) |
 | Risk Integration                  | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/47546754d382762468c6) |
 | Schemas                           | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/c85985861f9b277913ae) |
 | Sessions                          | [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/ff723148292df05bb58b) |


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- The Devices and Push Providers API were originally using `{{api_token}}` as the variable name in the authorization header, so change it to `{{apikey}}` to keep it consistent with the existing setup docs on the [developer website](https://developer.okta.com/code/rest/#set-up-your-environment) 
- **Is this PR related to a Monolith release?**:  no
- NFDEPLOY link:  https://630d15e6cbac8f1d1422f460--reverent-murdock-829d24.netlify.app
  - Postman collections list: https://630d15e6cbac8f1d1422f460--reverent-murdock-829d24.netlify.app/docs/reference/postman-collections/
  - Devices API: https://630d15e6cbac8f1d1422f460--reverent-murdock-829d24.netlify.app/docs/reference/api/devices/
  - Push Providers API: https://630d15e6cbac8f1d1422f460--reverent-murdock-829d24.netlify.app/docs/reference/api/push-providers/

### Resolves:

* [OKTA-528179](https://oktainc.atlassian.net/browse/OKTA-528179)

@okta/device-platform 
