### PR TITLE
OKTA-431895: Add API_ACCESS_MANAGEMENT_ADMIN to role types

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/admin-notifications/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/admin-notifications/index.md
@@ -944,7 +944,7 @@ Refer to the [product documentation](https://help.okta.com/okta_help.htm?id=ext_
 
 | Role type                     | Label                               |
 | :---------------------------- | :---------------------------------- |
-| `API_ADMIN`                   | API Access Management Administrator |
+| `API_ADMIN` or `API_ACCESS_MANAGEMENT_ADMIN` | API Access Management Administrator |
 | `APP_ADMIN`                   | Application Administrator           |
 | `GROUP_MEMBERSHIP_ADMIN`      | Group Membership Administrator      |
 | `HELP_DESK_ADMIN`             | Help Desk Administrator             |


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Update Subscriptions-Role API to support bot API_ACCESS_MANAGEMENT_ADMIN instead & API_ADMIN
- **Is this PR related to a Monolith release?** Yes. 2022.10.0

### Resolves:

[OKTA-431895](https://oktainc.atlassian.net/browse/OKTA-431895)

### Reviewers:
@williamngo-okta @rickyyang-okta @okta/dda 

## Screenshot:
![Screen Shot 2022-08-30 at 3 37 28 PM](https://user-images.githubusercontent.com/110849349/187528014-d21319a3-527a-4395-9a36-298688d443dc.png)
0f-18a03f75bed8.png)

