### PR TITLE
Urgent fix: Add Devices SDK to back navbar

### DIFF
--- a/packages/@okta/vuepress-theme-prose/const/navbar.const.js
+++ b/packages/@okta/vuepress-theme-prose/const/navbar.const.js
@@ -287,6 +287,10 @@ export const guides = [
                 guideName: "authenticators-okta-verify"
               },
               {
+                title: "Custom authenticator integration guide",
+                guideName: "authenticators-custom-authenticator"
+              },
+              {
                 title: "Google authenticator",
                 guideName: "authenticators-google-authenticator",
               },


### PR DESCRIPTION
The update to the navbar doesn't include the Devices SDK.