### PR TITLE
Fix typo in release life cycle page

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/releases-at-okta/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/releases-at-okta/index.md
@@ -11,8 +11,7 @@ Okta features travel through a regular life cycle:
 - [General Availability (GA)](#general-availability-ga)
 
 > **Note:** Okta reserves the right to add new parameters, properties, or resources to the API without advance notice.
-These updates are non-breaking because they are additive. Follow [the compatibility rules](/docs/reference/core-okta-api/) to ensure that your application doesn't break.
-when additive changes are made.
+These updates are non-breaking because they are additive. Follow [the compatibility rules](/docs/reference/core-okta-api/) to ensure that your application doesn't break when additive changes are made.
 Breaking changes such as removing or renaming an attribute are released as a new version of the API, and Okta provides a migration path for new API versions.
 
 Changes, regardless of life cycle stage, are always reported in the [Okta API Products Release Notes](/docs/release-notes/).


### PR DESCRIPTION
## Description:
- **What's changed?** Remove extra period in Release Life Cycle note.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
