### PR TITLE
fixing broken auth0 logo layout on signup page

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/layouts/_authorizationLayout.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/layouts/_authorizationLayout.scss
@@ -79,6 +79,7 @@
         min-width: 97px;
         img {
           width: 28px;
+          margin: 0; /* Override default positioning of content images */
         }
         &:after {
           content: '';


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** The Auth0 logo layout was reported as broken on https://developer.okta.com/signup/.
<img width="549" alt="Screenshot 2022-10-11 at 15 13 30" src="https://user-images.githubusercontent.com/87396614/195115207-2d2c8bc2-e16f-4c00-9398-d539119e51ce.png">

   This PR fixes that
- **Is this PR related to a Monolith release?** No

