### PR TITLE
Updated CSS to show correct image for light mode

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_menuItem.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_menuItem.scss
@@ -157,13 +157,13 @@ ul.menu--items {
     position: absolute;
     right: 0;
     top: 9px;
-    background-image: url('/img/icons/chevron-down-gray.svg');
+    background-image: url('/img/icons/chevron-down-white.svg');
     background-repeat: no-repeat;
     width: 8px;
     height: 4px;
 
     @include media("<desktop") {
-      background-image: url('/img/icons/chevron-down-gray.svg');
+      background-image: url('/img/icons/chevron-down-white.svg');
     }
   }
 }


### PR DESCRIPTION

## Description:
- **What's changed?** The small chevron image, in the developer.okta.com header, was the colour grey (or black), and was almost indistinguishable from the dark blue of the header. It appeared to throw the spacing off of the items. I've updated the CSS to use the white chevron image:

- **Is this PR related to a Monolith release?** n/a

### Resolves:

* a nit I saw while navigating

![Screen Shot 2022-10-13 at 1 43 32 PM](https://user-images.githubusercontent.com/70648001/195679503-8e3e9e56-5d8f-46d0-95e6-6b59632a7b46.png)
![Screen Shot 2022-10-13 at 1 43 21 PM](https://user-images.githubusercontent.com/70648001/195679504-83a95a90-3e84-452e-83b7-e241b8d30245.png)

