### PR TITLE
OKTA-538432 - Adding xrefs for OAuth 2 for Inline Hooks

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/common-hook-set-up-steps/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/common-hook-set-up-steps/main/index.md
@@ -82,7 +82,7 @@ The OAuth 2.0 Client Secret method sends a signed JWT to your external service. 
 * Create an app integration
 * Add a custom scope
 * Add OAuth 2.0 authentication fields to your inline hook
-* Add code to verify the JWT
+* Add code to your external service to verify the JWT
 
 #### Create an app integration
 
@@ -93,7 +93,9 @@ Before you can implement authorization, you need to register your app in Okta by
 1. Select **API Services** as the Sign-in method.
 1. Click **Next**.
 1. Specify the app integration name, then click **Save**.
-1. From the **General** tab of your app integration, note your generated **Client ID** and **Client secret**. These value are used when configuring your inline hook authentication.
+1. From the **General** tab of your app integration, note your generated **Client ID** and **Client secret**.
+
+These values are used when configuring your inline hook authentication.
 
 #### Add a custom scope
 
@@ -102,6 +104,7 @@ Before you can implement authorization, you need to register your app in Okta by
 #### Add OAuth 2.0 authentication fields to your inline hook
 
 When creating your inline hook, in the Authentication section, select **OAuth 2.0**.
+
 1. In the **Client Authentication** field, select **Use client secret** from the dropdown menu.
 1. Add the **Client ID** and **Client Secret** values from your app integration.
 1. Add the authorization server’s token URL, such as `https://${yourOktaDomain}/oauth2/default/v1/token`, and the custom scope that you created previously.
@@ -147,6 +150,8 @@ app.all('*', authenticationRequired); // Require authentication for all routes
 
 ```
 
+See the following Registration inline hook Glitch project that implements this code and provides a working example: [Okta Registration Hook (with OAuth 2.00 authentication)](https://glitch.com/~okta-inlinehook-registrationhook-oauth2).
+
 ### OAuth 2.0: Private Key
 
 The OAuth 2.0 private key method sends a signed JWT to your external service. To use this method, you must make the following configurations to your org and add code to decode the JWT from the Okta inline hook call:
@@ -155,7 +160,7 @@ The OAuth 2.0 private key method sends a signed JWT to your external service. To
 * Create an app integration
 * Add a custom scope
 * Add OAuth 2.0 authentication fields to your inline hook
-* Add code to verify the JWT
+* Add code to your external service to verify the JWT
 
 #### Create a key
 
@@ -163,7 +168,7 @@ The OAuth 2.0 private key method sends a signed JWT to your external service. To
 1. Click **Create new key**, and add a unique name for the key. You reference this name when adding your inline hook.
 1. Click **Create key**. The key is added to the table with a creation date and status.
 1. In the table, click your key name.
-1. Click **Copy key**. You need this public key in the next step.
+1. Click **Copy public key**. You need this public key in the next step.
 
 > **Note:** You can also create a key with the [Key Management API](/docs/reference/api/hook-keys/).
 
@@ -191,6 +196,7 @@ Before you can implement authorization, you need to register your app in Okta by
 1. When creating your inline hook, in the **Authentication** section, select **OAuth 2.0**.
 1. In the **Client Authentication** field, select **Use private key** from the dropdown menu.
 1. Add the Client ID value from your app integration.
+1. Select the **Key** that you created previously from the dropdown menu.
 1. Add the authorization server’s token URL, such as `https://${yourOktaDomain}/oauth2/default/v1/token`, and the custom scope that you created previously.
 1. Click **Save**.
 
@@ -233,6 +239,8 @@ const authenticationRequired = async (request, response, next) => {
 app.all('*', authenticationRequired); // Require authentication for all routes
 
 ```
+
+See the following Registration inline hook Glitch project that implements this code and provides a working example: [Okta Registration inline hook (with OAuth 2.00 authentication)](https://glitch.com/~okta-inlinehook-registrationhook-oauth2).
 
 ## Troubleshoot hook implementations
 

--- a/packages/@okta/vuepress-site/docs/guides/common-hook-set-up-steps/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/common-hook-set-up-steps/main/index.md
@@ -150,7 +150,7 @@ app.all('*', authenticationRequired); // Require authentication for all routes
 
 ```
 
-See the following Registration inline hook Glitch project that implements this code and provides a working example: [Okta Registration Hook (with OAuth 2.00 authentication)](https://glitch.com/~okta-inlinehook-registrationhook-oauth2).
+See the following project that implements this code and provides a working example: [Okta Registration inline hook (with OAuth 2.0 authentication)](https://glitch.com/~okta-inlinehook-registrationhook-oauth2).
 
 ### OAuth 2.0: Private Key
 
@@ -240,7 +240,7 @@ app.all('*', authenticationRequired); // Require authentication for all routes
 
 ```
 
-See the following Registration inline hook Glitch project that implements this code and provides a working example: [Okta Registration inline hook (with OAuth 2.00 authentication)](https://glitch.com/~okta-inlinehook-registrationhook-oauth2).
+See the following project that implements this code and provides a working example: [Okta Registration inline hook (with OAuth 2.0 authentication)](https://glitch.com/~okta-inlinehook-registrationhook-oauth2).
 
 ## Troubleshoot hook implementations
 

--- a/packages/@okta/vuepress-site/docs/guides/common-hook-set-up-steps/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/common-hook-set-up-steps/main/index.md
@@ -20,7 +20,7 @@ This guide explains common set-up steps when implementing an Okta Event or Inlin
 
 ---
 
-## About the common Hook set-up steps
+## About the common hook set-up steps
 
 Okta event and inline hooks use outbound calls, which are received and parsed by an external service to implement additional custom functionality for your Okta implementation.
 
@@ -79,10 +79,10 @@ After including the `npm` packages, add the following code snippet in your proje
 
 The OAuth 2.0 Client Secret method sends a signed JWT to your external service. To use this method, you must make the following configurations to your org and add code to decode the JWT from the Okta inline hook call:
 
-* Create an app integration
-* Add a custom scope
-* Add OAuth 2.0 authentication fields to your inline hook
-* Add code to your external service to verify the JWT
+* Create an app integration.
+* Add a custom scope.
+* Add OAuth 2.0 authentication fields to your inline hook.
+* Add code to your external service to verify the JWT.
 
 #### Create an app integration
 
@@ -150,7 +150,7 @@ app.all('*', authenticationRequired); // Require authentication for all routes
 
 ```
 
-See the following project that implements this code and provides a working example: [Okta Registration inline hook (with OAuth 2.0 authentication)](https://glitch.com/~okta-inlinehook-registrationhook-oauth2).
+<RegistrationHookXref/>
 
 ### OAuth 2.0: Private Key
 
@@ -240,7 +240,7 @@ app.all('*', authenticationRequired); // Require authentication for all routes
 
 ```
 
-See the following project that implements this code and provides a working example: [Okta Registration inline hook (with OAuth 2.0 authentication)](https://glitch.com/~okta-inlinehook-registrationhook-oauth2).
+<RegistrationHookXref/>
 
 ## Troubleshoot hook implementations
 

--- a/packages/@okta/vuepress-site/docs/guides/common-hook-set-up-steps/main/nodejs/auth.md
+++ b/packages/@okta/vuepress-site/docs/guides/common-hook-set-up-steps/main/nodejs/auth.md
@@ -8,3 +8,5 @@ app.use(basicAuth({
   users: { 'admin': 'supersecret' },
   unauthorizedResponse: req => 'Unauthorized'
 }));
+
+```

--- a/packages/@okta/vuepress-site/docs/guides/common-hook-set-up-steps/main/nodejs/scope.md
+++ b/packages/@okta/vuepress-site/docs/guides/common-hook-set-up-steps/main/nodejs/scope.md
@@ -1,6 +1,6 @@
 1. In the Admin Console, go to **Security** > **API**.
 1. On the **Authorization Servers** tab, select the name of the authorization server, and then select **Scopes**.
 1. Click **Add Scope**.
-1. Enter a name and description. You need the name of the scope when configuring your inline hook.
-1. Select **Include in public metadata**.
-1. Click **Save**.
+1. Enter a **Name** and **Description**. You need the name of the scope when configuring your inline hook.
+1. Select checkbox **Include in public metadata**.
+1. Click **Create**.

--- a/packages/@okta/vuepress-site/docs/guides/common-hook-set-up-steps/main/nodejs/scope.md
+++ b/packages/@okta/vuepress-site/docs/guides/common-hook-set-up-steps/main/nodejs/scope.md
@@ -2,5 +2,5 @@
 1. On the **Authorization Servers** tab, select the name of the authorization server, and then select **Scopes**.
 1. Click **Add Scope**.
 1. Enter a **Name** and **Description**. You need the name of the scope when configuring your inline hook.
-1. Select checkbox **Include in public metadata**.
+1. Select the checkbox **Include in public metadata**.
 1. Click **Create**.

--- a/packages/@okta/vuepress-site/docs/guides/registration-inline-hook/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/registration-inline-hook/main/index.md
@@ -269,7 +269,7 @@ You need to remix your own version of the Okta sample Glitch project and confirm
    * **Authentication Field** = `authorization`
    * **Authorization Secret** = `Basic YWRtaW46c3VwZXJzZWNyZXQ=`
 
-   > **Note**: If you want to use OAuth 2.0 to secure your inline hooks, see [Add Authentication method](/docs/guides/common-hook-set-up-steps/nodejs/main/#add-authentication-method) and [Okta Registration inline hook (with OAuth 2.0 authentication)](https://glitch.com/~okta-inlinehook-registrationhook-oauth2).
+   > **Note**: If you want to use OAuth 2.0 to secure your inline hooks, see [Add Authentication method](/docs/guides/common-hook-set-up-steps/nodejs/main/#add-authentication-method).
 
 1. Click **Save**.
 1. In your Glitch project, click **Logs**. If your set up is successful, a "Your app is listening on port {XXXX}" message appears.

--- a/packages/@okta/vuepress-site/docs/guides/registration-inline-hook/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/registration-inline-hook/main/index.md
@@ -91,7 +91,6 @@ See the [request properties](/docs/reference/registration-hook/#objects-in-the-r
 }
 ```
 
-
 ## Progressive enrollment request
 
 The following JSON example provides the end user's profile data to the external service for evaluation.
@@ -145,7 +144,6 @@ See the [request properties](/docs/reference/registration-hook/#objects-in-the-r
     }
 }
 ```
-
 
 ## Send response
 
@@ -270,6 +268,8 @@ You need to remix your own version of the Okta sample Glitch project and confirm
 
    * **Authentication Field** = `authorization`
    * **Authorization Secret** = `Basic YWRtaW46c3VwZXJzZWNyZXQ=`
+
+   > **Note**: If you want to use OAuth 2.0 to secure your inline hooks, see [Add Authentication method](/docs/guides/common-hook-set-up-steps/nodejs/main/#add-authentication-method) and [Okta Registration inline hook (with OAuth 2.0 authentication)](https://glitch.com/~okta-inlinehook-registrationhook-oauth2).
 
 1. Click **Save**.
 1. In your Glitch project, click **Logs**. If your set up is successful, a "Your app is listening on port {XXXX}" message appears.

--- a/packages/@okta/vuepress-theme-prose/global-components/RegistrationHookXref.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/RegistrationHookXref.vue
@@ -1,0 +1,11 @@
+<template>
+
+    <p>See the following project that implements this code and provides a working example: <a href="https://glitch.com/~okta-inlinehook-registrationhook-oauth2">Okta Registration inline hook (with OAuth 2.0 authentication)</a>.</p>
+
+</template>
+
+<script>
+export default {
+  name: "RegistrationHookXref"
+};
+</script>


### PR DESCRIPTION

## Description:
- **What's changed?** Added links to a new glitch project that works with the OAuth 2.0 for inline hooks feature.  Updated the Common Hooks guide with a mention in the existing Registration Hook guide. Also includes several UI updates and nits missed on initial release.
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* [OKTA-538432](https://oktainc.atlassian.net/browse/OKTA-532432)
