### PR TITLE
OKTA-538431 Further updates to hook docs for OAuth 2 support

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/common-hook-set-up-steps/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/common-hook-set-up-steps/main/index.md
@@ -4,7 +4,7 @@ excerpt: A list of set-up steps that are common to all hook implementations.
 layout: Guides
 ---
 
-This guide explains common set-up steps when implementing an Okta Event or Inline hook, including using Glitch.com as an example external service, adding basic authentication to the hook calls, JSON body parsing in the external service code, and troubleshooting steps.
+This guide explains common set-up steps when implementing an Okta Event or Inline hook, including using Glitch.com as an example external service, adding authentication to the hook calls, JSON body parsing in the external service code, and troubleshooting steps.
 
 ---
 

--- a/packages/@okta/vuepress-site/docs/reference/hooks-best-practices/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/hooks-best-practices/index.md
@@ -10,15 +10,15 @@ Event hooks and inline hooks are outbound calls from Okta to an external service
 
 The following sections review best practices to implement and secure Okta event hooks or inline hooks.
 
-## Secure your Hook endpoint
+## Secure your hook endpoint
 
-To prevent a malicious actor from making requests to the endpoint where your Okta Hooks are sent, use the following best practices:
+To prevent a malicious actor from making requests to the endpoint where your Okta hooks are sent, use the following best practices:
 
-* Configure Okta to send an authentication header in the Hook and validate it in every request by one of two ways:
+* Configure Okta to send an authentication header in the hook and validate it in every request by one of two ways:
 
   * Using [HTTP Basic Authentication](/books/api-security/authn/api-authentication-options/#http-basic-authentication). When activating and enabling your Hooks on the Okta org, set the **Authorization field** as `Authorization` and the **Authentication secret** in the Base64 `user:password` format.
 
-    >**Note:** You must include the authentication scheme as part of the **Authentication secret**. For Basic Authentication, your secret must appear similar to: `Basic Base64(user:password)`. See the following partial Hook header as an example:
+    >**Note:** You must include the authentication scheme as part of the **Authentication secret**. For Basic Authentication, your secret must appear similar to: `Basic Base64(user:password)`. See the following partial hook header as an example:
 
     ```http
     Accept: application/json
@@ -26,17 +26,22 @@ To prevent a malicious actor from making requests to the endpoint where your Okt
     Authorization: Basic YWRtaW46c3VwZXJzZWNyZXQ=
     ```
 
-  * Using a separate Secret Key, which can be configured on the Hook as a custom header field.
+  * Using a separate Secret Key, which can be configured on the hook as a custom header field.
+
+* For Okta inline hook calls, configure the hook to use OAuth 2.0 authentication using either:
+
+  * Client Secret method (`client_secret_post`): See [OAuth 2.0: Client secret](/docs/guides/common-hook-set-up-steps/nodejs/main/#oauth-2-0-client-secret).
+  * Private Key method (`private_key_jwt`): See [OAuth 2.0: Private Key](/docs/guides/common-hook-set-up-steps/nodejs/main/#oauth-2-0-private-key).
 
 * Create an allowlist of IP addresses to check incoming Okta calls. See [What IP addresses/ranges should we allow for inbound traffic?](https://support.okta.com/help/s/article/What-IP-addresses-ranges-should-we-whitelist-for-inbound-traffic-i-e-REST-API-calls-from-Okta-to-on-prem-JIRA-server?language=en_US) for a listing of Okta IP addresses.
 
->**Note:** This is a large list of IP addresses and the list is subject to change. Unless required by your organization, securing your Hook by authentication header is recommended.
+>**Note:** This is a large list of IP addresses and the list is subject to change. Unless required by your organization, securing your hook by authentication header or OAuth 2.0 is recommended.
 
-## Protect your Hook content from external viewers
+## Protect your hook content from external viewers
 
-Okta requires HTTPS to encrypt communications to your Hook endpoint to prevent unauthorized parties from reading the contents of an Okta Hook. When using HTTPS, ensure you keep your SSL certificate updated and the Domain Name System (DNS) secured, so that someone can’t reroute your calls to another location.
+Okta requires HTTPS to encrypt communications to your hook endpoint to prevent unauthorized parties from reading the contents of an Okta hook. When using HTTPS, ensure you keep your SSL certificate updated and the Domain Name System (DNS) secured, so that someone can’t reroute your calls to another location.
 
->**Note:** Adding an HTTP URL when enabling a Hook in the Admin Console displays an Invalid URL provided error.
+>**Note:** Adding an HTTP URL when enabling a hook in the Admin Console displays an Invalid URL provided error.
 
 ## Avoid delays in hook responses
 
@@ -51,11 +56,11 @@ A timeout of three seconds is enforced on all outbound requests for event and in
 
 See inline hook [Timeout and Retry](/docs/concepts/inline-hooks/#timeout-and-retry) and event hook [Timeout and Retry](/docs/concepts/event-hooks/#timeout-and-retry).
 
-## Limits, duplicates, and order of Hook calls
+## Limits, duplicates, and order of hook calls
 
-The number of Hook calls and the limits per org are available in the following table. Keep in mind these numbers and limits when designing your Hook solution.
+The number of hook calls and the limits per org are available in the following table. Keep in mind these numbers and limits when designing your hook solution.
 
-Your external service processing Hook requests must take into consideration that the order of event or inline hook calls is not guaranteed. Also, to avoid processing duplicate requests, use the `eventId` property to identify unique requests.
+Your external service processing hook requests must take into consideration that the order of event or inline hook calls is not guaranteed. Also, to avoid processing duplicate requests, use the `eventId` property to identify unique requests.
 
 | Hook Type | Limit Type | Limit | Description |
 | --------- | -----------| ----- | ----------- |
@@ -65,7 +70,7 @@ Your external service processing Hook requests must take into consideration that
 |             | Maximum number of inline hooks per org | 50 | The maximum number of inline hooks that can be configured per org is 50, which is a combined total for any combination of inline hook types. |
 |             | Concurrent rate limit | Variable | The maximum number of inline hooks that can be sent concurrently based on org type. See [Concurrent rate limits](/docs/reference/rl-additional-limits/#concurrent-rate-limits).|
 
-## Troubleshoot your Hook implementations
+## Troubleshoot your hook implementations
 
 Developers and administrators can preview sample Okta calls and responses from your external service for all event hooks ([Event hook preview](https://help.okta.com/okta_help.htm?id=ext-event-hooks-preview)) and for SAML and registration inline hooks ([Preview an inline hook](https://help.okta.com/okta_help.htm?id=ext-preview-inline-hooks)).
 
@@ -74,9 +79,9 @@ Review the Admin Console System Log to troubleshoot your implementations, in add
 * [Troubleshooting inline hooks](/docs/concepts/inline-hooks/#troubleshooting)
 * [Troubleshooting event hooks](/docs/concepts/event-hooks/#debugging)
 
-Inline hooks also provide an `error` object that can be returned as part of the Hook response. See [Inline hooks error object](/docs/concepts/inline-hooks/#error).
+Inline hooks also provide an `error` object that can be returned as part of the hook response. See [Inline hooks error object](/docs/concepts/inline-hooks/#error).
 
-See also the following guides for sample Okta Hook implementations:
+See also the following guides for sample Okta hook implementations:
 
 * [Event hook](/docs/guides/event-hook-implementation/)
 * [Password import inline hook](/docs/guides/password-import-inline-hook/)

--- a/packages/@okta/vuepress-site/docs/reference/import-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/import-hook/index.md
@@ -290,7 +290,7 @@ You then need to associate the registered inline hook with an app by completing 
 
 1. From the Settings column on the left side of the screen, select **To Okta**.
 
-1. In the **Inline Hooks** section, click the **User Creation** drop-down menu. Inline hooks that you've registered appears in the list. Select the inline hook to use.
+1. In the **Inline Hooks** section, click the **User Creation** dropdown menu. Inline hooks that you've registered appear in the list. Select the inline hook to use.
 
 1. Click **Save**.
 

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -13,6 +13,8 @@ For a general introduction to Okta inline hooks, see [inline hooks](/docs/concep
 
 For information on the API for registering external service endpoints with Okta, see [Inline Hooks Management API](/docs/reference/api/inline-hooks/).
 
+For steps to set up and activate the registration inline hook, see [Set up and activate the registration inline hook](/docs/guides/registration-inline-hook/nodejs/main/#set-up-your-glitch-project).
+
 For steps to enable this inline hook, see [Enabling a registration inline hook](/docs/guides/registration-inline-hook/nodejs/main/#enable-the-registration-inline-hook).
 
 For an example implementation of this inline hook, see [Registration inline hook](/docs/guides/registration-inline-hook/nodejs/main/).


### PR DESCRIPTION


## Description:
- **What's changed?** Reviewing and updating API references as well as a few other hook docs, as per the OAuth 2.0 for inline hook feature
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* [OKTA-538431](https://oktainc.atlassian.net/browse/OKTA-538431)
