### PR TITLE
Update SIW major point version

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/config.js
+++ b/packages/@okta/vuepress-site/.vuepress/config.js
@@ -4,7 +4,7 @@ const findLatestWidgetVersion = require('./scripts/findLatestWidgetVersion');
 const convertReplacementStrings = require('./scripts/convert-replacement-strings');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const Path = require('path')
-const signInWidgetMajorVersion = 6;
+const signInWidgetMajorVersion = 7;
 
 const projectRootDir = Path.resolve(__dirname, '../../../../');
 const outputDir = Path.resolve(__dirname, '../dist/');


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Updated `config.js` to use the latest SIW major version (7). This pulls in the correct point versions referenced on the site. See: https://github.com/okta/okta-developer-docs/wiki/Troubleshooting#problem-sign-in-widget-variable--okta_replace_with_widget_verrsion--not-pulling-in-correct-version
- **Is this PR related to a Monolith release?** 2022.11.0

### Resolves:

* n/a
