### PR TITLE
Add Hook response size as global component

### DIFF
--- a/packages/@okta/vuepress-site/docs/concepts/inline-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/inline-hooks/index.md
@@ -116,7 +116,7 @@ Always included is `data.context`, providing context information. In general, `d
 
 Your service receives the request from Okta and needs to respond to it. The response needs to include an HTTP response code and will usually also include a JSON payload. In particular, you will typically include a `commands` object in the JSON payload to specify actions for Okta to execute or to communicate information back to Okta.
 
->**Note:** The size of your response payload must be less than 256 KB.
+<HookResponseSize/>
 
 ### HTTP status code
 

--- a/packages/@okta/vuepress-site/docs/reference/import-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/import-hook/index.md
@@ -62,7 +62,9 @@ This object contains a number of sub-objects, each of which provides some type o
 
 ## Objects in response you send
 
-The `commands` and `error` objects that you can return in the JSON payload of your response are defined as follows:
+The `commands` and `error` objects that you can return in the JSON payload of your response are defined in the following sections.
+
+<HookResponseSize/>
 
 ### commands
 

--- a/packages/@okta/vuepress-site/docs/reference/password-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/password-hook/index.md
@@ -43,6 +43,8 @@ This specifies the default action Okta is set to take. Okta will take this actio
 
 The objects that you can return in the JSON payload of your response are an array of one or more `commands` objects, which specify commands to be executed by Okta.
 
+<HookResponseSize/>
+
 ### commands
 
 For the password import inline hook, the `commands` object lets you specify whether Okta should accept the end user's login credentials as valid or not.

--- a/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/registration-hook/index.md
@@ -95,7 +95,11 @@ Using the `com.okta.action.update` [command](#supported-commands) in your respon
 
 ## Response objects that you send
 
-The objects that you can return in the JSON payload of your response are an array of one or more `commands`, to be executed by Okta, or an `error` object, to indicate problems with the registration request. These objects are defined as follows:
+The objects that you can return in the JSON payload of your response are an array of one or more `commands`, to be executed by Okta, or an `error` object, to indicate problems with the registration request. 
+
+<HookResponseSize/>
+
+The response objects are defined as follows:
 
 ### commands
 

--- a/packages/@okta/vuepress-site/docs/reference/saml-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/saml-hook/index.md
@@ -286,7 +286,9 @@ The following sub-objects are included:
 
 ## Objects in response you send
 
-For the SAML assertion inline hook, the objects that you can return in the JSON payload of your response are defined as follows:
+For the SAML assertion inline hook, the objects that you can return in the JSON payload of your response are defined in the following sections.
+
+<HookResponseSize/>
 
 ### commands
 

--- a/packages/@okta/vuepress-site/docs/reference/telephony-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/telephony-hook/index.md
@@ -66,7 +66,9 @@ Provides information on the properties of the message being sent to the OTP requ
 
 ## Objects in the response that you send
 
-For the telephony inline hook, the `commands` and `error` objects that you can return in the JSON payload of your response are defined as follows:
+For the telephony inline hook, the `commands` and `error` objects that you can return in the JSON payload of your response are defined in the following sections.
+
+<HookResponseSize/>
 
 ### commands
 

--- a/packages/@okta/vuepress-site/docs/reference/token-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/token-hook/index.md
@@ -66,7 +66,9 @@ The set of scopes that have been granted. For descriptions of the scopes that ca
 
 ## Objects in the response that you send
 
-For the token inline hook, the `commands` and `error` objects that you can return in the JSON payload of your response are defined as follows:
+For the token inline hook, the `commands` and `error` objects that you can return in the JSON payload of your response are defined in the following sections.
+
+<HookResponseSize/>
 
 ### commands
 

--- a/packages/@okta/vuepress-theme-prose/global-components/HookResponseSize.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/HookResponseSize.vue
@@ -1,0 +1,11 @@
+<template>
+<blockquote>
+    <p>**Note:** The size of your response payload must be less than 256 KB.</p>
+</blockquote>
+</template>
+
+<script>
+export default {
+  name: "HookResponseSize"
+};
+</script>

--- a/packages/@okta/vuepress-theme-prose/global-components/HookResponseSize.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/HookResponseSize.vue
@@ -1,6 +1,6 @@
 <template>
 <blockquote>
-    <p>**Note:** The size of your response payload must be less than 256 KB.</p>
+    <p><strong>Note:</strong> The size of your response payload must be less than 256 KB.</p>
 </blockquote>
 </template>
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Added the release note on Hook response size from [PR# 3175](https://github.com/okta/okta-developer-docs/pull/3715) as a Global component and used that tag for all Hook API references.
- **Is this PR related to a Monolith release?** no

### Resolves:

*n/a
