### PR TITLE
OKTA-532542 Add missing UserOnDemandPeriod parameter in ASA Projects

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
@@ -99,7 +99,7 @@ This endpoint returns a list of objects with the following fields and a `200` co
 | `shared_standard_user_name`   | string | (Optional) The name for a shared standard user on Servers in this Project. If `force_shared_ssh_users` is `true`, this must be provided. |
 | `ssh_session_recording`   | boolean | (Optional) Whether to enable ssh recording on all Servers in this Project. Default is `false`. |
 | `team`   | string | The ASA Team of the Project |
-| `user_on_demand_period`   | string | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this  value is `null` and the on-demand user feature is disabled. |
+| `user_on_demand_period`   | number | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this  value is `null` and the on-demand user feature is disabled. |
 
 #### Usage example
 
@@ -185,7 +185,7 @@ This endpoint requires an object with the following fields.
 | `ssh_certificate_type`   | string | (Optional) The type of signature algorithm used for authentication keys. Supported values: `CERT_TYPE_ED25519_01`, `CERT_TYPE_RSA_01`, `CERT_TYPE_ECDSA_521_01`, `CERT_TYPE_ECDSA_384_01`, `CERT_TYPE_ECDSA_256_01`. Default is `CERT_TYPE_ED25519_01`. |
 | `ssh_session_recording`   | boolean | (Optional) Whether to enable ssh recording on all Servers in this Project. Default is `false`. |
 | `team`   | string | The ASA Team of the Project |
-| `user_on_demand_period`   | string | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this  value is `null` and the on-demand user feature is disabled. |
+| `user_on_demand_period`   | number | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this  value is `null` and the on-demand user feature is disabled. |
 
 #### Response body
 This endpoint returns an object with the following fields and a `201` code on a successful call.
@@ -205,7 +205,7 @@ This endpoint returns an object with the following fields and a `201` code on a 
 | `shared_standard_user_name`   | string | (Optional) The name for a shared standard user on Servers in this Project. If `force_shared_ssh_users` is `true`, this must be provided. |
 | `ssh_session_recording`   | boolean | (Optional) Whether to enable ssh recording on all Servers in this Project. Default is `false`. |
 | `team`   | string | The ASA Team of the Project |
-| `user_on_demand_period`   | string | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this  value is `null` and the on-demand user feature is disabled. |
+| `user_on_demand_period`   | number | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this  value is `null` and the on-demand user feature is disabled. |
 
 #### Usage example
 
@@ -289,7 +289,7 @@ This endpoint returns an object with the following fields and a `200` code on a 
 | `shared_standard_user_name`   | string | (Optional) The name for a shared standard user on Servers in this Project. If `force_shared_ssh_users` is `true`, this must be provided. |
 | `ssh_session_recording`   | boolean | (Optional) Whether to enable ssh recording on all Servers in this Project. Default is `false`. |
 | `team`   | string | The ASA Team of the Project |
-| `user_on_demand_period`   | string | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this  value is `null` and the on-demand user feature is disabled. |
+| `user_on_demand_period`   | number | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this  value is `null` and the on-demand user feature is disabled. |
 
 #### Usage example
 
@@ -391,7 +391,7 @@ This endpoint requires an object with the following fields.
 | `require_preauth_for_creds`   | boolean | (Optional) Whether to require preauthorization before an ASA User can retrieve credentials to sign in. Default is `false`. |
 | `ssh_certificate_type`   | string | (Optional) The type of signature algorithm used for authentication keys. Supported values: `CERT_TYPE_ED25519_01`, `CERT_TYPE_RSA_01`, `CERT_TYPE_ECDSA_521_01`, `CERT_TYPE_ECDSA_384_01`, `CERT_TYPE_ECDSA_256_01`. Default is `CERT_TYPE_ED25519_01`. |
 | `ssh_session_recording`   | boolean | Whether to enable ssh recording on all Servers in this Project. Default is `false`. |
-| `user_on_demand_period`   | string | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this  value is `null` and the on-demand user feature is disabled. |
+| `user_on_demand_period`   | number | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this  value is `null` and the on-demand user feature is disabled. |
 
 #### Response body
 This endpoint returns a `204 No Content` response on a successful call.

--- a/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
@@ -99,7 +99,7 @@ This endpoint returns a list of objects with the following fields and a `200` co
 | `shared_standard_user_name`   | string | (Optional) The name for a shared standard user on Servers in this Project. If `force_shared_ssh_users` is `true`, this must be provided. |
 | `ssh_session_recording`   | boolean | (Optional) Whether to enable ssh recording on all Servers in this Project. Default is `false`. |
 | `team`   | string | The ASA Team of the Project |
-| `user_on_demand_period`   | number | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this  value is `null` and the on-demand user feature is disabled. |
+| `user_on_demand_period`   | number | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this value is `null` and the on-demand user feature is disabled. |
 
 #### Usage example
 
@@ -185,7 +185,7 @@ This endpoint requires an object with the following fields.
 | `ssh_certificate_type`   | string | (Optional) The type of signature algorithm used for authentication keys. Supported values: `CERT_TYPE_ED25519_01`, `CERT_TYPE_RSA_01`, `CERT_TYPE_ECDSA_521_01`, `CERT_TYPE_ECDSA_384_01`, `CERT_TYPE_ECDSA_256_01`. Default is `CERT_TYPE_ED25519_01`. |
 | `ssh_session_recording`   | boolean | (Optional) Whether to enable ssh recording on all Servers in this Project. Default is `false`. |
 | `team`   | string | The ASA Team of the Project |
-| `user_on_demand_period`   | number | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this  value is `null` and the on-demand user feature is disabled. |
+| `user_on_demand_period`   | number | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this value is `null` and the on-demand user feature is disabled. |
 
 #### Response body
 This endpoint returns an object with the following fields and a `201` code on a successful call.
@@ -205,7 +205,7 @@ This endpoint returns an object with the following fields and a `201` code on a 
 | `shared_standard_user_name`   | string | (Optional) The name for a shared standard user on Servers in this Project. If `force_shared_ssh_users` is `true`, this must be provided. |
 | `ssh_session_recording`   | boolean | (Optional) Whether to enable ssh recording on all Servers in this Project. Default is `false`. |
 | `team`   | string | The ASA Team of the Project |
-| `user_on_demand_period`   | number | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this  value is `null` and the on-demand user feature is disabled. |
+| `user_on_demand_period`   | number | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this value is `null` and the on-demand user feature is disabled. |
 
 #### Usage example
 
@@ -289,7 +289,7 @@ This endpoint returns an object with the following fields and a `200` code on a 
 | `shared_standard_user_name`   | string | (Optional) The name for a shared standard user on Servers in this Project. If `force_shared_ssh_users` is `true`, this must be provided. |
 | `ssh_session_recording`   | boolean | (Optional) Whether to enable ssh recording on all Servers in this Project. Default is `false`. |
 | `team`   | string | The ASA Team of the Project |
-| `user_on_demand_period`   | number | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this  value is `null` and the on-demand user feature is disabled. |
+| `user_on_demand_period`   | number | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this value is `null` and the on-demand user feature is disabled. |
 
 #### Usage example
 
@@ -391,7 +391,7 @@ This endpoint requires an object with the following fields.
 | `require_preauth_for_creds`   | boolean | (Optional) Whether to require preauthorization before an ASA User can retrieve credentials to sign in. Default is `false`. |
 | `ssh_certificate_type`   | string | (Optional) The type of signature algorithm used for authentication keys. Supported values: `CERT_TYPE_ED25519_01`, `CERT_TYPE_RSA_01`, `CERT_TYPE_ECDSA_521_01`, `CERT_TYPE_ECDSA_384_01`, `CERT_TYPE_ECDSA_256_01`. Default is `CERT_TYPE_ED25519_01`. |
 | `ssh_session_recording`   | boolean | Whether to enable ssh recording on all Servers in this Project. Default is `false`. |
-| `user_on_demand_period`   | number | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this  value is `null` and the on-demand user feature is disabled. |
+| `user_on_demand_period`   | number | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this value is `null` and the on-demand user feature is disabled. |
 
 #### Response body
 This endpoint returns a `204 No Content` response on a successful call.

--- a/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
@@ -99,6 +99,7 @@ This endpoint returns a list of objects with the following fields and a `200` co
 | `shared_standard_user_name`   | string | (Optional) The name for a shared standard user on Servers in this Project. If `force_shared_ssh_users` is `true`, this must be provided. |
 | `ssh_session_recording`   | boolean | (Optional) Whether to enable ssh recording on all Servers in this Project. Default is `false`. |
 | `team`   | string | The ASA Team of the Project |
+| `user_on_demand_period`   | string | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this  value is `null` and the on-demand user feature is disabled. |
 
 #### Usage example
 
@@ -184,6 +185,7 @@ This endpoint requires an object with the following fields.
 | `ssh_certificate_type`   | string | (Optional) The type of signature algorithm used for authentication keys. Supported values: `CERT_TYPE_ED25519_01`, `CERT_TYPE_RSA_01`, `CERT_TYPE_ECDSA_521_01`, `CERT_TYPE_ECDSA_384_01`, `CERT_TYPE_ECDSA_256_01`. Default is `CERT_TYPE_ED25519_01`. |
 | `ssh_session_recording`   | boolean | (Optional) Whether to enable ssh recording on all Servers in this Project. Default is `false`. |
 | `team`   | string | The ASA Team of the Project |
+| `user_on_demand_period`   | string | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this  value is `null` and the on-demand user feature is disabled. |
 
 #### Response body
 This endpoint returns an object with the following fields and a `201` code on a successful call.
@@ -203,6 +205,7 @@ This endpoint returns an object with the following fields and a `201` code on a 
 | `shared_standard_user_name`   | string | (Optional) The name for a shared standard user on Servers in this Project. If `force_shared_ssh_users` is `true`, this must be provided. |
 | `ssh_session_recording`   | boolean | (Optional) Whether to enable ssh recording on all Servers in this Project. Default is `false`. |
 | `team`   | string | The ASA Team of the Project |
+| `user_on_demand_period`   | string | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this  value is `null` and the on-demand user feature is disabled. |
 
 #### Usage example
 
@@ -286,6 +289,7 @@ This endpoint returns an object with the following fields and a `200` code on a 
 | `shared_standard_user_name`   | string | (Optional) The name for a shared standard user on Servers in this Project. If `force_shared_ssh_users` is `true`, this must be provided. |
 | `ssh_session_recording`   | boolean | (Optional) Whether to enable ssh recording on all Servers in this Project. Default is `false`. |
 | `team`   | string | The ASA Team of the Project |
+| `user_on_demand_period`   | string | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this  value is `null` and the on-demand user feature is disabled. |
 
 #### Usage example
 
@@ -387,6 +391,7 @@ This endpoint requires an object with the following fields.
 | `require_preauth_for_creds`   | boolean | (Optional) Whether to require preauthorization before an ASA User can retrieve credentials to sign in. Default is `false`. |
 | `ssh_certificate_type`   | string | (Optional) The type of signature algorithm used for authentication keys. Supported values: `CERT_TYPE_ED25519_01`, `CERT_TYPE_RSA_01`, `CERT_TYPE_ECDSA_521_01`, `CERT_TYPE_ECDSA_384_01`, `CERT_TYPE_ECDSA_256_01`. Default is `CERT_TYPE_ED25519_01`. |
 | `ssh_session_recording`   | boolean | Whether to enable ssh recording on all Servers in this Project. Default is `false`. |
+| `user_on_demand_period`   | string | (Optional) The time period, in seconds, that an on-demand user account exists on the server following an access request. By default, this  value is `null` and the on-demand user feature is disabled. |
 
 #### Response body
 This endpoint returns a `204 No Content` response on a successful call.


### PR DESCRIPTION
## Description:
- **What's changed?** Add missing UserOnDemandPeriod parameter in ASA Projects
- **Is this PR related to a Monolith release?** No

### Preview:
https://6359a86c99c4633f5450a250--reverent-murdock-829d24.netlify.app/docs/reference/api/asa/projects/

### Resolves:

* [OKTA-532542](https://oktainc.atlassian.net/browse/OKTA-532542)
