### PR TITLE
OKTA-374309 Updated parameter for System Log API Actor and Target objects

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
@@ -235,7 +235,7 @@ Describes the user, app, client, or other entity (actor) who performs an action 
 | type        | Type of actor                                  | String              | FALSE    |
 | alternateId | Alternative ID of the actor                        | String              | TRUE     |
 | displayName | Display name of the actor                          | String              | TRUE     |
-| detail      | Details about the actor                            | Map[String->Object] | TRUE     |
+| detailEntry | Details about the actor                            | Map[String->Object] | TRUE     |
 
 ### Target object
 
@@ -247,7 +247,7 @@ The entity that an actor performs an action on. Targets can be anything, such as
 | type        | Type of a target                                             | String              | FALSE    |
 | alternateId | Alternative ID of a target                                   | String              | TRUE     |
 | displayName | Display name of a target                                     | String              | TRUE     |
-| detail      | Details on a target                                         | Map[String->Object] | TRUE     |
+| detailEntry | Details on a target                                         | Map[String->Object] | TRUE     |
 
 ```json
 {


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Changed the [Actor and Target](https://developer.okta.com/docs/reference/api/system-log/#actor-object) parameter `detail` to `detailEntry`,  as per Postman output,  see attached images.
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* [OKTA-374309](https://oktainc.atlassian.net/browse/OKTA-374309)

<img width="451" alt="Screen Shot 2022-11-08 at 3 36 12 PM" src="https://user-images.githubusercontent.com/70648001/200674030-0d5d5e0a-0082-448c-9f2e-5d36eaabb4e9.png">
<img width="473" alt="Screen Shot 2022-11-08 at 3 35 57 PM" src="https://user-images.githubusercontent.com/70648001/200674034-35b80d43-ad3e-4f3e-b617-7fece91d9c9f.png">

