### PR TITLE
Add links to Redocly for sign-in, sign-out, and error pages.

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/public/sitemap_index.xml
+++ b/packages/@okta/vuepress-site/.vuepress/public/sitemap_index.xml
@@ -6,4 +6,7 @@
    <sitemap>
       <loc>https://developer.okta.com/docs-sitemap.xml</loc>
    </sitemap>
+   <sitemap>
+      <loc>https://developer.okta.com/docs/api/sitemap.xml</loc>
+   </sitemap>
 </sitemapindex>

--- a/packages/@okta/vuepress-site/docs/reference/api/brands/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/brands/index.md
@@ -2261,6 +2261,18 @@ HTTP/1.1 200 OK
 }
 ```
 
+## Sign-in page operations
+
+Please see the [sign-in page API documentation](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getSignInPage) on the new beta reference site.
+
+## Sign-out page operations
+
+Please see the [sign-out page API documentation](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getSignOutPageSettings) on the new beta reference site.
+
+## Error page operations
+
+Please see the [error page API documentation](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getErrorPage) on the new beta reference site.
+
 ## Brand API Objects
 
 ### Brand object

--- a/packages/@okta/vuepress-site/docs/reference/api/brands/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/brands/index.md
@@ -2271,7 +2271,7 @@ See the [Customized Sign-out Page API reference](https://developer.okta.com/docs
 
 ## Error page operations
 
-Please see the [error page API documentation](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getErrorPage) on the new beta reference site.
+See the [Customized Error Page API reference](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getErrorPage) on the new beta reference site.
 
 ## Brand API Objects
 

--- a/packages/@okta/vuepress-site/docs/reference/api/brands/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/brands/index.md
@@ -2263,7 +2263,7 @@ HTTP/1.1 200 OK
 
 ## Sign-in page operations
 
-Please see the [sign-in page API documentation](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getSignInPage) on the new beta reference site.
+See the [Customized Sign-in Page API reference](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getSignInPage) on the new beta reference site.
 
 ## Sign-out page operations
 

--- a/packages/@okta/vuepress-site/docs/reference/api/brands/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/brands/index.md
@@ -2267,7 +2267,7 @@ See the [Customized Sign-in Page API reference](https://developer.okta.com/docs/
 
 ## Sign-out page operations
 
-Please see the [sign-out page API documentation](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getSignOutPageSettings) on the new beta reference site.
+See the [Customized Sign-out Page API reference](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getSignOutPageSettings) on the new beta reference site.
 
 ## Error page operations
 

--- a/packages/@okta/vuepress-site/docs/reference/beta-only/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/beta-only/index.md
@@ -10,5 +10,5 @@ In some cases, APIs have only been documented on the new beta reference site, an
 
 * [Agent Pools](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/AgentPools/#tag/AgentPools)
 * [Customized Sign-in Page](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getSignInPage)
-* [Sign-out Page](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getSignOutPageSettings)
+* [Customized Sign-out Page](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getSignOutPageSettings)
 * [Error Page](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getErrorPage)

--- a/packages/@okta/vuepress-site/docs/reference/beta-only/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/beta-only/index.md
@@ -9,3 +9,6 @@ We've got a new API reference in the works! With a fresh look and feel, our new 
 In some cases, APIs have only been documented on the new beta reference site, and not on the old API reference that you are currently looking at. This page provides a list of those, so that you can easily find them.
 
 * [Agent Pools](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/AgentPools/#tag/AgentPools)
+* [Sign-in Page](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getSignInPage)
+* [Sign-out Page](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getSignOutPageSettings)
+* [Error Page](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getErrorPage)

--- a/packages/@okta/vuepress-site/docs/reference/beta-only/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/beta-only/index.md
@@ -9,6 +9,6 @@ We've got a new API reference in the works! With a fresh look and feel, our new 
 In some cases, APIs have only been documented on the new beta reference site, and not on the old API reference that you are currently looking at. This page provides a list of those, so that you can easily find them.
 
 * [Agent Pools](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/AgentPools/#tag/AgentPools)
-* [Sign-in Page](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getSignInPage)
+* [Customized Sign-in Page](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getSignInPage)
 * [Sign-out Page](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getSignOutPageSettings)
 * [Error Page](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getErrorPage)

--- a/packages/@okta/vuepress-site/docs/reference/beta-only/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/beta-only/index.md
@@ -11,4 +11,4 @@ In some cases, APIs have only been documented on the new beta reference site, an
 * [Agent Pools](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/AgentPools/#tag/AgentPools)
 * [Customized Sign-in Page](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getSignInPage)
 * [Customized Sign-out Page](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getSignOutPageSettings)
-* [Error Page](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getErrorPage)
+* [Customized Error Page](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getErrorPage)

--- a/packages/@okta/vuepress-site/docs/reference/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/index.md
@@ -13,6 +13,9 @@ Details on parameters, requests, and responses for Okta's API endpoints.
 In some cases, APIs have only been documented on the [new beta reference site](https://developer.okta.com/docs/api/). This section provides a list of those, so that you can easily find them.
 
 * [Agent Pools](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/AgentPools/#tag/AgentPools)
+* [Customized Sign-in Page](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getSignInPage)
+* [Customized Sign-out Page](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getSignOutPageSettings)
+* [Customized Error Page](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Customization/#tag/Customization/operation/getErrorPage)
 
 ## Core Okta API
 


### PR DESCRIPTION
## Description:
- **What's changed?** Add links to Redocly for sign-in, sign-out, and error pages. Also adds the Redocly sitemap to Vuepress's sitemap index.
- **Is this PR related to a Monolith release?** Yes, ping @gormanho-okta to see if Redocly changes will go into Jan monthly

### Resolves:

* [OKTA-508039](https://oktainc.atlassian.net/browse/OKTA-508039)