### PR TITLE
OKTA-540378: Updating AWS Region list for AWS EventBridge

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/log-streaming/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/log-streaming/index.md
@@ -664,17 +664,29 @@ The AWS EventBridge Settings object specifies the configuration for the `aws_eve
 
 | Region      | Description                                                  |
 | ------------- | ------------------------------------------------------------ |
-| us-east-2 | US East (Ohio) |
-| us-east-1 | US East (N. Virginia) |
-| us-west-1 | US West (N. California) |
-| us-west-2 | US West (Oregon) |
-| ca-central-1 | Canada (Central) |
-| eu-central-1 | Europe (Frankfurt) |
-| eu-west-1 | Europe (Ireland) |
-| eu-west-2 | Europe (London) |
-| eu-west-3 | Europe (Paris) |
-| eu-south-1 | Europe (Milan) |
-| eu-north-1 | Europe (Stockholm) |
+| 	us-east-2 | US East (Ohio) |
+| 	us-east-1 | US East (N. Virginia) |
+| 	us-west-1 | US West (N. California) |
+| 	us-west-2 | US West (Oregon) |
+| 	af-south-1 | Africa (Cape Town) |
+| 	ap-east-1 | Asia Pacific (Hong Kong) |
+| 	ap-southeast-3 | Asia Pacific (Jakarta) |
+| 	ap-south-1 | Asia Pacific (Mumbai) |
+| 	ap-northeast-3 | Asia Pacific (Osaka) |
+| 	ap-northeast-2 | Asia Pacific (Seoul) |
+| 	ap-southeast-1 | Asia Pacific (Singapore) |
+| 	ap-southeast-2 | Asia Pacific (Sydney) |
+| 	ap-northeast-1 | Asia Pacific (Tokyo) |
+| 	ca-central-1 | Canada (Central) |
+| 	eu-central-1 | Europe (Frankfurt) |
+| 	eu-west-1 | Europe (Ireland) |
+| 	eu-west-2 | Europe (London) |
+| 	eu-south-1 | Europe (Milan) |
+| 	eu-west-3 | Europe (Paris) |
+| 	eu-north-1 | Europe (Stockholm) |
+| 	me-south-1 | Middle East (Bahrain) |
+| 	me-central-1 | Middle East (UAE) |
+| 	sa-east-1 | South America (São Paulo) |
 
 
 ### Splunk Cloud Settings object

--- a/packages/@okta/vuepress-site/docs/reference/api/log-streaming/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/log-streaming/index.md
@@ -664,29 +664,29 @@ The AWS EventBridge Settings object specifies the configuration for the `aws_eve
 
 | Region      | Description                                                  |
 | ------------- | ------------------------------------------------------------ |
-| 	us-east-2 | US East (Ohio) |
-| 	us-east-1 | US East (N. Virginia) |
-| 	us-west-1 | US West (N. California) |
-| 	us-west-2 | US West (Oregon) |
-| 	af-south-1 | Africa (Cape Town) |
-| 	ap-east-1 | Asia Pacific (Hong Kong) |
-| 	ap-southeast-3 | Asia Pacific (Jakarta) |
-| 	ap-south-1 | Asia Pacific (Mumbai) |
-| 	ap-northeast-3 | Asia Pacific (Osaka) |
-| 	ap-northeast-2 | Asia Pacific (Seoul) |
-| 	ap-southeast-1 | Asia Pacific (Singapore) |
-| 	ap-southeast-2 | Asia Pacific (Sydney) |
-| 	ap-northeast-1 | Asia Pacific (Tokyo) |
-| 	ca-central-1 | Canada (Central) |
-| 	eu-central-1 | Europe (Frankfurt) |
-| 	eu-west-1 | Europe (Ireland) |
-| 	eu-west-2 | Europe (London) |
-| 	eu-south-1 | Europe (Milan) |
-| 	eu-west-3 | Europe (Paris) |
-| 	eu-north-1 | Europe (Stockholm) |
-| 	me-south-1 | Middle East (Bahrain) |
-| 	me-central-1 | Middle East (UAE) |
-| 	sa-east-1 | South America (São Paulo) |
+| us-east-2 | US East (Ohio) |
+| us-east-1 | US East (N. Virginia) |
+| us-west-1 | US West (N. California) |
+| us-west-2 | US West (Oregon) |
+| af-south-1 | Africa (Cape Town) |
+| ap-east-1 | Asia Pacific (Hong Kong) |
+| ap-southeast-3 | Asia Pacific (Jakarta) |
+| ap-south-1 | Asia Pacific (Mumbai) |
+| ap-northeast-3 | Asia Pacific (Osaka) |
+| ap-northeast-2 | Asia Pacific (Seoul) |
+| ap-southeast-1 | Asia Pacific (Singapore) |
+| ap-southeast-2 | Asia Pacific (Sydney) |
+| ap-northeast-1 | Asia Pacific (Tokyo) |
+| ca-central-1 | Canada (Central) |
+| eu-central-1 | Europe (Frankfurt) |
+| eu-west-1 | Europe (Ireland) |
+| eu-west-2 | Europe (London) |
+| eu-south-1 | Europe (Milan) |
+| eu-west-3 | Europe (Paris) |
+| eu-north-1 | Europe (Stockholm) |
+| me-south-1 | Middle East (Bahrain) |
+| me-central-1 | Middle East (UAE) |
+| sa-east-1 | South America (São Paulo) |
 
 
 ### Splunk Cloud Settings object

--- a/packages/@okta/vuepress-site/docs/reference/api/schemas/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/schemas/index.md
@@ -1573,50 +1573,29 @@ For brevity, the following response doesn't include all available properties.
           "type": "string",
           "writeOnce": true,
           "oneOf": [
-            {
-              "title": "US East (Ohio)",
-              "const": "us-east-2"
-            },
-            {
-              "title": "US East (N. Virginia)",
-              "const": "us-east-1"
-            },
-            {
-              "title": "US West (N. California)",
-              "const": "us-west-1"
-            },
-            {
-              "title": "US West (Oregon)",
-              "const": "us-west-2"
-            },
-            {
-              "title": "Canada (Central)",
-              "const": "ca-central-1"
-            },
-            {
-              "title": "Europe (Frankfurt)",
-              "const": "eu-central-1"
-            },
-            {
-              "title": "Europe (Ireland)",
-              "const": "eu-west-1"
-            },
-            {
-              "title": "Europe (London)",
-              "const": "eu-west-2"
-            },
-            {
-              "title": "Europe (Paris)",
-              "const": "eu-west-3"
-            },
-            {
-              "title": "Europe (Milan)",
-              "const": "eu-south-1"
-            },
-            {
-              "title": "Europe (Stockholm)",
-              "const": "eu-north-1"
-            }
+            { "title": "US East (Ohio)", "const": "us-east-2" },
+            { "title": "US East (N. Virginia)", "const": "us-east-1" },
+            { "title": "US West (N. California)", "const": "us-west-1" },
+            { "title": "US West (Oregon)", "const": "us-west-2" },
+            { "title": "Africa (Cape Town)", "const": "af-south-1" },
+            { "title": "Asia Pacific (Hong Kong)", "const": "ap-east-1" },
+            { "title": "Asia Pacific (Jakarta) ", "const": "ap-southeast-3" },
+            { "title": "Asia Pacific (Mumbai)", "const": "ap-south-1" },
+            { "title": "Asia Pacific (Osaka)", "const": "ap-northeast-3" },
+            { "title": "Asia Pacific (Seoul)", "const": "ap-northeast-2" },
+            { "title": "Asia Pacific (Singapore)", "const": "ap-southeast-1" },
+            { "title": "Asia Pacific (Sydney)", "const": "ap-southeast-2" },
+            { "title": "Asia Pacific (Tokyo)", "const": "ap-northeast-1" },
+            { "title": "Canada (Central)", "const": "ca-central-1" },
+            { "title": "Europe (Frankfurt)", "const": "eu-central-1" },
+            { "title": "Europe (Ireland)", "const": "eu-west-1" },
+            { "title": "Europe (London)", "const": "eu-west-2" },
+            { "title": "Europe (Milan)", "const": "eu-south-1" },
+            { "title": "Europe (Paris)", "const": "eu-west-3" },
+            { "title": "Europe (Stockholm)", "const": "eu-north-1" },
+            { "title": "Middle East (Bahrain)", "const": "me-south-1" },
+            { "title": "Middle East (UAE)", "const": "me-central-1" },
+            { "title": "South America (São Paulo)", "const": "sa-east-1" }
           ]
         }
       },
@@ -1716,50 +1695,29 @@ For brevity, the following response doesn't include all available properties.
             "type": "string",
             "writeOnce": true,
             "oneOf": [
-              {
-                "title": "US East (Ohio)",
-                "const": "us-east-2"
-              },
-              {
-                "title": "US East (N. Virginia)",
-                "const": "us-east-1"
-              },
-              {
-                "title": "US West (N. California)",
-                "const": "us-west-1"
-              },
-              {
-                "title": "US West (Oregon)",
-                "const": "us-west-2"
-              },
-              {
-                "title": "Canada (Central)",
-                "const": "ca-central-1"
-              },
-              {
-                "title": "Europe (Frankfurt)",
-                "const": "eu-central-1"
-              },
-              {
-                "title": "Europe (Ireland)",
-                "const": "eu-west-1"
-              },
-              {
-                "title": "Europe (London)",
-                "const": "eu-west-2"
-              },
-              {
-                "title": "Europe (Paris)",
-                "const": "eu-west-3"
-              },
-              {
-                "title": "Europe (Milan)",
-                "const": "eu-south-1"
-              },
-              {
-                "title": "Europe (Stockholm)",
-                "const": "eu-north-1"
-              }
+              { "title": "US East (Ohio)", "const": "us-east-2" },
+              { "title": "US East (N. Virginia)", "const": "us-east-1" },
+              { "title": "US West (N. California)", "const": "us-west-1" },
+              { "title": "US West (Oregon)", "const": "us-west-2" },
+              { "title": "Africa (Cape Town)", "const": "af-south-1" },
+              { "title": "Asia Pacific (Hong Kong)", "const": "ap-east-1" },
+              { "title": "Asia Pacific (Jakarta) ", "const": "ap-southeast-3" },
+              { "title": "Asia Pacific (Mumbai)", "const": "ap-south-1" },
+              { "title": "Asia Pacific (Osaka)", "const": "ap-northeast-3" },
+              { "title": "Asia Pacific (Seoul)", "const": "ap-northeast-2" },
+              { "title": "Asia Pacific (Singapore)", "const": "ap-southeast-1" },
+              { "title": "Asia Pacific (Sydney)", "const": "ap-southeast-2" },
+              { "title": "Asia Pacific (Tokyo)", "const": "ap-northeast-1" },
+              { "title": "Canada (Central)", "const": "ca-central-1" },
+              { "title": "Europe (Frankfurt)", "const": "eu-central-1" },
+              { "title": "Europe (Ireland)", "const": "eu-west-1" },
+              { "title": "Europe (London)", "const": "eu-west-2" },
+              { "title": "Europe (Milan)", "const": "eu-south-1" },
+              { "title": "Europe (Paris)", "const": "eu-west-3" },
+              { "title": "Europe (Stockholm)", "const": "eu-north-1" },
+              { "title": "Middle East (Bahrain)", "const": "me-south-1" },
+              { "title": "Middle East (UAE)", "const": "me-central-1" },
+              { "title": "South America (São Paulo)", "const": "sa-east-1" }
             ]
           }
         },


### PR DESCRIPTION
Resolves: OKTA-540378

<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Adding more regions to AWS regions list for AWS EventBridge Log Streaming
- **Is this PR related to a Monolith release?** Yes (probably 2023.1.0)

### Resolves:

* [OKTA-540378](https://oktainc.atlassian.net/browse/OKTA-540378)
