### PR TITLE
Add missing GitHub social redirects in conductor.yml

### DIFF
--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -2405,6 +2405,18 @@ redirects:
     to: /docs/guides/social-login/apple/main/
   - from: /docs/guides/add-an-external-idp/apple/main
     to: /docs/guides/social-login/apple/main/
+  - from: /docs/guides/add-an-external-idp/github/before-you-begin/index.html
+    to: /docs/guides/social-login/github/main/
+  - from: /docs/guides/add-an-external-idp/github/before-you-begin
+    to: /docs/guides/social-login/github/main/
+  - from: /docs/guides/add-an-external-idp/github/configure-idp-in-okta/index.html
+    to: /docs/guides/social-login/github/main/#create-the-identity-provider-in-okta
+  - from: /docs/guides/add-an-external-idp/github/configure-idp-in-okta
+    to: /docs/guides/social-login/github/main/#create-the-identity-provider-in-okta
+  - from: /docs/guides/add-an-external-idp/github/main/index.html
+    to: /docs/guides/social-login/github/main/
+  - from: /docs/guides/add-an-external-idp/github/main
+    to: /docs/guides/social-login/github/main/
   - from: /docs/guides/add-an-external-idp/-/configure-idp-in-okta/index.html
     to: /docs/guides/add-an-external-idp/openidconnect/main/#create-an-identity-provider-in-okta
   - from: /docs/guides/add-an-external-idp/-/configure-idp-in-okta


### PR DESCRIPTION
Adding a social IdP via the Okta Admin console contains a dead link when using GitHub (possibly other IdPs)

Repro:
Go to `https://dev-133337-admin.okta.com/admin/access/identity-providers
Select **GitHub** -> **Click next** 

The context help in the right side of the form contains a link to: `https://developer.okta.com/docs/guides/add-an-external-idp/github/configure-idp-in-okta/` 

![image](https://user-images.githubusercontent.com/99954/205759484-8d092e0c-9ada-474e-be28-12bbaa42d690.png)

If you select Google or Apple, the docs site will redirect correctly (these URLs are already in the conductor.yml)

> NOTE: All possible IdPs should be checked to make sure they redirect correctly.

This PR was created from the GitHub Web UI and was not tested (I copy and pasted the `apple` one and updated it for `github`)

Also the product URLs should be updated to avoid the redirect.