### PR TITLE
Remove the term "AIW" in social-login guide

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/social-login/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/social-login/main/index.md
@@ -22,7 +22,7 @@ Configure a social Identity Provider so that your users can quickly sign up or s
 **What you need**
 
 * [Okta Developer Edition organization](https://developer.okta.com/signup)
-* An OpenID Connect (OIDC) app integration in Okta for the app that you want to add authentication to. You can [create a new OIDC app integration using AIW](https://help.okta.com/okta_help.htm?id=ext_Apps_App_Integration_Wizard-oidc) or use an existing one.
+* An OpenID Connect (OIDC) app integration in Okta for the app that you want to add authentication to. You can [create a new OIDC app integration](https://help.okta.com/okta_help.htm?id=ext_Apps_App_Integration_Wizard-oidc) or use an existing one.
 * An account with <StackSnippet snippet="idpaccount" inline />
 
 ---


### PR DESCRIPTION
It's an Okta-specific abbreviation, customers are not going to know what it means (I didn't know what it was without a search).

Otherwise, this term should qualified on the page:

> Application Integration Wizard (AIW)

But, IMHO it's more clear if it's removed.

> NOTE: the `/docs/guides/add-an-external-idp/azure/main/` page contains the unqualified term `AIW` too (possibly other pages)