### PR TITLE
Add new OAuth app link to GitHub social IdP docs

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/social-login/main/github/appatidp.md
+++ b/packages/@okta/vuepress-site/docs/guides/social-login/main/github/appatidp.md
@@ -1,4 +1,4 @@
-1. Create and register an [OAuth](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app) app at GitHub.
+1. Create and register an [OAuth](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app) app at [GitHub](https://github.com/settings/applications/new).
 
 1. When you create an application at the IdP, you must provide a redirect URI for authentication.
 


### PR DESCRIPTION
Streamline the process of pointing the developer to the right place, developers can create a new OAuth application by navigating directly to `https://github.com/settings/applications/new`

GitHub enterprise customers with custom domains would likely use a different link, but those users likely would be integrating with SAML or other user store and would not be integrating with Okta this way.