### PR TITLE
OKTA-551186 - Add update to 2022.11.1 release notes

### DIFF
--- a/packages/@okta/vuepress-site/docs/release-notes/2022-okta-identity-engine/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2022-okta-identity-engine/index.md
@@ -18,6 +18,8 @@ title: Okta Identity Engine API Products release notes 2022
 
 * The wrong response code (500) was sent when an admin attempted to use the app target or group target operations of the Administrator Role API with a custom role binding identifier. (OKTA-529688)
 
+* Inline hook requests configured to use OAuth 2.0 authentication sent expired access tokens in the authorization header. (OKTA-551186)
+
 ### Monthly release 2022.11.0
 
 | Change | Expected in Preview Orgs |

--- a/packages/@okta/vuepress-site/docs/release-notes/2022/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2022/index.md
@@ -8,11 +8,13 @@ title: Okta API Products release notes 2022
 
 | Change | Expected in Preview Orgs |
 |--------------------------------------------------------------------------|--------------------------|
-| [Bug fixed in 2022.11.1](#bug-fixed-in-2022-11-1)                      | November 30, 2022            |
+| [Bugs fixed in 2022.11.1](#bugs-fixed-in-2022-11-1)                      | November 30, 2022            |
 
-#### Bug fixed in 2022.11.1
+#### Bugs fixed in 2022.11.1
 
 * The wrong response code (500) was sent when an admin attempted to use the app target or group target operations of the Administrator Role API with a custom role binding identifier. (OKTA-529688)
+
+* Inline hook requests configured to use OAuth 2.0 authentication sent expired access tokens in the authorization header. (OKTA-551186)
 
 ### Monthly release 2022.11.0
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Adding a release note for inline hook requests sending expired access tokens
- **Is this PR related to a Monolith release?** 2022.11.1

### Resolves:

* [OKTA-551186](https://oktainc.atlassian.net/browse/OKTA-551186)
