### PR TITLE
update for seamless migration & remove cloudflare

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -83,7 +83,7 @@ Yes. When you turn the custom domain on, the Okta domain (for example, `example.
 
 This method of configuring a custom domain is recommended because Okta manages your certificate renewals in perpetuity through an integration with Let's Encrypt, which is a free certificate authority. The certificate procurement process is free, and also faster and easier than configuring a custom domain with your own TLS certificate.
 
-> **Note:** If your custom domain is currently using your own TLS certificate and you'd like to migrate it to use an Okta-managed certificate, contact support@okta.com to request a seamless migration with no downtime.
+> **Note:** If your custom domain uses your own TLS certificate and you want to migrate to an Okta-managed certificate, contact your Okta account team or post on our [forum](https://devforum.okta.com/) to request a seamless migration with no downtime.
 
 > **Note:** You don't need a [Certificate Authorization Authority (CAA)](https://datatracker.ietf.org/doc/html/rfc6844) record to use an Okta-managed TLS certificate. However, if you do have a CAA record, keep the following in mind:
 >

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -83,6 +83,8 @@ Yes. When you turn the custom domain on, the Okta domain (for example, `example.
 
 This method of configuring a custom domain is recommended because Okta manages your certificate renewals in perpetuity through an integration with Let's Encrypt, which is a free certificate authority. The certificate procurement process is free, and also faster and easier than configuring a custom domain with your own TLS certificate.
 
+> **Note:** If your custom domain is currently using your own TLS certificate and you'd like to migrate it to use an Okta-managed certificate, contact support@okta.com to request a seamless migration with no downtime.
+
 > **Note:** You don't need a [Certificate Authorization Authority (CAA)](https://datatracker.ietf.org/doc/html/rfc6844) record to use an Okta-managed TLS certificate. However, if you do have a CAA record, keep the following in mind:
 >
 >   * If it's your first time setting up a custom domain with an Okta-managed certificate, you need to add `letsencrypt.org` to the issuers list or Okta can't get the TLS certificate. See [Let's Encrypt - Using CAA](https://letsencrypt.org/docs/caa/).
@@ -262,37 +264,6 @@ Additionally, you may want to change the issuer for your OpenID Connect apps tha
 ### Update app endpoints
 
 If you have apps that use Okta endpoints with the uncustomized URL domain, update them to use the custom URL domain.
-
-## Optional: Create a custom domain within Cloudflare
-
-If you need to set up a custom domain, you can use Cloudflare.
-
-### Transfer your domain and create a certificate
-
-> **Note:** [Sign up for Cloudflare](https://dash.cloudflare.com/sign-up) if you don't have an account.
-
-Sign in to Cloudflare and select **+Add Site**. It's best if you point an entire domain at Cloudflare. For example, `example.com`. The free plan is good enough for these steps.
-
-After transferring your domain, you need to create an origin CA certificate:
-
-1. Select the **SSL/TLS** app, and then click **Origin Server**.
-2. Click **Create Certificate** to open the **Origin Certificate Installation** dialog box.
-3. Select **Let Cloudflare generate a private key and a CSR**.
-4. Change **Certificate Validity** to **1 year** (Okta rejects certificates with a 15-year expiration), and then click **Next**.
-5. Copy the **Origin Certificate** to a `tls.cert` file on your hard drive, and then copy the **Private key** to `private.key`.
-6. In Okta, go to **Customization** > **Domain Name** > **Edit** > **Get Started**.
-7. Enter a subdomain name (for example: `id.example.com`) and click **Next**. You are prompted to verify domain ownership.
-8. In Cloudflare, add the specified `TXT` record using the **DNS** > **+ Add record** option.
-9. In Okta, select **Verify** > **Next**.
-10. In the **Certificate** box, copy/paste the contents of `tls.cert`.
-
-    > **Note:** On a Mac you can use `cat tls.cert | pbcopy` in a terminal to copy the file to your clipboard.
-
-11. Paste the contents of `private.key` in the **Private key** box. Click **Next**.
-12. You are prompted to add a [CNAME record](https://datatracker.ietf.org/doc/html/rfc1035#section-3.2.2). Add this to your Cloudflare DNS, and then click **Finish**.
-13. Wait until `https://<id.domain.name>` resolves in your browser before you continue.
-
-> **Note:** When you first try this, it's possible that your network caches DNS entries, and you won't be able to get to `id.example.com`. As a workaround, you can tether with your phone, then graph the IP address and add it as an entry to your `hosts`.
 
 ### Configure a custom domain for your Authorization Server
 


### PR DESCRIPTION
## Description:
- **What's changed?**
- added note to call out ability to seamlessly migrate to Okta-managed certs with no downtime by contacting support
- removed section on configuring custom domain with cloudflare - that was a stopgap before we had okta-managed certs and should not be recommended anymore
- **Is this PR related to a Monolith release?** 
- no

### Resolves:

* https://oktainc.atlassian.net/browse/OKTA-556756
