### PR TITLE
OKTA-508755 - Groups API - Add search parameters

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
@@ -180,10 +180,13 @@ Enumerates Groups in your organization with pagination. A subset of Groups can b
 | q         | Finds a group that matches the `name` property                                               | Query     | String   | FALSE    |         |
 | expand        | If specified, it causes additional metadata to be included in the response. Possible values are `stats` and/or `app`.                                             | Query     | String   | FALSE    |         |
 | search | Searches for groups with a supported [filtering](/docs/reference/core-okta-api/#filter) expression for all [attributes](#group-attributes) except for `_embedded`, `_links`, and `objectClass`  | Query     | String   | FALSE    |         |
+| sortBy      | Specifies field to sort by (for search queries only).                                                                                           | Search query | String     | FALSE    |
+| sortOrder   | Specifies sort order asc or desc (for search queries only).                                                                                     | Search query | String     | FALSE    |
 
 > **Notes:** The `after` cursor should be treated as an opaque value and obtained through the next link relation. See [Pagination](/docs/reference/core-okta-api/#pagination).<br><br>
 Search currently performs a `startsWith` match but it should be considered an implementation detail and may change without notice in the future.<br><br>
 Results from the filter or query parameter are driven from an eventually consistent datasource. The synchronization lag is typically less than one second.
+
 ###### Filters
 
 The following expressions are supported for Groups with the `filter` query parameter:
@@ -358,7 +361,6 @@ curl -v -X GET \
 ```
 
 ##### Response example
-
 
 ```json
 [
@@ -725,16 +727,24 @@ curl -v -X GET \
 
 Searches for groups based on the properties specified in the search parameter
 
-Property names in the search parameter are case sensitive, whereas operators (`eq`, `sw`, etc.) and string values are case insensitive.
+Property names in the search parameter are case sensitive, whereas operators (`eq`, `sw`, and so on) and string values are case insensitive.
 
 This operation:
 
-* Supports [pagination](/docs/reference/core-okta-api/#pagination).
-* Requires [URL encoding](http://en.wikipedia.org/wiki/Percent-encoding). For example, `search=type eq "OKTA_GROUP"` is encoded as `search=type+eq+%22OKTA_GROUP%22`. Use an ID lookup for records that you update to ensure your results contain the latest data. Search results are eventually consistent.
-* Searches many properties:
+- Supports [pagination](/docs/reference/core-okta-api/#pagination).
+
+- Requires [URL encoding](http://en.wikipedia.org/wiki/Percent-encoding). For example, `search=type eq "OKTA_GROUP"` is encoded as `search=type+eq+%22OKTA_GROUP%22`. Use an ID lookup for records that you update to ensure your results contain the latest data. Search results are eventually consistent.
+
+- Searches many properties:
   - Any group profile property, including imported app group profile properties.
   - The top-level properties `id`, `created`, `lastMembershipUpdated`, `lastUpdated`, and `type`.
   - The [source](#group-attributes) of groups with type of `APP_GROUP`, accessed as `source.id`.
+
+- Accepts `sortBy` and `sortOrder` parameters.
+  - `sortBy` can be any single property, for example `sortBy=profile.lastName`
+  - `sortOrder` is optional and defaults to ascending
+  - `sortOrder` is ignored if `sortBy` is not present
+  - Users with the same value for the `sortBy` property will be ordered by `id`
 
 | Search Term Example                                       | Description                                                               |
 | :-------------------------------------------------------- | :------------------------------------------------------------------------ |
@@ -1122,7 +1132,6 @@ curl -v -X DELETE \
 
 ##### Response example
 
-
 ```http
 HTTP/1.1 204 No Content
 ```
@@ -1155,7 +1164,6 @@ Creates a Group rule to dynamically add users to the specified Group if they mat
 Created [Rule](#rule-object)
 
 ##### Request example
-
 
 ```bash
 curl -v -X POST \

--- a/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
@@ -744,7 +744,7 @@ This operation:
   - `sortBy` can be any single property, for example `sortBy=profile.name`
   - `sortOrder` is optional and defaults to ascending
   - `sortOrder` is ignored if `sortBy` is not present
-  - Users with the same value for the `sortBy` property will be ordered by `id`
+  - Groups with the same value for the `sortBy` property will be ordered by `id`
 
 | Search Term Example                                       | Description                                                               |
 | :-------------------------------------------------------- | :------------------------------------------------------------------------ |

--- a/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
@@ -741,7 +741,7 @@ This operation:
   - The [source](#group-attributes) of groups with type of `APP_GROUP`, accessed as `source.id`.
 
 - Accepts `sortBy` and `sortOrder` parameters.
-  - `sortBy` can be any single property, for example `sortBy=profile.lastName`
+  - `sortBy` can be any single property, for example `sortBy=profile.name`
   - `sortOrder` is optional and defaults to ascending
   - `sortOrder` is ignored if `sortBy` is not present
   - Users with the same value for the `sortBy` property will be ordered by `id`


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Added the `sortBy` and `sortOrder` parameters to the Groups API; re-purposed same content that was in Users API for these parameters.
- **Is this PR related to a Monolith release?** 2022.12.0

### Resolves:

* [OKTA-508755](https://oktainc.atlassian.net/browse/OKTA-508755)
