### PR TITLE
Add userVerification property to WebAuthn AuthN verify API

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
@@ -5496,6 +5496,7 @@ curl -v -X POST \
          "_embedded":{
             "challenge":{
                "challenge":"K0UNqWlz2TCCDd5qEkBf",
+               "userVerification": "preferred",
                "extensions":{
                }
             }


### PR DESCRIPTION
## Description:
- Add WebAuthn's userVerification property to the verify API response in AuthN API
- Not related to a monolith release; this is rectifying a missed doc

### Resolves:

* [OKTA-559053](https://oktainc.atlassian.net/browse/OKTA-559053)
