### PR TITLE
Implement netlify-preview action

### DIFF
--- a/.github/workflows/build-and-checks.js.yml
+++ b/.github/workflows/build-and-checks.js.yml
@@ -4,7 +4,6 @@ on: pull_request
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: '--max_old_space_size=3584'
@@ -14,13 +13,17 @@ jobs:
         node-version: [14.x]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Checkout repository!
+      uses: actions/checkout@v3
+    - name: Setup node - ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: yarn install --frozen-lockfile
-    - run: yarn build
-    - run: ./scripts/yarn-checks.sh
+    - name: Install dependencies
+      run: yarn install --frozen-lockfile
+    - name: Build
+      run: yarn build
+    - name: Run checks
+      run: ./scripts/yarn-checks.sh
       shell: bash

--- a/.github/workflows/netlify-preview.js.yml
+++ b/.github/workflows/netlify-preview.js.yml
@@ -5,14 +5,32 @@ on:
     types: [created]
 
 jobs:
+  check-secrets:
+    runs-on: ubuntu-latest
+    environment: Netlify
+    env:
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+    
+    steps:
+      - name: Has secrets?
+        if: env.NETLIFY_AUTH_TOKEN == '' || env.NETLIFY_SITE_ID == ''
+        run: exit 1
+      
+      - uses: vishnudxb/cancel-workflow@v1.2
+        if: failure()
+        with:
+          repo: okta/okta-developer-docs
+          workflow_id: ${{ github.run_id }}
+          access_token: ${{ github.token }}
+
   deploy-preview:
     # This runs only for okta/okta-developer-docs
     # This runs only for PR comments
     # This runs only if PR comment is "/netlify preview"
     if: github.repository_owner == 'okta' && github.event.issue.pull_request && contains(github.event.comment.body, '/netlify preview')
-    environment: Netlify
-    name: 'deploy preview'
     runs-on: ubuntu-latest
+    environment: Netlify
     env:
       NODE_OPTIONS: '--max_old_space_size=3584'
 
@@ -23,15 +41,24 @@ jobs:
     steps:
     - name: Checkout repository!
       uses: actions/checkout@v3
+
+    - name: Checkout Pull Request
+      run: hub pr checkout ${{ github.event.issue.number }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Setup node - ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+
     - name: Install dependencies
       run: yarn install --frozen-lockfile
+
     - name: Build preview
-      run: yarn preview
+      run: yarn build
+
     - name: Deploy preview to Netlify
       uses: nwtgck/actions-netlify@v2.0.0
       with:
@@ -41,5 +68,5 @@ jobs:
         enable-pull-request-comment: true
         overwrites-pull-request-comment: false
       env:
-        NETLIFY_AUTH_TOKEN: ${{ env.NETLIFY_AUTH_TOKEN }}
-        NETLIFY_SITE_ID: ${{ env.NETLIFY_SITE_ID }}
+        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/netlify-preview.js.yml
+++ b/.github/workflows/netlify-preview.js.yml
@@ -1,10 +1,15 @@
 name: 'Netlify'
 
-on: workflow_dispatch
+on:
+  issue_comment:
+    types: [created]
 
 jobs:
   deploy-preview:
-    if: github.repository_owner == 'okta'
+    # This runs only for okta/okta-developer-docs
+    # This runs only for PR comments
+    # This runs only if PR comment is "/netlify preview"
+    if: github.repository_owner == 'okta' && github.event.issue.pull_request && contains(github.event.comment.body, '/netlify preview')
     environment: Netlify
     name: 'deploy preview'
     runs-on: ubuntu-latest
@@ -26,7 +31,7 @@ jobs:
     - name: Install dependencies
       run: yarn install --frozen-lockfile
     - name: Build preview
-      run: yarn build
+      run: yarn preview
     - name: Deploy preview to Netlify
       uses: nwtgck/actions-netlify@v2.0.0
       with:

--- a/.github/workflows/netlify-preview.js.yml
+++ b/.github/workflows/netlify-preview.js.yml
@@ -1,0 +1,42 @@
+name: 'Netlify'
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  deploy-preview:
+    if: github.repository_owner == 'okta' && github.event.label.name == 'preview'
+    name: 'deploy preview'
+    runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: '--max_old_space_size=3584'
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+    - name: Checkout repository!
+      uses: actions/checkout@v3
+    - name: Setup node - ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - name: Install dependencies
+      run: yarn install --frozen-lockfile
+    - name: Build preview
+      run: yarn preview
+    - run: ls
+    - name: Deploy preview to Netlify
+      uses: nwtgck/actions-netlify@v2.0.0
+      with:
+        publish-dir: 'packages/@okta/vuepress-site/dist'
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        deploy-message: "Deploy from GitHub Actions"
+        enable-pull-request-comment: true
+        overwrites-pull-request-comment: true
+      env:
+        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/netlify-preview.js.yml
+++ b/.github/workflows/netlify-preview.js.yml
@@ -1,12 +1,11 @@
 name: 'Netlify'
 
-on:
-  pull_request:
-    types: [labeled]
+on: workflow_dispatch
 
 jobs:
   deploy-preview:
-    if: github.repository_owner == 'okta' && github.event.label.name == 'preview'
+    if: github.repository_owner == 'okta'
+    environment: Netlify
     name: 'deploy preview'
     runs-on: ubuntu-latest
     env:
@@ -28,7 +27,6 @@ jobs:
       run: yarn install --frozen-lockfile
     - name: Build preview
       run: yarn preview
-    - run: ls
     - name: Deploy preview to Netlify
       uses: nwtgck/actions-netlify@v2.0.0
       with:
@@ -38,5 +36,5 @@ jobs:
         enable-pull-request-comment: true
         overwrites-pull-request-comment: false
       env:
-        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        NETLIFY_AUTH_TOKEN: ${{ env.NETLIFY_AUTH_TOKEN }}
+        NETLIFY_SITE_ID: ${{ env.NETLIFY_SITE_ID }}

--- a/.github/workflows/netlify-preview.js.yml
+++ b/.github/workflows/netlify-preview.js.yml
@@ -5,25 +5,6 @@ on:
     types: [created]
 
 jobs:
-  check-secrets:
-    runs-on: ubuntu-latest
-    environment: Netlify
-    env:
-      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-    
-    steps:
-      - name: Has secrets?
-        if: env.NETLIFY_AUTH_TOKEN == '' || env.NETLIFY_SITE_ID == ''
-        run: exit 1
-      
-      - uses: vishnudxb/cancel-workflow@v1.2
-        if: failure()
-        with:
-          repo: okta/okta-developer-docs
-          workflow_id: ${{ github.run_id }}
-          access_token: ${{ github.token }}
-
   deploy-preview:
     # This runs only for okta/okta-developer-docs
     # This runs only for PR comments
@@ -33,12 +14,25 @@ jobs:
     environment: Netlify
     env:
       NODE_OPTIONS: '--max_old_space_size=3584'
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
     strategy:
       matrix:
         node-version: [14.x]
 
     steps:
+    - name: Has secrets?
+      if: env.NETLIFY_AUTH_TOKEN == '' || env.NETLIFY_SITE_ID == ''
+      run: exit 1
+    
+    - uses: vishnudxb/cancel-workflow@v1.2
+      if: failure()
+      with:
+        repo: okta/okta-developer-docs
+        workflow_id: ${{ github.run_id }}
+        access_token: ${{ github.token }}
+
     - name: Checkout repository!
       uses: actions/checkout@v3
 

--- a/.github/workflows/netlify-preview.js.yml
+++ b/.github/workflows/netlify-preview.js.yml
@@ -36,7 +36,7 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         deploy-message: "Deploy from GitHub Actions"
         enable-pull-request-comment: true
-        overwrites-pull-request-comment: true
+        overwrites-pull-request-comment: false
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/netlify-preview.js.yml
+++ b/.github/workflows/netlify-preview.js.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: yarn install --frozen-lockfile
     - name: Build preview
-      run: yarn preview
+      run: yarn build
     - name: Deploy preview to Netlify
       uses: nwtgck/actions-netlify@v2.0.0
       with:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "yarn workspace @okta/vuepress-site dev",
     "build": "yarn stylelint && yarn workspace @okta/vuepress-site build",
+    "preview": "yarn workspace @okta/vuepress-site build",
     "broken-link-checker:all": "node scripts/broken-link-checker all",
     "broken-link-checker:internal": "node scripts/broken-link-checker internal",
     "broken-link-checker:external": "node scripts/broken-link-checker external",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "yarn workspace @okta/vuepress-site dev",
     "build": "yarn stylelint && yarn workspace @okta/vuepress-site build",
-    "preview": "yarn workspace @okta/vuepress-site build",
     "broken-link-checker:all": "node scripts/broken-link-checker all",
     "broken-link-checker:internal": "node scripts/broken-link-checker internal",
     "broken-link-checker:external": "node scripts/broken-link-checker external",


### PR DESCRIPTION
## Description:
- Implement netlify-preview action

To toggle the job, comment `/netlify preview`

This only runs when
- Within okta/okta-developer-docs
- If secrets are not available, the job will short-circuit
- Triggers on new PR comments
- Executes if PR comment is "/netlify preview"

### Resolves:
* [OKTA-558239](https://oktainc.atlassian.net/browse/OKTA-558239)

![Screen Shot 2022-12-15 at 7 04 38 PM](https://user-images.githubusercontent.com/72201855/207992758-72ebd360-01b0-479e-a87d-a109b1d7a2e2.png)

