### PR TITLE
OKTA-557217, 219: fix broken links

### DIFF
--- a/packages/@okta/vuepress-site/code/javascript/okta_sign-in_widget/index.md
+++ b/packages/@okta/vuepress-site/code/javascript/okta_sign-in_widget/index.md
@@ -346,7 +346,7 @@ See the following Okta Classic Engine examples:
 
 - Android:
     - [Sign in with your own UI](https://github.com/okta/okta-oidc-android#Sign-in-with-your-own-UI)
-    - [Custom sign-in example](https://github.com/okta/samples-android/tree/master/custom-sign-in)
+    - [Custom sign-in example](https://github.com/okta/samples-android/tree/legacy-samples/custom-sign-in)
 - iOS:
     - [Authenticate a user](https://github.com/okta/okta-auth-swift#authenticate-a-user)
     - [Okta iOS custom sign-in example](https://github.com/okta/samples-ios/tree/legacy-samples/custom-sign-in)

--- a/packages/@okta/vuepress-site/code/javascript/okta_sign-in_widget/index.md
+++ b/packages/@okta/vuepress-site/code/javascript/okta_sign-in_widget/index.md
@@ -342,14 +342,14 @@ We also have mobile SDKs for Android, React Native, iOS, and Xamarin.
 
 For mobile apps, embedding the Sign-In Widget isn't currently supported. A possible workaround is to redirect to Okta for authentication and [customize the hosted Sign-In Widget](/docs/guides/custom-widget/main/#style-the-okta-hosted-sign-in-widget). Support is provided for building your own UI in mobile apps.
 
-See the following examples:
+See the following Okta Classic Engine examples:
 
 - Android:
     - [Sign in with your own UI](https://github.com/okta/okta-oidc-android#Sign-in-with-your-own-UI)
     - [Custom sign-in example](https://github.com/okta/samples-android/tree/master/custom-sign-in)
 - iOS:
     - [Authenticate a user](https://github.com/okta/okta-auth-swift#authenticate-a-user)
-    - [Okta iOS custom sign-in example](https://github.com/okta/samples-ios/tree/master/custom-sign-in)
+    - [Okta iOS custom sign-in example](https://github.com/okta/samples-ios/tree/legacy-samples/custom-sign-in)
 
 <!--
 - React Native

--- a/packages/@okta/vuepress-site/docs/guides/archive-embedded-siw/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/archive-embedded-siw/main/index.md
@@ -356,7 +356,7 @@ See the following examples:
     - [Custom Sign In Example](https://github.com/okta/samples-android/tree/master/custom-sign-in)
 - iOS:
     - [Authenticate a User](https://github.com/okta/okta-auth-swift#authenticate-a-user)
-    - [Okta iOS Custom Sign In Example](https://github.com/okta/samples-ios/tree/master/custom-sign-in)
+    - [Okta iOS Custom Sign In Example](https://github.com/okta/samples-ios/tree/legacy-samples/custom-sign-in)
 
 <!--
 - React Native

--- a/packages/@okta/vuepress-site/docs/guides/archive-embedded-siw/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/archive-embedded-siw/main/index.md
@@ -353,7 +353,7 @@ See the following examples:
 
 - Android:
     - [Sign in with your own UI](https://github.com/okta/okta-oidc-android#Sign-in-with-your-own-UI)
-    - [Custom Sign In Example](https://github.com/okta/samples-android/tree/master/custom-sign-in)
+    - [Custom Sign In Example](https://github.com/okta/samples-android/tree/legacy-samples/custom-sign-in)
 - iOS:
     - [Authenticate a User](https://github.com/okta/okta-auth-swift#authenticate-a-user)
     - [Okta iOS Custom Sign In Example](https://github.com/okta/samples-ios/tree/legacy-samples/custom-sign-in)


### PR DESCRIPTION
Fix links to sample code moved from main branch to legacy branch.

**Current preview links**
Last Update: 12/20/22 15:30 GMT
Embedded Okta Sign-In Widget fundamentals:
https://63a1c4e22d0b5d084ce5f39b--reverent-murdock-829d24.netlify.app/docs/guides/archive-embedded-siw/main/#mobile-sdks
Okta Sign-In widget guide:
https://63a1c4e22d0b5d084ce5f39b--reverent-murdock-829d24.netlify.app/code/javascript/okta_sign-in_widget/#mobile-sdks

