### PR TITLE
Remove Community > Developer Days link

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/config.js
+++ b/packages/@okta/vuepress-site/.vuepress/config.js
@@ -161,7 +161,6 @@ module.exports = ctx => ({
         children: [
           { text: 'Forum', link: 'https://devforum.okta.com' },
           { text: 'Toolkit', link: 'https://toolkit.okta.com/' },
-          { text: 'Developer Days', link: 'https://regionalevents.okta.com/DeveloperDays2022' },
           { type: 'divider' },
           { type: 'icons',
             icons: [

--- a/packages/@okta/vuepress-site/docs/reference/api/hook-keys/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/hook-keys/index.md
@@ -14,7 +14,7 @@ The Okta Key Management API provides a CRUD interface for JSON Web Keys (JWK) us
 
 ## Get started
 
-Explore the Key Management API:[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/a36f6c129009072f78b5?action=collection%2Fimport)
+Explore the Key Management API:[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/a36f6c129009072f78b5)
 
 ## Key Management operations
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** The header link, Community > Developer Days, is now out-of-date; removing as per Chelsea. (Also made small syntax update to Key Mgmt API Postman reference.)
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* n/a
