### PR TITLE
OKTA-538908 Remove groups scope from the optional scopes available for OIN OIDC integration

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/oin-oidc-protocols/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oin-oidc-protocols/main/index.md
@@ -112,11 +112,12 @@ Other optional scopes available (these are returned from the `/userinfo` endpoin
 
 * `address`: Requests access to the `address` claim
 * `phone`: Requests access to the `phone_number` and `phone_number_verified` claims
-* `groups`: Requests access to the `groups` claim. This is a custom scope for Okta
 
-> **Note**: `offline_access` scope isn't available since refresh tokens aren't supported for apps published in OIN.
+> **Note**: The following scopes aren't supported for integrations published in the OIN:
+> * `offline_access` scope (since refresh tokens aren't supported)
+> * Custom scopes (such as the `groups` scope)
 
-You can only request the [OIDC scopes](/docs/reference/api/oidc/#scopes). Custom scopes, like the `groups` scope, can't be configured.
+You can only request the [OIDC scopes](/docs/reference/api/oidc/#scopes). However, custom scopes can't be configured.
 
 Okta utilizes access policies to decide whether the scopes can be granted. If any of the requested scopes are rejected by the access policies, the request is rejected.
 


### PR DESCRIPTION
## Description:
- **What's changed?** Remove `groups` scope from the optional scopes available for the OIN OIDC protocols guide. Another unsupported scopes note is added in PR3827 (this is a new OIN submission requirements doc with an OIN limitations section, which will list the non-supported scopes).
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-538908](https://oktainc.atlassian.net/browse/OKTA-538908)
