### PR TITLE
OKTA-566108 Add rate limit note for resend request in Activate factor section

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/factors/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/factors/index.md
@@ -1979,6 +1979,11 @@ The rate limit for a user to activate one of their OTP-based factors (such as SM
 }
 ```
 
+> **Note:** If the user exceeds their OTP-based factor rate limit, then an OTP [resend](#resend-sms-as-part-of-enrollment) request isn't allowed for the same factor. This applies to the following resend endpoints:<br>
+> * `/api/v1/users/${userId}}/factors/${factorId}/resend`
+> * `/api/v1/users/me/factors/${factorId}/resend`
+> * `/api/v1/authn/factors/${factorId}/lifecycle/resend`
+
 #### Activate TOTP Factor
 
 Activates a `token:software:totp` Factor by verifying the OTP

--- a/packages/@okta/vuepress-site/docs/reference/api/factors/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/factors/index.md
@@ -1967,7 +1967,7 @@ The `sms` and `token:software:totp` [Factor types](#factor-type) require activat
 
 ###### Rate limit
 
-The rate limit for a user to activate one of their OTP-based factors (such as SMS, CALL, EMAIL, Google OTP, or Okta Verify TOTP) is five attempts within five minutes. The following example error message is returned if the user exceeds their OTP-based factor rate limit:
+The rate limit for a user to activate one of their OTP-based factors (such as SMS, call, email, Google OTP, or Okta Verify TOTP) is five attempts within five minutes. The following example error message is returned if the user exceeds their OTP-based factor rate limit:
 
 ```json
 {
@@ -1979,10 +1979,7 @@ The rate limit for a user to activate one of their OTP-based factors (such as SM
 }
 ```
 
-> **Note:** If the user exceeds their OTP-based factor rate limit, then an OTP [resend](#resend-sms-as-part-of-enrollment) request isn't allowed for the same factor. This applies to the following resend endpoints:<br>
-> * `/api/v1/users/${userId}}/factors/${factorId}/resend`
-> * `/api/v1/users/me/factors/${factorId}/resend`
-> * `/api/v1/authn/factors/${factorId}/lifecycle/resend`
+> **Note:** If the user exceeds their SMS, call, or email factor activate rate limit, then an OTP [resend](#resend-sms-as-part-of-enrollment) request (`/api/v1/users/${userId}}/factors/${factorId}/resend`) isn't allowed for the same factor.
 
 #### Activate TOTP Factor
 


### PR DESCRIPTION
## Description:
- **What's changed?** Add Note in Factors API for resend after OTP-based activate factor rate limit exceeded
- **Is this PR related to a Monolith release?** Yes 2023.01.1(vuln-after all prod cells)

![Screen Shot 2023-01-12 at 11 43 29 AM](https://user-images.githubusercontent.com/80703015/212129190-57097dbd-2d4b-4653-a8c7-f1f6efd0cbba.png)

### Resolves:

* [OKTA-566108](https://oktainc.atlassian.net/browse/OKTA-566108) for corresponding RN item: OKTA-550739
