### PR TITLE
OKTA-567461 Cred Platform - Review Trusted Origins API filter parameter

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/trusted-origins/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/trusted-origins/index.md
@@ -137,7 +137,7 @@ curl -X POST \
   "scopes": [
     {
       "type": "IFRAME_EMBED",
-      "allowedOktaApps": [“OKTA_ENDUSER”]
+      "allowedOktaApps": ["OKTA_ENDUSER"]
     }
   ]
 }' "https://${yourOktaDomain}/api/v1/trustedOrigins"


### PR DESCRIPTION
fix quotes

also, the filter example doesn't seem to work:
https://developer.okta.com/docs/reference/api/trusted-origins/#list-trusted-origins-with-a-filter

you can't filter by id, but you can filter by name. are there other fields that can be used in the filter?