### PR TITLE
ASA -  PolicySync Cleanup

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
@@ -1742,7 +1742,7 @@ This endpoint returns a list of objects with the following fields and a `200` co
 | `hostname`   | string | The hostname of the Server |
 | `id`   | string | The UUID corresponding to the Server |
 | `instance_details`   | object | Information that the cloud provider provides about the Server, if one exists |
-| `labels`   | object | (Optional) The labels for this server. This parameter is only available with the PolicySync feature, which is currently in EA. |
+| `labels`   | object | (Optional) The labels for this server. This parameter is used by the PolicySync feature. |
 | `last_seen`   | string | The last time that the Server made a request to the ASA platform |
 | `managed`   | boolean | True if the Server is managed by 'sftd'. Unmanaged Servers are used in configurations where users may have a bastion, for example, that they don't want/can't connect to through 'sftd'. With an Unmanaged Server record to represent this box, ASA knows that it exists and to use it as a bastion hop. |
 | `os`   | string | The particular OS of the Server, such as CentOS 6 or Debian 9.13 |
@@ -1862,7 +1862,7 @@ This endpoint returns an object with the following fields and a `200` code on a 
 | `hostname`   | string | The hostname of the Server |
 | `id`   | string | The UUID corresponding to the Server |
 | `instance_details`   | object | Information that the cloud provider provides about the Server, if one exists |
-| `labels`   | object | (Optional) The labels for this server. This parameter is only available with the PolicySync feature, which is currently in EA |
+| `labels`   | object | (Optional) The labels for this server. This parameter is used by the PolicySync feature. |
 | `last_seen`   | string | The last time that the Server made a request to the ASA platform |
 | `managed`   | boolean | True if the Server is managed by 'sftd'. Unmanaged Servers are used in configurations where users may have a bastion, for example, that they don't want/can't connect to through 'sftd'. With an Unmanaged Server record to represent this box, ASA knows that it exists and to use it as a bastion hop. |
 | `os`   | string | The particular OS of the Server, such as CentOS 6 or Debian 9.13 |
@@ -1956,7 +1956,7 @@ This endpoint returns an object with the following fields and a `200` code on a 
 | `hostname`   | string | The hostname of the Server |
 | `id`   | string | The UUID corresponding to the Server |
 | `instance_details`   | object | Information that the cloud provider provides about the Server, if one exists |
-| `labels`   | object | (Optional) The labels for this server. Only available with the PolicySync feature, which is currently in EA |
+| `labels`   | object | (Optional) The labels for this server. This parameter is used by the PolicySync feature. |
 | `last_seen`   | string | The last time that the Server made a request to the ASA platform |
 | `managed`   | boolean | True if the Server is managed by 'sftd'. Unmanaged Servers are used in configurations where users may have a bastion, for example, that they don't want/can't connect to through 'sftd'. With an Unmanaged Server record to represent this box, ASA knows that it exists and to use it as a bastion hop. |
 | `os`   | string | The particular OS of the Server, such as CentOS 6 or Debian 9.13 |
@@ -2053,7 +2053,7 @@ HTTP 204 No Content
 ### Update a Server on a Project
 
 <ApiOperation method="PUT" url="https://app.scaleft.com/v1/teams/${team_name}/projects/${project_name}/servers/${server_id}" />
-Updates a Server on a Project. This endpoint is only available with the PolicySync feature, which is currently in EA.
+Updates a Server on a Project. This endpoint is intended for use with the PolicySync feature.
 
 This endpoint requires one of the following roles: `access_admin`, or `server_admin`.
 

--- a/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/asa/projects/index.md
@@ -1742,7 +1742,7 @@ This endpoint returns a list of objects with the following fields and a `200` co
 | `hostname`   | string | The hostname of the Server |
 | `id`   | string | The UUID corresponding to the Server |
 | `instance_details`   | object | Information that the cloud provider provides about the Server, if one exists |
-| `labels`   | object | (Optional) The labels for this server. This parameter is used by the PolicySync feature. |
+| `labels`   | object | (Optional) The labels for this server. This parameter is used by the PolicySync feature, see [PolicySync: Attribute-Based Access Control](https://help.okta.com/okta_help.htm?type=asa&id=ext-asa-policysync).|
 | `last_seen`   | string | The last time that the Server made a request to the ASA platform |
 | `managed`   | boolean | True if the Server is managed by 'sftd'. Unmanaged Servers are used in configurations where users may have a bastion, for example, that they don't want/can't connect to through 'sftd'. With an Unmanaged Server record to represent this box, ASA knows that it exists and to use it as a bastion hop. |
 | `os`   | string | The particular OS of the Server, such as CentOS 6 or Debian 9.13 |
@@ -1862,7 +1862,7 @@ This endpoint returns an object with the following fields and a `200` code on a 
 | `hostname`   | string | The hostname of the Server |
 | `id`   | string | The UUID corresponding to the Server |
 | `instance_details`   | object | Information that the cloud provider provides about the Server, if one exists |
-| `labels`   | object | (Optional) The labels for this server. This parameter is used by the PolicySync feature. |
+| `labels`   | object | (Optional) The labels for this server. This parameter is used by the PolicySync feature, see [PolicySync: Attribute-Based Access Control](https://help.okta.com/okta_help.htm?type=asa&id=ext-asa-policysync). |
 | `last_seen`   | string | The last time that the Server made a request to the ASA platform |
 | `managed`   | boolean | True if the Server is managed by 'sftd'. Unmanaged Servers are used in configurations where users may have a bastion, for example, that they don't want/can't connect to through 'sftd'. With an Unmanaged Server record to represent this box, ASA knows that it exists and to use it as a bastion hop. |
 | `os`   | string | The particular OS of the Server, such as CentOS 6 or Debian 9.13 |
@@ -1956,7 +1956,7 @@ This endpoint returns an object with the following fields and a `200` code on a 
 | `hostname`   | string | The hostname of the Server |
 | `id`   | string | The UUID corresponding to the Server |
 | `instance_details`   | object | Information that the cloud provider provides about the Server, if one exists |
-| `labels`   | object | (Optional) The labels for this server. This parameter is used by the PolicySync feature. |
+| `labels`   | object | (Optional) The labels for this server. This parameter is used by the PolicySync feature, see [PolicySync: Attribute-Based Access Control](https://help.okta.com/okta_help.htm?type=asa&id=ext-asa-policysync).|
 | `last_seen`   | string | The last time that the Server made a request to the ASA platform |
 | `managed`   | boolean | True if the Server is managed by 'sftd'. Unmanaged Servers are used in configurations where users may have a bastion, for example, that they don't want/can't connect to through 'sftd'. With an Unmanaged Server record to represent this box, ASA knows that it exists and to use it as a bastion hop. |
 | `os`   | string | The particular OS of the Server, such as CentOS 6 or Debian 9.13 |
@@ -2053,7 +2053,7 @@ HTTP 204 No Content
 ### Update a Server on a Project
 
 <ApiOperation method="PUT" url="https://app.scaleft.com/v1/teams/${team_name}/projects/${project_name}/servers/${server_id}" />
-Updates a Server on a Project. This endpoint is intended for use with the PolicySync feature.
+Updates a Server on a Project. This endpoint is intended for use with the PolicySync feature, see [PolicySync: Attribute-Based Access Control](https://help.okta.com/okta_help.htm?type=asa&id=ext-asa-policysync).
 
 This endpoint requires one of the following roles: `access_admin`, or `server_admin`.
 

--- a/packages/@okta/vuepress-site/docs/reference/api/asa/teams/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/asa/teams/index.md
@@ -77,7 +77,7 @@ This endpoint returns a list of objects with the following fields and a `200` co
 | `hostname`   | string | The hostname of the Server |
 | `id`   | string | The UUID corresponding to the Server |
 | `instance_details`   | object | Information that the cloud provider provides about the Server, if one exists |
-| `labels`   | object | (Optional) The labels for this server. This parameter is only available with the PolicySync feature, which is currently in EA. |
+| `labels`   | object | (Optional) The labels for this server. This parameter is used by the PolicySync feature. |
 | `last_seen`   | string | The last time that the Server made a request to the ASA platform |
 | `managed`   | boolean | True if the Server is managed by 'sftd'. Unmanaged Servers are used in configurations where users may have a bastion, for example, that they don't want/can't connect to through 'sftd'. With an Unmanaged Server record to represent this box, ASA knows that it exists and to use it as a bastion hop. |
 | `os`   | string | The particular OS of the Server, such as CentOS 6 or Debian 9.13 |
@@ -159,7 +159,7 @@ https://app.scaleft.com/v1/teams/${team_name}/servers
 ### Update a Server
 
 <ApiOperation method="PUT" url="https://app.scaleft.com/v1/teams/${team_name}/servers/${server_id}" />
-Updates a Server. This endpoint is only available with the PolicySync feature, which is currently in EA.
+Updates a Server. This endpoint is intended for use with the PolicySync feature.
 
 This endpoint requires one of the following roles: `access_admin`, or `server_admin`.
 


### PR DESCRIPTION
## Description:
- **What's changed?** Updated PolicySync references to reflect GA status.
- **Is this PR related to a Monolith release?** 2023.01.0

Alias URL won't be live until next HOC publish cycle. Maybe Jan 16 or 17?

### Resolves:

* [OKTA-566414](https://oktainc.atlassian.net/browse/OKTA-566414)
