### PR TITLE
OKTA-570767 Deprecate Risk Providers API page and link to Redocly

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/main/index.md
@@ -341,6 +341,6 @@ This procedure reviews the Admin Console's System Log to identify the risk event
 ## See also
 
 - [Implement OAuth for Okta with a Service App](/docs/guides/implement-oauth-for-okta-serviceapp/)
-- [Risk Providers API](/docs/reference/api/risk-providers/)
+- [Risk Providers API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/RiskProvider/)
 - [Risk Events API](/docs/reference/api/risk-events/)
 - [Risk Scoring and Risk Based Authentication](https://help.okta.com/okta_help.htm?id=csh-risk-scoring)

--- a/packages/@okta/vuepress-site/docs/reference/api/risk-providers/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/risk-providers/index.md
@@ -4,6 +4,11 @@ title: Risk Providers
 
 # Risk Providers API
 
+The Risk Providers API reference is now available at the new [Risk Providers&mdash;Okta API reference portal](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/RiskProvider/#tag/RiskProvider).
+
+Explore the [Okta Public API Collections](https://www.postman.com/okta-eng/workspace/okta-public-api-collections/overview) workspace to get started with the Risk Providers API Postman collection.
+
+<!--
 <ApiLifecycle access="ea" />
 
 The Okta Risk Providers API provides the ability to manage the Risk Providers within Okta.
@@ -331,3 +336,4 @@ The Risk Provider object has the following properties:
     "clientId": "A-Valid-Client-ID"
   }
 ```
+-->

--- a/packages/@okta/vuepress-site/docs/reference/api/risk-providers/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/risk-providers/index.md
@@ -4,7 +4,7 @@ title: Risk Providers
 
 # Risk Providers API
 
-The Risk Providers API reference is now available at the new [Risk Providers&mdash;Okta API reference portal](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/RiskProvider/#tag/RiskProvider).
+The Risk Providers API reference is now available at the new [Okta API reference portal](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/RiskProvider/#tag/RiskProvider).
 
 Explore the [Okta Public API Collections](https://www.postman.com/okta-eng/workspace/okta-public-api-collections/overview) workspace to get started with the Risk Providers API Postman collection.
 


### PR DESCRIPTION
## Description:
- **What's changed?** Deprecate Risk Providers API page and link to new Okta API reference portal (Redocly).
- **Is this PR related to a Monolith release?** No

### Preview:
https://63d2d52034b93b08b9cc23fa--reverent-murdock-829d24.netlify.app/docs/reference/api/risk-providers/
![Screen Shot 2023-02-22 at 6 18 42 PM](https://user-images.githubusercontent.com/80703015/220785473-358d967e-d1f6-462a-9ca5-60797fb2c0bd.png)

### Resolves:

* [OKTA-570767](https://oktainc.atlassian.net/browse/OKTA-570767)
