### PR TITLE
Team Scotty: Correct warning threshold percentages on RL Dashboard Guide

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/rl-dashboard/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/rl-dashboard/index.md
@@ -37,7 +37,7 @@ The following describes typical uses of the functions in the Rate limits report:
 
 * If the API had rate limit violations in the past, you can proactively monitor that API by checking its rate limits, any increase in traffic, and any abnormal activity. If you notice an increase in rate limit usage, you can start investigating the issue.
 * If you're going to have an event and the API is going to be affected, you can check the current traffic on the API before the event. Then you can plan for traffic on the API during the event and determine the rate limit capacity for it.
-* If you want to control the warning threshold on traffic consumption for an API, you can configure the rate limits settings and customize when your org should trigger a warning event. For instance, if you have CIAM and you've configured a [custom threshold](#warning-notification), a warning alert appears if you reach 90% of the rate limit. If you have Workforce, a warning alert appears if you reach 60% of the rate limit.
+* If you want to control the warning threshold on traffic consumption for an API, you can configure the rate limits settings and customize when your org should trigger a warning event. For instance, if you have CIAM and you've configured a [custom threshold](#warning-notification), a warning alert appears if you reach 60% of the rate limit. If you have Workforce, a warning alert appears if you reach 90% of the rate limit.
 
 ### Open the rate limits report
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Corrected percentages on warning threshold (from 60 to 90 for workforce; 90 to 60 for CIAM)
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* n/a
