### PR TITLE
OKTA-573094: Removing unsupported regions

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/log-streaming/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/log-streaming/index.md
@@ -667,9 +667,6 @@ The AWS EventBridge Settings object specifies the configuration for the `aws_eve
 | us-east-1 | US East (N. Virginia) |
 | us-west-1 | US West (N. California) |
 | us-west-2 | US West (Oregon) |
-| af-south-1 | Africa (Cape Town) |
-| ap-east-1 | Asia Pacific (Hong Kong) |
-| ap-southeast-3 | Asia Pacific (Jakarta) |
 | ap-south-1 | Asia Pacific (Mumbai) |
 | ap-northeast-3 | Asia Pacific (Osaka) |
 | ap-northeast-2 | Asia Pacific (Seoul) |
@@ -680,11 +677,8 @@ The AWS EventBridge Settings object specifies the configuration for the `aws_eve
 | eu-central-1 | Europe (Frankfurt) |
 | eu-west-1 | Europe (Ireland) |
 | eu-west-2 | Europe (London) |
-| eu-south-1 | Europe (Milan) |
 | eu-west-3 | Europe (Paris) |
 | eu-north-1 | Europe (Stockholm) |
-| me-south-1 | Middle East (Bahrain) |
-| me-central-1 | Middle East (UAE) |
 | sa-east-1 | South America (São Paulo) |
 
 

--- a/packages/@okta/vuepress-site/docs/reference/api/schemas/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/schemas/index.md
@@ -1580,9 +1580,6 @@ For brevity, the following response doesn't include all available properties.
             { "title": "US East (N. Virginia)", "const": "us-east-1" },
             { "title": "US West (N. California)", "const": "us-west-1" },
             { "title": "US West (Oregon)", "const": "us-west-2" },
-            { "title": "Africa (Cape Town)", "const": "af-south-1" },
-            { "title": "Asia Pacific (Hong Kong)", "const": "ap-east-1" },
-            { "title": "Asia Pacific (Jakarta) ", "const": "ap-southeast-3" },
             { "title": "Asia Pacific (Mumbai)", "const": "ap-south-1" },
             { "title": "Asia Pacific (Osaka)", "const": "ap-northeast-3" },
             { "title": "Asia Pacific (Seoul)", "const": "ap-northeast-2" },
@@ -1593,11 +1590,8 @@ For brevity, the following response doesn't include all available properties.
             { "title": "Europe (Frankfurt)", "const": "eu-central-1" },
             { "title": "Europe (Ireland)", "const": "eu-west-1" },
             { "title": "Europe (London)", "const": "eu-west-2" },
-            { "title": "Europe (Milan)", "const": "eu-south-1" },
             { "title": "Europe (Paris)", "const": "eu-west-3" },
             { "title": "Europe (Stockholm)", "const": "eu-north-1" },
-            { "title": "Middle East (Bahrain)", "const": "me-south-1" },
-            { "title": "Middle East (UAE)", "const": "me-central-1" },
             { "title": "South America (São Paulo)", "const": "sa-east-1" }
           ]
         }
@@ -1705,9 +1699,6 @@ For brevity, the following response doesn't include all available properties.
               { "title": "US East (N. Virginia)", "const": "us-east-1" },
               { "title": "US West (N. California)", "const": "us-west-1" },
               { "title": "US West (Oregon)", "const": "us-west-2" },
-              { "title": "Africa (Cape Town)", "const": "af-south-1" },
-              { "title": "Asia Pacific (Hong Kong)", "const": "ap-east-1" },
-              { "title": "Asia Pacific (Jakarta) ", "const": "ap-southeast-3" },
               { "title": "Asia Pacific (Mumbai)", "const": "ap-south-1" },
               { "title": "Asia Pacific (Osaka)", "const": "ap-northeast-3" },
               { "title": "Asia Pacific (Seoul)", "const": "ap-northeast-2" },
@@ -1718,11 +1709,8 @@ For brevity, the following response doesn't include all available properties.
               { "title": "Europe (Frankfurt)", "const": "eu-central-1" },
               { "title": "Europe (Ireland)", "const": "eu-west-1" },
               { "title": "Europe (London)", "const": "eu-west-2" },
-              { "title": "Europe (Milan)", "const": "eu-south-1" },
               { "title": "Europe (Paris)", "const": "eu-west-3" },
               { "title": "Europe (Stockholm)", "const": "eu-north-1" },
-              { "title": "Middle East (Bahrain)", "const": "me-south-1" },
-              { "title": "Middle East (UAE)", "const": "me-central-1" },
               { "title": "South America (São Paulo)", "const": "sa-east-1" }
             ]
           }


### PR DESCRIPTION
Resolves: OKTA-573094

<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Updating AWS regions list for Log Streaming, removing regions that are currently not supported by Okta account
- **Is this PR related to a Monolith release?** 2023.02.0 Feb Monthly

### Resolves:

* [OKTA-573094](https://oktainc.atlassian.net/browse/OKTA-573094)
