### PR TITLE
OKTA-576345 Add ialValue and aalValue in IdPs API

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
@@ -4858,9 +4858,11 @@ Okta supports the following enterprise and social Identity Provider types:
 
 The properties in the Identity Provider Properties object vary depending on the IdP type.
 
-| Property | Description        | DataType     | Nullable | Readonly |
-| -------- | ------------------ | ------------ | -------- | -------- |
-| additionalAmr <ApiLifecycle access="ea" /> | The additional Assurance Methods References (AMR) values for the `x509` IdP type. Supported values: `sc` (smart card), `hwk` (hardware-secured key), `pin` (personal identification number), and `mfa` (multifactor authentication)  | Array of strings | TRUE    | FALSE    |
+| Property | Description        | DataType     | Applies to IdP type |
+| -------- | ------------------ | ------------ | -------------------- |
+| additionalAmr <ApiLifecycle access="ea" /> | The additional Assurance Methods References (AMR) values for the `X509` IdP type. Supported values: `sc` (smart card), `hwk` (hardware-secured key), `pin` (personal identification number), and `mfa` (multifactor authentication)  | Array of strings | `X509`    |
+| ialValue | The [type of identity verification](https://developers.login.gov/oidc/#ial-values) (IAL) value for the `LOGINGOV` and `LOGINGOV_SANDBOX` IdP types. See [Add a Login.gov IdP](/docs/guides/add-logingov-idp/main/#create-an-identity-provider-in-okta)  | String | `LOGINGOV`, `LOGINGOV_SANDBOX`    |
+| aalValue | The [authenication assurance level](https://developers.login.gov/oidc/#aal-values) (AAL) value for the `LOGINGOV` and `LOGINGOV_SANDBOX` IdP types.  | String | `LOGINGOV`, `LOGINGOV_SANDBOX`    |
 
 > **Note:** The `additionalAmr` property supports the [Early Access](/docs/reference/releases-at-okta/#early-access-ea) (Self-Service) Smart Card authenticator feature. Enable the feature for your org from the **Settings** > **Features** page in the Admin Console.
 


### PR DESCRIPTION
## Description:
- **What's changed?** Add properties.ialValue and properties.aalValue in IdPs API for Login.gov IdP.
- **Is this PR related to a Monolith release?** yes, 2023.02.0 (this PR can be merged anytime after 2023.02.0 monthly)

### Resolves:

* [OKTA-576345](https://oktainc.atlassian.net/browse/OKTA-576345)
