### PR TITLE
OKTA-580362 Deprecate Risk Events API markdown page and link to Redocly

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/third-party-risk-integration/main/index.md
@@ -342,5 +342,5 @@ This procedure reviews the Admin Console's System Log to identify the risk event
 
 - [Implement OAuth for Okta with a Service App](/docs/guides/implement-oauth-for-okta-serviceapp/)
 - [Risk Providers API](/docs/reference/api/risk-providers/)
-- [Risk Events API](/docs/reference/api/risk-events/)
+- [Risk Events API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/RiskEvent/)
 - [Risk Scoring and Risk Based Authentication](https://help.okta.com/okta_help.htm?id=csh-risk-scoring)

--- a/packages/@okta/vuepress-site/docs/reference/api/risk-events/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/risk-events/index.md
@@ -4,6 +4,11 @@ title: Risk Events
 
 # Risk Events API
 
+The Risk Events API reference is now available at the new [Okta API reference portal](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/RiskEvent/#tag/RiskEvent).
+
+Explore the [Okta Public API Collections](https://www.postman.com/okta-eng/workspace/okta-public-api-collections/overview) workspace to get started with the Risk Events API Postman collection.
+
+<!--
 <ApiLifecycle access="ea" />
 
 The Okta Risk Events API provides the ability for third-party Risk Providers to send Risk Events to Okta.
@@ -138,3 +143,5 @@ The Risk Subject object has the following properties:
     "message": "none"
 }
 ```
+
+-->

--- a/packages/@okta/vuepress-site/docs/release-notes/2021/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2021/index.md
@@ -362,7 +362,7 @@ The Okta [Brands API](/docs/reference/api/brands/) allows customization of the l
 
 #### Risk Providers and Risk Events APIs are EA
 
-The Okta [Risk Providers API](/docs/reference/api/risk-providers/) enables security teams to integrate IP-based risk signals to analyze and orchestrate risk-based access using the authentication layer. Practitioners can step up, reduce friction, or block the user based on risk signals across the customer's security stack. Apart from improving security efficacy, this feature also enhances the user experience by reducing friction for good users based on positive user signals. The Okta [Risk Events API](/docs/reference/api/risk-events/) provides the ability for third-party Risk Providers to send Risk Events to Okta. See [Third-party risk provider integration](/docs/guides/third-party-risk-integration/). <!-- OKTA-415574 -->
+The Okta [Risk Providers API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/RiskProvider/) enables security teams to integrate IP-based risk signals to analyze and orchestrate risk-based access using the authentication layer. Practitioners can step up, reduce friction, or block the user based on risk signals across the customer's security stack. Apart from improving security efficacy, this feature also enhances the user experience by reducing friction for good users based on positive user signals. The Okta [Risk Events API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/RiskEvent/) provides the ability for third-party Risk Providers to send Risk Events to Okta. See [Third-party risk provider integration](/docs/guides/third-party-risk-integration/). <!-- OKTA-415574 -->
 
 #### SAML parameter SessionNotOnOrAfter is GA in Preview
 


### PR DESCRIPTION
## Description:
- **What's changed?** Comment out Risk Events API page and link to Redocly. Replace internal links to Redocly
- **Is this PR related to a Monolith release?** No

### Preview:
https://63f7d977c0063717884ea9a4--reverent-murdock-829d24.netlify.app/docs/reference/api/risk-events/
![image](https://user-images.githubusercontent.com/80703015/221248775-de370081-7aff-4f9f-a858-38aaf38bbd10.png)

### Resolves:

* [OKTA-580362](https://oktainc.atlassian.net/browse/OKTA-580362)
