### PR TITLE
Link to correct android SDK for ciba guide

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/configure-ciba/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/configure-ciba/main/index.md
@@ -318,5 +318,5 @@ The next step in the CIBA authentication flow is to send a request for tokens to
 ## See also
 
 * [Okta Devices Swift SDK](https://github.com/okta/okta-devices-swift) for iOS
-* [Okta Mobile Kotlin SDK](https://github.com/okta/okta-mobile-kotlin) for Android
+* [Okta Devices Kotlin SDK](https://github.com/okta/okta-devices-kotlin) for Android
 * [Custom Authenticator integration guide](/docs/guides/authenticators-custom-authenticator/ios/main/)


### PR DESCRIPTION
Guide is linking to the wrong Android SDK.

<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
Guide is linking to the wrong Android SDK.

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
