### PR TITLE
updates for Angular quickstart

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/addconfigpkg.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/addconfigpkg.md
@@ -2,5 +2,5 @@ Use Okta's Angular SDK and Okta's JavaScript SDK in your Angular application. Ad
 
 ```shell
 cd okta-angular-quickstart
-npm install @okta/okta-angular@6.0 @okta/okta-auth-js@7.0
+npm install @okta/okta-angular@6.1 @okta/okta-auth-js@7.2
 ```

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/configmid.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/configmid.md
@@ -21,4 +21,8 @@ Make the following changes to `src/app/app.module.ts`:
    });
    ```
 
-4. Add `{ provide: OKTA_CONFIG, useValue: { oktaAuth } }` to the `providers` array to add the Okta services to the dependency injection system. The Okta Angular SDK provides the `OKTA_CONFIG` injection token.
+4. Add the Okta configuration to the `OktaAuthModule` using the `forRoot` static method:
+
+   ```ts
+   OktaAuthModule.forRoot({ oktaAuth })
+   ```

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/createproject.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/createproject.md
@@ -4,11 +4,11 @@ You need recent versions of [Node](https://nodejs.org/en/) and  [npm](https://ww
 Create an Angular application named **okta-angular-quickstart** with routing in your current directory using the following command. Choose **CSS** when it asks you what stylesheet format you want to use.
 
 ```shell
-npx @angular/cli@14 new okta-angular-quickstart --routing
+npx @angular/cli@15 new okta-angular-quickstart --routing
 ```
 
 This creates an Angular application using version 14 regardless of the version of the Angular CLI installed on your system.
 
-> **Note**: This guide uses Angular CLI v14, okta-angular v6.0.0, and okta-auth-js v7.0.0.
+> **Note**: This guide uses Angular CLI v15, okta-angular v6.1.0, and okta-auth-js v7.2.0.
 
 > **Note**: You can also install the Okta CLI and run `okta start angular` to download and configure an Angular app with Okta integrated. This quickstart uses the basic Angular CLI output instead, as it's easier to understand the Okta-specific additions if you work through them yourself.

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/loginredirect.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/loginredirect.md
@@ -37,9 +37,7 @@ The `OktaAuth` service has methods for sign-in and sign-outactions.
      }
 
      public async signIn() : Promise<void> {
-       await this._oktaAuth.signInWithRedirect().then(
-         _ => this._router.navigate(['/profile'])
-       );
+       await this._oktaAuth.signInWithRedirect();
      }
 
      public async signOut(): Promise<void> {

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/reqautheverything.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/reqautheverything.md
@@ -1,6 +1,6 @@
 The Okta Angular SDK has a guard to check for the authenticated state that you can add to protected routes. It's common in Angular to use feature modules and protect the route to the feature so that all child routes are also guarded.
 
-In `app-routing.module.ts`, add the `OktaAuthGuard` to protect the route accessing a lazy loaded feature module using the `canLoad` property.
+In `app-routing.module.ts`, add the `OktaAuthGuard` to protect the route accessing a lazy loaded feature module using the `canActivate` property.
 
 1. Update the Okta import statement to:
 
@@ -14,7 +14,7 @@ In `app-routing.module.ts`, add the `OktaAuthGuard` to protect the route accessi
    {
      path: 'protected',
      loadChildren: () => import('./protected/protected.module').then(m => m.ProtectedModule),
-     canLoad: [OktaAuthGuard]
+     canActivate: [OktaAuthGuard]
    },
    ```
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/specificlinks.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/specificlinks.md
@@ -4,7 +4,7 @@ See [Get started with Angular](https://angular.io/start) to learn about the fram
 
 Okta Developer Blog:
 
+* [Streamline Your Okta Configuration in Angular Apps](https://developer.okta.com/blog/2023/03/07/angular-forroot)
+* [Three Ways to Configure Modules in Your Angular App](https://developer.okta.com/blog/2022/02/24/angular-async-config)
 * [Build a Beautiful App + Login with Angular Material](https://developer.okta.com/blog/2020/01/21/angular-material-login)
-* [How to Customize Your Angular Build with Webpack](https://developer.okta.com/blog/2019/12/09/angular-webpack)
 * [Use the Okta CLI to Quickly Build Secure Angular Apps](https://developer.okta.com/blog/2020/12/03/angular-okta)
-* [Loading Components Dynamically in an Angular App](https://developer.okta.com/blog/2021/12/08/angular-dynamic-components)


### PR DESCRIPTION
## Description:
- **What's changed?** Updating to use Angular v15 and `forRoot` pattern to configure `OktaAuthModule`, which is the preferred way for new apps to get started. The Angular quickstart link has a PR [https://github.com/okta-samples/okta-angular-quickstart/pull/4](https://github.com/okta-samples/okta-angular-quickstart/pull/4)
- **Is this PR related to a Monolith release?** No
