### PR TITLE
Remove simulated mobile phone Target.ID Limitation for OIE

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/ie-limitations/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/ie-limitations/main/index.md
@@ -44,36 +44,6 @@ The following Event Types are available only in Identity Engine and can't be use
 
 ***
 
-### Target.ID value simulated for mobile phone event types
-
-**What Changed:** `Target.ID` represents a simulated value for the following event types:
-
-* `system.voice.send_phone_verification_call`
-* `system.sms.send_phone_verification_message`
-
-Specifically, when `Target.Type` equals `MobilePhone` for these events, `Target.ID` has no intrinsic value other than being a placeholder that allows backward compatibility with Classic Engine. In Classic Engine, `Target.ID` is unique per phone number, stored in Okta's backend systems, and can be used to link all events for a given phone number. The following example from the System Log API shows these fields:
-
-```json
-  "target": [
-    {
-      "id": "qFGtyCw3hwhHh55555555z",
-      "type": "MobilePhone",
-      "alternateId": "+15555555555",
-      "displayName": "+15555555555",
-      "detailEntry": null
-    }
-  ]
-```
-
-If you use the `Target.Id` to link and reconcile events in Classic, use the phone number in Identity Engine. The phone number is found in `Target.AlternateId`.
-
-**Further Information:**
-
-* [System Log](/docs/reference/api/system-log/)
-* [Event Types](/docs/reference/api/event-types/)
-
-***
-
 ### Help Support number
 
 **What Changed:** In Identity Engine, if the user is unable to use an Authenticator, the Help Support number is no longer provided. The only support available is the Authenticator list page that provides alternative ways for the user to authenticate.


### PR DESCRIPTION
## Description:
- **What's changed?** Removes an OIE limitation that was eliminated last year. See [here](https://okta.slack.com/archives/C04MY18LZLP/p1678980539780729).

Specifically, the _Target.ID value simulated for mobile phone event types_ item was changed to match the functionality of Classic.
- **Is this PR related to a Monolith release?** No

[Netlify Preview](https://6413496f3c69df202f8d6511--reverent-murdock-829d24.netlify.app/docs/guides/ie-limitations/main/)

### Resolves:

* [OKTA-588896](https://oktainc.atlassian.net/browse/OKTA-588896)
