### PR TITLE
Fix <Card> height issues

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_card.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_card.scss
@@ -18,6 +18,7 @@
 
   border: 1px solid #b7bcc0;
   border-radius: 4px;
+  height: 100%;
 }
 
 .cards-own .card a {

--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_card.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_card.scss
@@ -15,10 +15,11 @@
 
   align-self: start;
   max-width: 50ch;
-
+  
+  height: 100%;
+  
   border: 1px solid #b7bcc0;
   border-radius: 4px;
-  height: 100%;
 }
 
 .cards-own .card a {


### PR DESCRIPTION
## Description:
- **What's changed?** Cards on the DOC [Concepts](https://developer.okta.com/docs/concepts/) page have a weird spacing issue that causes boxes to appear at different sizes from each other.
This issue doesn't seem to impact cards on other topics within DOC.

- Topics that include the Cards element ([Search](https://github.com/search?q=repo%3Aokta%2Fokta-developer-docs%20%3Ccards%3E&type=code))
  - okta-developer-docs/packages/@okta/vuepress-site/code/index.md
  - okta-developer-docs/packages/@okta/vuepress-site/docs/concepts/index.md
  - okta-developer-docs/packages/@okta/vuepress-site/docs/guides/quickstart/main/index.md
  - okta-developer-docs/packages/@okta/vuepress-site/docs/guides/identity-providers/index.md
  - okta-developer-docs/packages/@okta/vuepress-site/docs/reference/index.md
  - okta-developer-docs/packages/@okta/vuepress-site/docs/guides/oin-sso-overview/index.md
  - okta-developer-docs/packages/@okta/vuepress-site/docs/guides/sign-in-overview/main/index.md
  - okta-developer-docs/packages/@okta/vuepress-site/docs/guides/oin-lifecycle-mgmt-overview/index.md

- **Is this PR related to a Monolith release?** No

[Preview](https://641377ee12f90c081da62a2c--reverent-murdock-829d24.netlify.app/docs/concepts/)

### Resolves:

* [OKTA-589036](https://oktainc.atlassian.net/browse/OKTA-589036)
