### PR TITLE
Make auth_time be a reserved claim both for access token and ID token

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/token-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/token-hook/index.md
@@ -133,7 +133,6 @@ Okta defines a number of reserved claims that can't be overridden. When you add 
 | app_id         | ID Token          |
 | app_type       | ID Token          |
 | at_hash        | ID Token          |
-| auth_time      | ID Token          |
 | client_id      | ID Token          |
 | client_ip      | ID Token          |
 | client_req_id  | ID Token          |
@@ -177,6 +176,7 @@ Okta defines a number of reserved claims that can't be overridden. When you add 
 | jti            | Access Token & ID Token |
 | token_type     | Access Token & ID Token |
 | ver            | Access Token & ID Token |
+| auth_time      | Access Token & ID Token |
 
 ### error
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. --> Make auth_time be a reserved claim both for access token and ID token
  
-- -- Before 
<img width="396" alt="Screen Shot 2023-03-18 at 9 38 45 PM" src="https://user-images.githubusercontent.com/90656320/226152338-7a922bbf-e145-4676-90ae-f7f18bad9ac7.png">

-- -- After
<img width="416" alt="Screen Shot 2023-03-18 at 9 38 28 PM" src="https://user-images.githubusercontent.com/90656320/226152344-0ad4fb41-c484-428d-891b-a099c6a6b1d8.png">


- **Is this PR related to a Monolith release?** <!-- If so, which one? -->  Monolith-2023.03.2

### Resolves:

* [OKTA-589502](https://oktainc.atlassian.net/browse/OKTA-589502)
