### PR TITLE
OKTA-591733 Add maintenance token usage section to custom authenticator guide

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/android/sdksteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/android/sdksteps.md
@@ -18,7 +18,7 @@ Add the Okta Devices SDK dependency to your `build.gradle` file:
 implementation("com.okta.devices:devices-push:$okta.sdk.version")
 ```
 
-`$okta.sdk.version` is the latest release version. See [Release status](https://github.com/okta/okta-devices-kotlin/releases) for the latest Okta Devices SDK version.
+The latest release version is `$okta.sdk.version`. See [Release status](https://github.com/okta/okta-devices-kotlin/releases) for the latest Okta Devices SDK version.
 
 ### Initialize the client
 
@@ -38,7 +38,7 @@ val authenticator: PushAuthenticator = PushAuthenticatorBuilder.create(
 
 Before enrolling the device, ensure that you have the following:
 
-* An OIDC web authentication client. See [Create an OAuth 2.0 app integration](#create-an-oidc-web-authentication-client).
+* An OIDC Web Authentication client. See [Create an OAuth 2.0 app integration](#create-an-oidc-web-authentication-client).
 * A custom authenticator. See [Add a custom authenticator](#add-a-custom-authenticator).
 * A registration token from Firebase. See [Set up notification services](#set-up-notification-services).
 
@@ -209,18 +209,18 @@ Other operations are low risk and may not require interactive authentication. Fo
 * Enable and disable CIBA capability for the push authenticator enrollment
 * Update device tokens for push authenticator enrollment
 
-To successfully obtain the maintenance token, you must first configure your Okta OIDC application to support the JWT Bearer grant type.
+To successfully obtain the maintenance token, you must first configure your Okta OIDC application to support the JWT Bearer grant type:
 
-You can use the Apps API's [update application](/docs/reference/api/apps/#update-application) operation (`PUT /apps/${appId}`) to modify the `settings.oauthClient.grant_types` property array to include the JWT Bearer grant type, `urn:ietf:params:oauth:grant-type:jwt-bearer`.
+* You can use the Apps API's [update application](/docs/reference/api/apps/#update-application) operation (`PUT /apps/${appId}`) to modify the `settings.oauthClient.grant_types` property array to include the JWT Bearer grant type, `urn:ietf:params:oauth:grant-type:jwt-bearer`.
 
-Alternatively, when you add or update a custom authenticator with an existing OIDC application, the application automatically updates with the JWT Bearer grant type.
+    Explore the [Configure and Use JWT Bearer Grant](https://god.gw.postman.com/run-collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=collection%2Ffork&collection-url=entityId%3D26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd%26entityType%3Dcollection%26workspaceId%3Daf55a245-1ac6-42d1-8af4-11e21e791e4e) Postman Collection for API examples of
+    * How to get your OIDC app object properties
+    * How to update your OIDC app to include the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type
+    * How to obtain a token with your OIDC app client ID
 
-Explore the [Configure and Use JWT Bearer Grant](https://god.gw.postman.com/run-collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=collection%2Ffork&collection-url=entityId%3D26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd%26entityType%3Dcollection%26workspaceId%3Daf55a245-1ac6-42d1-8af4-11e21e791e4e) Postman Collection for API examples of
-* How to get your OIDC app object properties
-* How to update your OIDC app to include the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type
-* How to obtain a token with your OIDC app client ID
+    Fork this collection and add `url`, `apiKey`, `appId`, and `yourClientId` environment variables to run the example endpoints. The `PUT` method is a full property-replace operation, so you need to specify all required OIDC app properties, including any previous grant types. See [Create an API token](/docs/guides/create-an-api-token/main/) to obtain an `apiKey` from your org for testing purposes.
 
-Fork this collection and add `url`, `apiKey`, `appId`, and `yourClientId` environment variables to run the example endpoints. The `PUT` method is a full property-replace operation, so you need to specify all required OIDC app properties, including any previous grant types. See [Create an API token](/docs/guides/create-an-api-token/main/) to obtain an `apiKey` from your org for testing purposes.
+* Alternatively, when you use the Admin Console to add or update a custom authenticator with an existing OIDC application, then the application automatically updates with the JWT Bearer grant type. See [Add a custom authenticator](#add-a-custom-authenticator).
 
 ##### Usage example
 

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/android/sdksteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/android/sdksteps.md
@@ -213,14 +213,14 @@ To successfully obtain the maintenance token, you must first configure your Okta
 
 * You can use the Apps API's [update application](/docs/reference/api/apps/#update-application) operation (`PUT /apps/${appId}`) to modify the `settings.oauthClient.grant_types` property array to include the JWT Bearer grant type, `urn:ietf:params:oauth:grant-type:jwt-bearer`.
 
-* Alternatively, when you use the Admin Console to add or update the OIDC application in a custom authenticator, then the application automatically updates with the JWT Bearer grant type. See [Add a custom authenticator](#add-a-custom-authenticator).
+* Alternatively, when you use the Admin Console to add or update the OIDC application in a custom authenticator, the application automatically updates with the JWT Bearer grant type. See [Add a custom authenticator](#add-a-custom-authenticator).
 
 ##### Apps API usage sample
 
-Explore the [Configure and Use JWT Bearer Grant](https://god.gw.postman.com/run-collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=collection%2Ffork&collection-url=entityId%3D26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd%26entityType%3Dcollection%26workspaceId%3Daf55a245-1ac6-42d1-8af4-11e21e791e4e) Postman Collection for API examples of
-* How to get your OIDC app object properties
-* How to update your OIDC app to include the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type
-* How to obtain a token with your OIDC app client ID
+Explore the [Configure and Use JWT Bearer Grant](https://god.gw.postman.com/run-collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=collection%2Ffork&collection-url=entityId%3D26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd%26entityType%3Dcollection%26workspaceId%3Daf55a245-1ac6-42d1-8af4-11e21e791e4e) Postman Collection for API examples of how to do the following:
+* Get your OIDC app object properties.
+* Update your OIDC app to include the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type.
+* Obtain a token with your OIDC app client ID.
 
 Fork this collection and add `url`, `apiKey`, `appId`, and `yourClientId` environment variables to run the example endpoints. The `PUT` method is a full property-replace operation, so you need to specify all required OIDC app properties, including any previous grant types. See [Create an API token](/docs/guides/create-an-api-token/main/) to obtain an `apiKey` from your org for testing purposes.
 

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/android/sdksteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/android/sdksteps.md
@@ -213,7 +213,7 @@ To successfully obtain the maintenance token, you must first configure your Okta
 
 * You can use the Apps API's [update application](/docs/reference/api/apps/#update-application) operation (`PUT /apps/${appId}`) to modify the `settings.oauthClient.grant_types` property array to include the JWT Bearer grant type, `urn:ietf:params:oauth:grant-type:jwt-bearer`.
 
-* Alternatively, when you use the Admin Console to add or update a custom authenticator with an existing OIDC application, then the application automatically updates with the JWT Bearer grant type. See [Add a custom authenticator](#add-a-custom-authenticator).
+* Alternatively, when you use the Admin Console to add or update the OIDC application in a custom authenticator, then the application automatically updates with the JWT Bearer grant type. See [Add a custom authenticator](#add-a-custom-authenticator).
 
 ##### Apps API usage sample
 

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/android/sdksteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/android/sdksteps.md
@@ -187,11 +187,6 @@ Alternatively, you can retrieve undelivered challenges by using the [MyAccount A
 
 ### Access token management
 
-> **Note:** To enable the JWT bearer grant type:
->  * Send a PUT request to `/apps/{appId}`. Ensure that the `grant_types` array contains the following string:
->    `urn:ietf:params:oauth:grant-type:jwt-bearer`
->  * If you use a custom authorization server, update the policy rules to update the grant type.
-
 The SDK communicates with an Okta server using the HTTPS protocol and requires an access token for user authentication and authorization. For authentication flows and access token requests, use the latest version of the [Okta Kotlin Mobile SDK](https://github.com/okta/okta-mobile-kotlin). To enroll a push authenticator, the user needs to have an access token that contains the `okta.myAccount.appAuthenticator.manage` scope. You can also use this scope for the following operations:
 
 * Enroll and unenroll user verification keys
@@ -206,13 +201,30 @@ The SDK communicates with an Okta server using the HTTPS protocol and requires a
   * Enable or disable user verification for push authenticator enrollment
   * Delete push authenticator enrollment
 
-Other operations are considered low risk and may not require interactive authentication. For that reason, the Okta OIDC SDK provides the silent user reauthentication method, `retrieveMaintenanceToken`. This method retrieves a maintenance access token for reauthentication that allows an application to silently perform the following operations:
+### Maintenance token configuration and usage
+
+Other operations are low risk and may not require interactive authentication. For that reason, the Okta Devices SDK provides the silent user reauthentication method, `retrieveMaintenanceToken`. This method retrieves a maintenance access token for reauthentication that allows an application to silently perform the following operations:
 
 * Request pending push challenges
 * Enable and disable CIBA capability for the push authenticator enrollment
 * Update device tokens for push authenticator enrollment
 
-Usage example:
+To successfully obtain the maintenance token, you must first configure your Okta OIDC application to support the JWT Bearer grant type.
+
+You can use the Apps API's [update application](/docs/reference/api/apps/#update-application) operation (`PUT /apps/${appId}`) to modify the `settings.oauthClient.grant_types` property array to include the JWT Bearer grant type, `urn:ietf:params:oauth:grant-type:jwt-bearer`.
+
+Alternatively, when you add or update a custom authenticator with an existing OIDC application, the application automatically updates with the JWT Bearer grant type.
+
+See the [Configure and Use JWT Bearer Grant](https://www.postman.com/okta-eng/workspace/okta-example-collections/collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=share&creator=15037798) Postman Collection for API examples of
+* How to get your OIDC app object properties
+* How to update your OIDC app to include the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type
+* How to obtain a token with your OIDC app client ID
+
+Explore the **Configure and Use JWT Bearer Grant** Postman Collection: [![Run in Postman](https://run.pstmn.io/button.svg)](https://god.gw.postman.com/run-collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=collection%2Ffork&collection-url=entityId%3D26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd%26entityType%3Dcollection%26workspaceId%3Daf55a245-1ac6-42d1-8af4-11e21e791e4e)
+
+Fork this collection and add `url`, `apiKey`, `appId`, and `yourClientId` environment variables to run the example endpoints. The `PUT` method is a full property-replace operation, so you need to specify all required OIDC app properties, including any previous grant types. See [Create an API token](/docs/guides/create-an-api-token/main/) to obtain an `apiKey` from your org for testing purposes.
+
+##### Usage example
 
 ```kotlin
 suspend fun retrievePushChallenges() {

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/android/sdksteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/android/sdksteps.md
@@ -213,16 +213,18 @@ To successfully obtain the maintenance token, you must first configure your Okta
 
 * You can use the Apps API's [update application](/docs/reference/api/apps/#update-application) operation (`PUT /apps/${appId}`) to modify the `settings.oauthClient.grant_types` property array to include the JWT Bearer grant type, `urn:ietf:params:oauth:grant-type:jwt-bearer`.
 
-    Explore the [Configure and Use JWT Bearer Grant](https://god.gw.postman.com/run-collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=collection%2Ffork&collection-url=entityId%3D26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd%26entityType%3Dcollection%26workspaceId%3Daf55a245-1ac6-42d1-8af4-11e21e791e4e) Postman Collection for API examples of
-    * How to get your OIDC app object properties
-    * How to update your OIDC app to include the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type
-    * How to obtain a token with your OIDC app client ID
-
-    Fork this collection and add `url`, `apiKey`, `appId`, and `yourClientId` environment variables to run the example endpoints. The `PUT` method is a full property-replace operation, so you need to specify all required OIDC app properties, including any previous grant types. See [Create an API token](/docs/guides/create-an-api-token/main/) to obtain an `apiKey` from your org for testing purposes.
-
 * Alternatively, when you use the Admin Console to add or update a custom authenticator with an existing OIDC application, then the application automatically updates with the JWT Bearer grant type. See [Add a custom authenticator](#add-a-custom-authenticator).
 
-##### Usage example
+##### Apps API usage sample
+
+Explore the [Configure and Use JWT Bearer Grant](https://god.gw.postman.com/run-collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=collection%2Ffork&collection-url=entityId%3D26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd%26entityType%3Dcollection%26workspaceId%3Daf55a245-1ac6-42d1-8af4-11e21e791e4e) Postman Collection for API examples of
+* How to get your OIDC app object properties
+* How to update your OIDC app to include the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type
+* How to obtain a token with your OIDC app client ID
+
+Fork this collection and add `url`, `apiKey`, `appId`, and `yourClientId` environment variables to run the example endpoints. The `PUT` method is a full property-replace operation, so you need to specify all required OIDC app properties, including any previous grant types. See [Create an API token](/docs/guides/create-an-api-token/main/) to obtain an `apiKey` from your org for testing purposes.
+
+##### Kotlin maintenance token usage example
 
 ```kotlin
 suspend fun retrievePushChallenges() {

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/android/sdksteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/android/sdksteps.md
@@ -215,12 +215,10 @@ You can use the Apps API's [update application](/docs/reference/api/apps/#update
 
 Alternatively, when you add or update a custom authenticator with an existing OIDC application, the application automatically updates with the JWT Bearer grant type.
 
-See the [Configure and Use JWT Bearer Grant](https://www.postman.com/okta-eng/workspace/okta-example-collections/collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=share&creator=15037798) Postman Collection for API examples of
+Explore the [Configure and Use JWT Bearer Grant](https://god.gw.postman.com/run-collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=collection%2Ffork&collection-url=entityId%3D26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd%26entityType%3Dcollection%26workspaceId%3Daf55a245-1ac6-42d1-8af4-11e21e791e4e) Postman Collection for API examples of
 * How to get your OIDC app object properties
 * How to update your OIDC app to include the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type
 * How to obtain a token with your OIDC app client ID
-
-Explore the **Configure and Use JWT Bearer Grant** Postman Collection: [![Run in Postman](https://run.pstmn.io/button.svg)](https://god.gw.postman.com/run-collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=collection%2Ffork&collection-url=entityId%3D26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd%26entityType%3Dcollection%26workspaceId%3Daf55a245-1ac6-42d1-8af4-11e21e791e4e)
 
 Fork this collection and add `url`, `apiKey`, `appId`, and `yourClientId` environment variables to run the example endpoints. The `PUT` method is a full property-replace operation, so you need to specify all required OIDC app properties, including any previous grant types. See [Create an API token](/docs/guides/create-an-api-token/main/) to obtain an `apiKey` from your org for testing purposes.
 

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
@@ -1,4 +1,4 @@
-Use the Devices SDK to enable your app to verify the identity of a user by responding to notifications from a Custom Authenticator.
+Use the Devices SDK to enable your app to verify the identity of a user by responding to notifications from a custom authenticator.
 
 To set up and configure your app:
 
@@ -84,7 +84,7 @@ func initOktaDeviceAuthenticator() {
 }
 ```
 
-Use the name of the group you added when you added the App Group Capability earlier. The compiler conditional ensures that Device Authenticator uses the appropriate APNs environment.
+Use the name of the group that you added when you added the App Group Capability earlier. The compiler conditional ensures that Device Authenticator uses the appropriate APNs environment.
 
 ### Register the device
 
@@ -99,7 +99,7 @@ To enroll a device, you need:
 
 Alternatively, you can enroll the device by using the [MyAccount App Authenticators API](https://developer.okta.com/docs/api/openapi/okta-myaccount/myaccount/tag/AppAuthenticator/#tag/AppAuthenticator/operation/createAppAuthenticatorEnrollment).
 
-There are many different ways that your app may start the flow for enrolling a device, such as the user setting a preference or adding an authentication method. No matter how the enrollment flow is started it follows the same steps:
+There are many different ways that your app may start the flow for enrolling a device, such as the user setting a preference or adding an authentication method. No matter how the enrollment flow starts, it follows the same steps:
 
 - Sign the user in if they’re currently signed out.
 - Create the configuration for the authenticator.
@@ -365,7 +365,7 @@ To successfully obtain the maintenance token, you must first configure your Okta
 
 You can use the Apps API's [update application](/docs/reference/api/apps/#update-application) operation (`PUT /apps/${appId}`) to modify the `settings.oauthClient.grant_types` property array to include the JWT Bearer grant type, `urn:ietf:params:oauth:grant-type:jwt-bearer`.
 
-Alternatively, when you add or update a custom authenticator with an existing OIDC application, the application automatically bootstraps with the JWT Bearer grant type.
+Alternatively, when you add or update a custom authenticator with an existing OIDC application, the application automatically updates with the JWT Bearer grant type.
 
 See the [Configure and Use JWT Bearer Grant](https://www.postman.com/okta-eng/workspace/okta-example-collections/collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=share&creator=15037798) Postman Collection for API examples of
 * How to get your OIDC app object properties

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
@@ -364,14 +364,14 @@ To successfully obtain the maintenance token, you must first configure your Okta
 
 * You can use the Apps API's [update application](/docs/reference/api/apps/#update-application) operation (`PUT /apps/${appId}`) to modify the `settings.oauthClient.grant_types` property array to include the JWT Bearer grant type, `urn:ietf:params:oauth:grant-type:jwt-bearer`.
 
-* Alternatively, when you use the Admin Console to add or update the OIDC application in a custom authenticator, then the application automatically updates with the JWT Bearer grant type. See [Add a custom authenticator](#add-a-custom-authenticator).
+* Alternatively, when you use the Admin Console to add or update the OIDC application in a custom authenticator, the application automatically updates with the JWT Bearer grant type. See [Add a custom authenticator](#add-a-custom-authenticator).
 
 ##### Apps API usage sample
 
-Explore the [Configure and Use JWT Bearer Grant](https://god.gw.postman.com/run-collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=collection%2Ffork&collection-url=entityId%3D26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd%26entityType%3Dcollection%26workspaceId%3Daf55a245-1ac6-42d1-8af4-11e21e791e4e) Postman Collection for API examples of
-* How to get your OIDC app object properties
-* How to update your OIDC app to include the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type
-* How to obtain a token with your OIDC app client ID
+Explore the [Configure and Use JWT Bearer Grant](https://god.gw.postman.com/run-collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=collection%2Ffork&collection-url=entityId%3D26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd%26entityType%3Dcollection%26workspaceId%3Daf55a245-1ac6-42d1-8af4-11e21e791e4e) Postman Collection for API examples of how to do the following:
+* Get your OIDC app object properties.
+* Update your OIDC app to include the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type.
+* Obtain a token with your OIDC app client ID.
 
 Fork this collection and add `url`, `apiKey`, `appId`, and `yourClientId` environment variables to run the example endpoints. The `PUT` method is a full property-replace operation, so you need to specify all required OIDC app properties, including any previous grant types. See [Create an API token](/docs/guides/create-an-api-token/main/) to obtain an `apiKey` from your org for testing purposes.
 

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
@@ -27,9 +27,8 @@ A valid user account authentication token is necessary to add a device as an aut
 
 Then add the extra permissions that the Devices SDK requires to the access token. Add the following strings to the space-delimited list of scopes in the `Okta.plist` file:
 
-- `okta.authenticators.manage.self`
-- `okta.authenticators.read`
-- `okta.users.read.self`
+- `okta.myAccount.appAuthenticator.manage`
+- `okta.myAccount.appAuthenticator.read`
 
 If you’re initializing the scopes in your app's code instead of using the `Okta.plist` file, update that code using the scopes as strings.
 

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
@@ -358,13 +358,21 @@ The following is a list of operations that are considered high risk and require 
   * Enable or disable user verification for push authenticator enrollment
   * Delete push authenticator enrollment
 
-Other operations are low risk and may not require interactive authentication. For that reason, the Okta OIDC SDK provides the silent user reauthentication method, `retrieveMaintenanceToken`. This method retrieves a maintenance access token for reauthentication that allows an application to silently perform the following operations:
+### Maintenance token configuration and usage
+
+Other operations are low risk and may not require interactive authentication. For that reason, the Okta Devices SDK provides the silent user reauthentication method, `retrieveMaintenanceToken`. This method retrieves a maintenance access token for reauthentication that allows an application to silently perform the following operations:
 
 * Request pending push challenges
 * Enable and disable CIBA capability for the push authenticator enrollment
 * Update device tokens for push authenticator enrollment
 
-Usage example:
+#### Usage example
+
+In order to successfully obtain the maintenance token, your OIDC application must first be configured to support the JWT Bearer grant type. You can use the [Update application](/docs/reference/api/apps/#update-application) operation (`PUT /apps/${appId}`) to modify the `settings.oauthClient.grant_types` property array to include the JWT Bearer grant type `urn:ietf:params:oauth:grant-type:jwt-bearer`.
+
+Alternatively, when you add or update an existing application a custom authenticator, the application will automatically be bootstrapped with the JWT Bearer grant type.
+
+For more information on how to configure and use the JWT Bearer grant type, refer to this Postman Collection <insert hyperlink> or contact Okta Support.
 
 ```swift
 func retrievePushChallenges() {
@@ -377,7 +385,7 @@ func retrievePushChallenges() {
                 enrollment.retrievePushChallenges(authenticationToken: authToken) { result in
                     switch result {
                     case .success(let challenges):
-                        print("Challenges retrieve: \(challenges)")      
+                        print("Challenges retrieve: \(challenges)")
                     case .failure(let error):
                         print(error.localizedDescription)
                 }

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
@@ -355,7 +355,7 @@ The following is a list of operations that are considered high risk and require 
 
 ### Maintenance token configuration and usage
 
-Other operations are low risk and may not require interactive authentication. For that reason, the Okta Devices SDK provides the silent user re-authentication method, `retrieveMaintenanceToken`. This method retrieves a maintenance access token for re-authentication that allows an application to silently perform the following operations:
+Other operations are low risk and may not require interactive authentication. For that reason, the Okta Devices SDK provides the silent user reauthentication method, `retrieveMaintenanceToken`. This method retrieves a maintenance access token for reauthentication that allows an application to silently perform the following operations:
 
 * Request pending push challenges
 * Enable and disable CIBA capability for the push authenticator enrollment
@@ -374,9 +374,7 @@ See the [Configure and Use JWT Bearer Grant](https://www.postman.com/okta-eng/wo
 
 Explore the **Configure and Use JWT Bearer Grant** Postman Collection: [![Run in Postman](https://run.pstmn.io/button.svg)](https://god.gw.postman.com/run-collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=collection%2Ffork&collection-url=entityId%3D26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd%26entityType%3Dcollection%26workspaceId%3Daf55a245-1ac6-42d1-8af4-11e21e791e4e)
 
-Fork this collection and add `url`, `apiKey`, `appId`, and `clientId` environment variables to run the example endpoints. The `PUT` method is a full property-replace operation, so you need to specify all required OIDC app properties, including any previous grant types.
-
->  **Note:** If you use custom authorization servers, update the policy rules to update the grant type. See [Authorization Servers API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/AuthorizationServer/#tag/AuthorizationServer/operation/replaceAuthorizationServerPolicyRule).
+Fork this collection and add `url`, `apiKey`, `appId`, and `yourClientId` environment variables to run the example endpoints. The `PUT` method is a full property-replace operation, so you need to specify all required OIDC app properties, including any previous grant types. See [Create an API token](/docs/guides/create-an-api-token/main/) to obtain an `apiKey` from your org for testing purposes.
 
 ##### Usage example
 

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
@@ -339,11 +339,6 @@ Alternatively, you can retrieve undelivered challenges by using the [MyAccount A
 
 ## Access token management
 
-> **Note:** To enable the JWT bearer grant type:
->  * Send a PUT request to `/apps/{appId}`. Ensure that the `grant_types` array contains the following string:
->    `urn:ietf:params:oauth:grant-type:jwt-bearer`
->  * If you use custom authorization servers, update the policy rules to update the grant type. See [Authorization Servers API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/AuthorizationServer/#tag/AuthorizationServer/operation/replaceAuthorizationServerPolicyRule)
-
 The SDK communicates with an Okta server using the HTTPS protocol and requires an access token for user authentication and authorization. For authentication flows and access token requests, use the latest version of the [Okta Swift mobile SDK](https://github.com/okta/okta-mobile-swift). To enroll a push authenticator, the user needs to have an access token that contains the `okta.myAccount.appAuthenticator.manage` scope. You can also use this scope for the following operations:
 
 * Enroll and unenroll user verification keys
@@ -366,13 +361,24 @@ Other operations are low risk and may not require interactive authentication. Fo
 * Enable and disable CIBA capability for the push authenticator enrollment
 * Update device tokens for push authenticator enrollment
 
-#### Usage example
+In order to successfully obtain the maintenance token, your Okta OIDC application must first be configured to support the JWT Bearer grant type.
 
-In order to successfully obtain the maintenance token, your OIDC application must first be configured to support the JWT Bearer grant type. You can use the [Update application](/docs/reference/api/apps/#update-application) operation (`PUT /apps/${appId}`) to modify the `settings.oauthClient.grant_types` property array to include the JWT Bearer grant type `urn:ietf:params:oauth:grant-type:jwt-bearer`.
+You can use the Apps API's [update application](/docs/reference/api/apps/#update-application) operation (`PUT /apps/${appId}`) to modify the `settings.oauthClient.grant_types` property array to include the JWT Bearer grant type, `urn:ietf:params:oauth:grant-type:jwt-bearer`.
 
-Alternatively, when you add or update an existing application a custom authenticator, the application will automatically be bootstrapped with the JWT Bearer grant type.
+Alternatively, when you add or update a custom authenticator with an existing OIDC application, the application is automatically bootstrapped with the JWT Bearer grant type.
 
-For more information on how to configure and use the JWT Bearer grant type, refer to this Postman Collection <insert hyperlink> or contact Okta Support.
+See the [Configure and Use JWT Bearer Grant](https://www.postman.com/okta-eng/workspace/okta-example-collections/collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=share&creator=15037798) Postman collection for API examples of
+* How to get your OIDC app object properties
+* How to update your OIDC app to include the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type
+* How to obtain a token with your OIDC app client ID
+
+Explore the **Configure and Use JWT Bearer Grant** Postman collection: [![Run in Postman](https://run.pstmn.io/button.svg)](https://god.gw.postman.com/run-collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=collection%2Ffork&collection-url=entityId%3D26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd%26entityType%3Dcollection%26workspaceId%3Daf55a245-1ac6-42d1-8af4-11e21e791e4e)
+
+Fork this collection and add `url`, `apiKey`, `appId`, and `clientId` environment variables to run the example endpoints. The `PUT` method is a full property-replace operation, so you need to specify all of the required OIDC app properties, including any previous grant types.
+
+>  **Note:** If you use custom authorization servers, update the policy rules to update the grant type. See [Authorization Servers API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/AuthorizationServer/#tag/AuthorizationServer/operation/replaceAuthorizationServerPolicyRule)
+
+##### Usage example
 
 ```swift
 func retrievePushChallenges() {
@@ -388,6 +394,7 @@ func retrievePushChallenges() {
                         print("Challenges retrieve: \(challenges)")
                     case .failure(let error):
                         print(error.localizedDescription)
+                    }
                 }
             case .failure(let error):
                 print(error.localizedDescription)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
@@ -364,7 +364,7 @@ To successfully obtain the maintenance token, you must first configure your Okta
 
 * You can use the Apps API's [update application](/docs/reference/api/apps/#update-application) operation (`PUT /apps/${appId}`) to modify the `settings.oauthClient.grant_types` property array to include the JWT Bearer grant type, `urn:ietf:params:oauth:grant-type:jwt-bearer`.
 
-* Alternatively, when you use the Admin Console to add or update a custom authenticator with an existing OIDC application, then the application automatically updates with the JWT Bearer grant type. See [Add a custom authenticator](#add-a-custom-authenticator).
+* Alternatively, when you use the Admin Console to add or update the OIDC application in a custom authenticator, then the application automatically updates with the JWT Bearer grant type. See [Add a custom authenticator](#add-a-custom-authenticator).
 
 ##### Apps API usage sample
 

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
@@ -367,12 +367,10 @@ You can use the Apps API's [update application](/docs/reference/api/apps/#update
 
 Alternatively, when you add or update a custom authenticator with an existing OIDC application, the application automatically updates with the JWT Bearer grant type.
 
-See the [Configure and Use JWT Bearer Grant](https://www.postman.com/okta-eng/workspace/okta-example-collections/collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=share&creator=15037798) Postman Collection for API examples of
+Explore the [Configure and Use JWT Bearer Grant](https://god.gw.postman.com/run-collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=collection%2Ffork&collection-url=entityId%3D26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd%26entityType%3Dcollection%26workspaceId%3Daf55a245-1ac6-42d1-8af4-11e21e791e4e) Postman Collection for API examples of
 * How to get your OIDC app object properties
 * How to update your OIDC app to include the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type
 * How to obtain a token with your OIDC app client ID
-
-Explore the **Configure and Use JWT Bearer Grant** Postman Collection: [![Run in Postman](https://run.pstmn.io/button.svg)](https://god.gw.postman.com/run-collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=collection%2Ffork&collection-url=entityId%3D26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd%26entityType%3Dcollection%26workspaceId%3Daf55a245-1ac6-42d1-8af4-11e21e791e4e)
 
 Fork this collection and add `url`, `apiKey`, `appId`, and `yourClientId` environment variables to run the example endpoints. The `PUT` method is a full property-replace operation, so you need to specify all required OIDC app properties, including any previous grant types. See [Create an API token](/docs/guides/create-an-api-token/main/) to obtain an `apiKey` from your org for testing purposes.
 

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
@@ -360,11 +360,11 @@ Other operations are low risk and may not require interactive authentication. Fo
 * Enable and disable CIBA capability for the push authenticator enrollment
 * Update device tokens for push authenticator enrollment
 
-To successfully obtain the maintenance token, you must first configure your Okta OIDC application to support the JWT Bearer grant type.
+To successfully obtain the maintenance token, you must first configure your Okta OIDC application to support the JWT Bearer grant type:
 
-You can use the Apps API's [update application](/docs/reference/api/apps/#update-application) operation (`PUT /apps/${appId}`) to modify the `settings.oauthClient.grant_types` property array to include the JWT Bearer grant type, `urn:ietf:params:oauth:grant-type:jwt-bearer`.
+* You can use the Apps API's [update application](/docs/reference/api/apps/#update-application) operation (`PUT /apps/${appId}`) to modify the `settings.oauthClient.grant_types` property array to include the JWT Bearer grant type, `urn:ietf:params:oauth:grant-type:jwt-bearer`.
 
-Alternatively, when you add or update a custom authenticator with an existing OIDC application, the application automatically updates with the JWT Bearer grant type.
+* Alternatively, when you use the Admin Console to add or update a custom authenticator with an existing OIDC application, then the application automatically updates with the JWT Bearer grant type. See [Add a custom authenticator](#add-a-custom-authenticator).
 
 Explore the [Configure and Use JWT Bearer Grant](https://god.gw.postman.com/run-collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=collection%2Ffork&collection-url=entityId%3D26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd%26entityType%3Dcollection%26workspaceId%3Daf55a245-1ac6-42d1-8af4-11e21e791e4e) Postman Collection for API examples of
 * How to get your OIDC app object properties

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
@@ -366,6 +366,8 @@ To successfully obtain the maintenance token, you must first configure your Okta
 
 * Alternatively, when you use the Admin Console to add or update a custom authenticator with an existing OIDC application, then the application automatically updates with the JWT Bearer grant type. See [Add a custom authenticator](#add-a-custom-authenticator).
 
+##### Apps API usage sample
+
 Explore the [Configure and Use JWT Bearer Grant](https://god.gw.postman.com/run-collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=collection%2Ffork&collection-url=entityId%3D26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd%26entityType%3Dcollection%26workspaceId%3Daf55a245-1ac6-42d1-8af4-11e21e791e4e) Postman Collection for API examples of
 * How to get your OIDC app object properties
 * How to update your OIDC app to include the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type
@@ -373,7 +375,7 @@ Explore the [Configure and Use JWT Bearer Grant](https://god.gw.postman.com/run-
 
 Fork this collection and add `url`, `apiKey`, `appId`, and `yourClientId` environment variables to run the example endpoints. The `PUT` method is a full property-replace operation, so you need to specify all required OIDC app properties, including any previous grant types. See [Create an API token](/docs/guides/create-an-api-token/main/) to obtain an `apiKey` from your org for testing purposes.
 
-##### Usage example
+##### Swift maintenance token usage example
 
 ```swift
 func retrievePushChallenges() {

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-custom-authenticator/main/ios/sdksteps.md
@@ -1,4 +1,4 @@
-Use the Devices SDK to enable your app to verify the identity of a user by responding to notifications from a custom authenticator.
+Use the Devices SDK to enable your app to verify the identity of a user by responding to notifications from a Custom Authenticator.
 
 To set up and configure your app:
 
@@ -355,28 +355,28 @@ The following is a list of operations that are considered high risk and require 
 
 ### Maintenance token configuration and usage
 
-Other operations are low risk and may not require interactive authentication. For that reason, the Okta Devices SDK provides the silent user reauthentication method, `retrieveMaintenanceToken`. This method retrieves a maintenance access token for reauthentication that allows an application to silently perform the following operations:
+Other operations are low risk and may not require interactive authentication. For that reason, the Okta Devices SDK provides the silent user re-authentication method, `retrieveMaintenanceToken`. This method retrieves a maintenance access token for re-authentication that allows an application to silently perform the following operations:
 
 * Request pending push challenges
 * Enable and disable CIBA capability for the push authenticator enrollment
 * Update device tokens for push authenticator enrollment
 
-In order to successfully obtain the maintenance token, your Okta OIDC application must first be configured to support the JWT Bearer grant type.
+To successfully obtain the maintenance token, you must first configure your Okta OIDC application to support the JWT Bearer grant type.
 
 You can use the Apps API's [update application](/docs/reference/api/apps/#update-application) operation (`PUT /apps/${appId}`) to modify the `settings.oauthClient.grant_types` property array to include the JWT Bearer grant type, `urn:ietf:params:oauth:grant-type:jwt-bearer`.
 
-Alternatively, when you add or update a custom authenticator with an existing OIDC application, the application is automatically bootstrapped with the JWT Bearer grant type.
+Alternatively, when you add or update a custom authenticator with an existing OIDC application, the application automatically bootstraps with the JWT Bearer grant type.
 
-See the [Configure and Use JWT Bearer Grant](https://www.postman.com/okta-eng/workspace/okta-example-collections/collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=share&creator=15037798) Postman collection for API examples of
+See the [Configure and Use JWT Bearer Grant](https://www.postman.com/okta-eng/workspace/okta-example-collections/collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=share&creator=15037798) Postman Collection for API examples of
 * How to get your OIDC app object properties
 * How to update your OIDC app to include the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type
 * How to obtain a token with your OIDC app client ID
 
-Explore the **Configure and Use JWT Bearer Grant** Postman collection: [![Run in Postman](https://run.pstmn.io/button.svg)](https://god.gw.postman.com/run-collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=collection%2Ffork&collection-url=entityId%3D26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd%26entityType%3Dcollection%26workspaceId%3Daf55a245-1ac6-42d1-8af4-11e21e791e4e)
+Explore the **Configure and Use JWT Bearer Grant** Postman Collection: [![Run in Postman](https://run.pstmn.io/button.svg)](https://god.gw.postman.com/run-collection/26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd?action=collection%2Ffork&collection-url=entityId%3D26510466-46beb74b-4755-4cf0-9847-845ccac1ccbd%26entityType%3Dcollection%26workspaceId%3Daf55a245-1ac6-42d1-8af4-11e21e791e4e)
 
-Fork this collection and add `url`, `apiKey`, `appId`, and `clientId` environment variables to run the example endpoints. The `PUT` method is a full property-replace operation, so you need to specify all of the required OIDC app properties, including any previous grant types.
+Fork this collection and add `url`, `apiKey`, `appId`, and `clientId` environment variables to run the example endpoints. The `PUT` method is a full property-replace operation, so you need to specify all required OIDC app properties, including any previous grant types.
 
->  **Note:** If you use custom authorization servers, update the policy rules to update the grant type. See [Authorization Servers API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/AuthorizationServer/#tag/AuthorizationServer/operation/replaceAuthorizationServerPolicyRule)
+>  **Note:** If you use custom authorization servers, update the policy rules to update the grant type. See [Authorization Servers API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/AuthorizationServer/#tag/AuthorizationServer/operation/replaceAuthorizationServerPolicyRule).
 
 ##### Usage example
 


### PR DESCRIPTION
## Description:
- **What's changed?** Update Access token management section to add "Add Maintenance token configuration and usage" section to custom authenticator guide (for both iOS and Android). Also add Postman collection example.
- **Is this PR related to a Monolith release?** No

### Preview:
https://641c9eb002e2a006f325ff99--reverent-murdock-829d24.netlify.app/docs/guides/authenticators-custom-authenticator/android/main/

![image](https://user-images.githubusercontent.com/80703015/227322707-17a988ff-10cc-4f2b-a62a-670df82b9d95.png)


### Resolves:

* [OKTA-591733](https://oktainc.atlassian.net/browse/OKTA-591733)
