### PR TITLE
OKTA-495057 Add navbar links to code\aspnet and code\blazor

### DIFF
--- a/packages/@okta/vuepress-theme-prose/const/navbar.const.js
+++ b/packages/@okta/vuepress-theme-prose/const/navbar.const.js
@@ -827,7 +827,9 @@ export const languagesSdk = [
          {
             title: "Server-side",
             subLinks: [
-               { title: ".NET", path: "/code/dotnet/aspnetcore/" },
+               { title: "ASP.NET Core", path: "/code/dotnet/aspnetcore/" },
+               { title: "ASP.NET Framework", path: "/code/dotnet/aspnet/" },
+               { title: "Blazor", path: "/code/dotnet/blazor/" },
                { title: "Go", path: "/code/go/" },
                { title: "Java", path: "/code/java/" },
                { title: "Node.js", path: "/code/nodejs/" },


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** 
Aded two missing navbar links to code/aspnet and code/blazor

- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-495057](https://oktainc.atlassian.net/browse/OKTA-495057)
