### PR TITLE
Added deprecation tag to show that the matches operator is deprecated…

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
@@ -287,7 +287,7 @@ The format for conditional expressions is:
 * The `OR` operator
 * The `!` operator to designate NOT
 * Standard relational operators including <code>&lt;</code>, <code>&gt;</code>, <code>&lt;=</code>, and <code>&gt;=</code>.
-* The `matches` operator to evaluate a string against a regular expression.
+* The `matches` operator to evaluate a string against a regular expression. <ApiLifecycle access="deprecated" />
 
 > **Note:** Use the double equals sign `==` to check for equality and `!=` for inequality.
 


### PR DESCRIPTION
…. OKTA-405284

## Description:
- **What's changed?** Marked the 'matches' operator as deprecated for Okta Expression Language.
- **Is this PR related to a Monolith release?** No.

### Resolves:

* [OKTA-405284](https://oktainc.atlassian.net/browse/OKTA-405284)
