### PR TITLE
Remove old SAML config doc example links in OIN submission requirements

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/submit-app-prereq/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/submit-app-prereq/main/index.md
@@ -327,10 +327,6 @@ Include this section if there are known issues that apply to the entire configur
 
 * [How to Configure SAML 2.0 for Template for admins](https://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-Template-self.html)
 * [How to Configure SAML 2.0 Template with company support](https://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-Template-with-company-support.html)
-* [GitHub Enterprise](https://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-Github_Enterprise.html)
-* [Runscope](https://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-Runscope.html)
-* [Salesforce](https://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-in-Salesforce.html)
-* [Zoom.us](https://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-Zoom.us.html)
 
 ##### SCIM examples
 


### PR DESCRIPTION
## Description:
- **What's changed?** Remove SAML config doc example links for Runscope, GitHub, Salesforce,  and Zoom in the OIN submission prerequisite doc
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
