### PR TITLE
Remove EA tag from policy API doc

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -1880,7 +1880,6 @@ You can define multiple IdP instances in a single Policy Action. This allows use
 | name <ApiLifecycle access="ie" />  | Provider `name` in Okta | String    | No       |
 
 #### Policy Action with Dynamic IdP routing
-<ApiLifecycle access="ea"/>
 
 > **Note:** Dynamic IdP Routing is an [Early Access](/docs/reference/releases-at-okta/#early-access-ea) (Self-Service) feature. You can enable the feature for your org from the **Settings** > **Features** page in the Admin Console.
 


### PR DESCRIPTION
## Description:
- **What's changed?** Removes EA tag from "Policy action with dynamic IdP routing" section.
- **Is this PR related to a Monolith release?** Nope.

### Resolves:

* [OKTA-595677](https://oktainc.atlassian.net/browse/OKTA-595677)
