### PR TITLE
OKTA-596621 Add SSPR primary factor and authenticator key constraints to Password Policy

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -1792,13 +1792,13 @@ In the final example, end users are required to verify two Authenticators before
 
 This object enables or disables users to reset their own password and defines the authenticators and constraints needed to complete the reset.
 
-> **Note:** The following indicated objects and properties are only available as a part of the Identity Engine. Please contact support for further information. <ApiLifecycle access="ie" />
+> **Note:** The following indicated objects and properties are only available as a part of the Identity Engine. <ApiLifecycle access="ie" />
 
 | Property | Description | Data Type | Supported Values | Required | Default |
 | -------- | --------- | ----------- | ---------------- | -------- | ------- |
 | access | Indicates if the action is permitted | String | `ALLOW`, `DENY`  | No  | `DENY` |
-| type <ApiLifecycle access="ie" /> | Type of rule action | String | `selfServicePasswordReset` | No | `selfServicePasswordReset` |
-| requirement <ApiLifecycle access="ie" /> | JSON object that contains Authenticator methods required to be verified if `access` is `ALLOW`. If access is `ALLOW` and `requirement` isn't specified, `recovery.factors` from the parent policy object is used to determine recovery factors. | [Self Service Password Reset Action Requirement object](#self-service-password-reset-action-requirement-object)  | No | |
+| type <ApiLifecycle access="ie" /> | Type of rule action | String | `selfServicePasswordReset` | No <br>(read only) | `selfServicePasswordReset` |
+| requirement <ApiLifecycle access="ie" /> | JSON object that contains Authenticator methods required to be verified if `access` is `ALLOW`. If access is `ALLOW` and `requirement` isn't specified, `recovery.factors` from the parent policy object is used to determine recovery factors. | [Self Service Password Reset Action Requirement object](#self-service-password-reset-action-requirement-object)  | | No |
 
 ###### Self Service Password Reset Action Requirement object
 
@@ -1819,25 +1819,25 @@ Defines the authenticators permitted for the initial authentication step of pass
 
 | Property | Description | Data Type | Supported Values | Required | Default |
 | -------- | ----------- | --------- | ---------------- | -------- | ------- |
-| methodConstraints | Constraints on the values specified in the `methods` array. Specifying a constraint limits methods to specific authenticators. Currently, Google OTP is the only accepted constraint. | [Self Service Password Reset Action Primary Requirement Constraint object](#self-service-password-reset-action-primary-requirement-constraint-object) | | No | |
-| methods | Authenticator methods allowed for the initial authentication step of password recovery. Method `otp` requires a constraint limiting it to a Google authenticator. | Array | `push`, `sms`, `voice`, `email`, `otp` | No | |
+| methodConstraints | Specifies an authenticator-specific constraint on the values in the `methods` array. Currently, Google OTP is the only accepted constraint for the `OTP` method. | Array of [Self Service Password Reset Action Primary Requirement Constraint object](#self-service-password-reset-action-primary-requirement-constraint-object) | `[ {"method": "otp", "allowedAuthenticators": [ { "key": "google_otp" } ] } ]` | No | |
+| methods | Authenticator methods allowed for the initial authentication step of password recovery. The `OTP` method requires a constraint limiting it to the Google authenticator. | Array | `PUSH`, `SMS`, `VOICE`, `EMAIL`, `OTP` | No | |
 
 ###### Self Service Password Reset Action Primary Requirement Constraint object
 
 <ApiLifecycle access="ie" />
 
-Constraints on the values specified in the `requirement.primary.methods` array. Specifying a constraint limits methods to specific authenticators. Currently, Google OTP is the only accepted constraint.
+Constraints on the values specified in the `selfServicePasswordReset.requirement.primary.methods` array. Specifying a constraint limits methods to specific authenticators. Currently, Google OTP is the only accepted constraint.
 
 | Property | Description | Data Type | Supported Values | Required | Default |
 | -------- | ----------- | --------- | ---------------- | -------- | ------- |
-| allowedAuthenticators | Limits the authenticators that can be used for a given method. Currently, only the `otp` method supports constraints, and Google authenticator is the only allowed authenticator. | Array of [authenticator keys](/docs/reference/api/authenticators-admin/#authenticator-properties). | `[ { "key": "google_otp" } ]` | No | |
-| method  | Specifies the method that is limited to the specific authenticator in `allowedAuthenticators`. Currently, Google OTP is the only accepted constraint. | String | `otp` | No | |
+| allowedAuthenticators | Limits the authenticators that can be used for a given method. Currently, only the `OTP` method supports constraints and Google authenticator is the only allowed authenticator. | Array of [authenticator keys](/docs/reference/api/authenticators-admin/#authenticator-properties). | `[ { "key": "google_otp" } ]` | No | |
+| method  | Specifies the method that is limited to the specific authenticator in `allowedAuthenticators`. Currently, Google OTP is the only accepted constraint. | String | `OTP` | No | |
 
 ###### Self Service Password Reset Action Step-up Requirement object
 
 <ApiLifecycle access="ie" />
 
-Defines the secondary authenticators needed for password reset if `stepUp.required` is true. The following are three valid configurations:
+Defines the secondary authenticators needed for password reset if `selfServicePasswordReset.requirement.stepUp.required` is true. The following are three valid configurations:
 
 * `required` = false
 * `required` = true with no methods to use any SSO authenticator
@@ -1845,8 +1845,8 @@ Defines the secondary authenticators needed for password reset if `stepUp.requir
 
 | Property | Description | Data Type | Supported Values | Required | Default |
 | -------- | ----------- | --------- | ---------------- | -------- | ------- |
-| required  | Indicates if any step-up verification is required to recover a password that follows a primary methods verification | Boolean  |  `true`, `false` | Yes | |
-| methods | Authenticator methods required for secondary authentication step of password recovery.  Specify this value only when `required` is true and `security_question` is permitted for the secondary authentication. | Array of strings | `[ "security_question" ]` | No | |
+| required  | Indicates if any step-up verification is required to recover a password that follows a primary methods verification | Boolean  |  `true`, `false` | No | |
+| methods | Authenticator methods required for secondary authentication step of password recovery.  When `required` is true, the only supported secondary authentication method is `security_question`. | Array of strings | `[ "security_question" ]` | No | |
 
 ##### Self Service Unlock Action object
 

--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -1820,7 +1820,7 @@ Defines the authenticators permitted for the initial authentication step of pass
 | Property | Description | Data Type | Supported Values | Required | Default |
 | -------- | ----------- | --------- | ---------------- | -------- | ------- |
 | methodConstraints | Specifies an authenticator-specific constraint on the values in the `methods` array. Currently, Google OTP is the only accepted constraint for the `OTP` method. | Array of [Self Service Password Reset Action Primary Requirement Constraint object](#self-service-password-reset-action-primary-requirement-constraint-object) | `[ {"method": "otp", "allowedAuthenticators": [ { "key": "google_otp" } ] } ]` | No | |
-| methods | Authenticator methods allowed for the initial authentication step of password recovery. The `OTP` method requires a constraint limiting it to the Google authenticator. | Array | `PUSH`, `SMS`, `VOICE`, `EMAIL`, `OTP` | No | |
+| methods | Authenticator methods allowed for the initial authentication step of password recovery. The `OTP` method requires a constraint limiting it to the Google authenticator. | Array | `PUSH`, `SMS`, `VOICE`, `EMAIL`, and `OTP` | No | |
 
 ###### Self Service Password Reset Action Primary Requirement Constraint object
 

--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -744,7 +744,7 @@ The Rules object defines several attributes:
 
 ### Actions objects
 
-Just as Policies contain settings, Rules contain "Actions" that typically specify actions to be taken, or operations that may be allowed, if the Rule conditions are satisfied. For example, in a Password Policy, Rule actions govern whether self-service operations such as reset password or unlock are permitted. Just as different Policy types have different settings, Rules have different actions depending on the type of Policy that they belong to.
+Just as Policies contain settings, Rules contain "Actions" that typically specify actions to be taken, or operations that may be allowed, if the Rule conditions are satisfied. For example, in a Password Policy, Rule actions govern whether self-service operations such as reset password or unlock are permitted (see [Password Rules Action data](#password-rules-action-data)). Just as different Policy types have different settings, Rules have different actions depending on the type of Policy that they belong to.
 
 ### Conditions object
 
@@ -1790,16 +1790,63 @@ In the final example, end users are required to verify two Authenticators before
 
 ##### Self Service Password Reset Action object
 
-> **Note:** The following indicated objects and properties are only available as a part of the Identity Engine. Please contact support for further information.
+This object enables or disables users to reset their own password and defines the authenticators and constraints needed to complete the reset.
 
-| Property                                                       | Data Type   | Description                                                                                 | Supported Values                | Required | Default
-| ---                                                            | ---         | ---                                                                                         | ---                             | ---      | ---
-| `access`                                                       | String      | Indicates if the action is permitted                                                        | `ALLOW`, `DENY`                 | No       | `DENY`
-| `requirement` <ApiLifecycle access="ie" />                     | Object      | JSON object that contains Authenticator methods required to be verified if `access` is `ALLOW`. If access is `ALLOW` and `requirement` isn't specified, `recovery.factors` from the parent policy object is used to determine recovery factors.                             | No       |
-| `requirement.primary.methods` <ApiLifecycle access="ie" />     | Array       | Authenticator methods that can be used by the End User to initiate a password recovery            | `EMAIL`, `SMS`, `VOICE`, `PUSH` | Yes |
-| `requirement.stepUp.required` <ApiLifecycle access="ie" />     | Boolean     | Indicates if any step-up verification is required to recover a password that follows a primary methods verification | `true`, `false` | Yes |
-| `requirement.stepUp.methods`  <ApiLifecycle access="ie" />     | Array       | If `requirement.stepUp.required` is `true`, a JSON object that contains Authenticator methods is required to be verified as a step up. If not specified, any enrolled Authenticator methods allowed for sign-on can be used as step up. | `null` or an array containing`SECURITY_QUESTION` | No
+> **Note:** The following indicated objects and properties are only available as a part of the Identity Engine. Please contact support for further information. <ApiLifecycle access="ie" />
 
+| Property | Description | Data Type | Supported Values | Required | Default |
+| -------- | --------- | ----------- | ---------------- | -------- | ------- |
+| access | Indicates if the action is permitted | String | `ALLOW`, `DENY`  | No  | `DENY` |
+| type <ApiLifecycle access="ie" /> | Type of rule action | String | `selfServicePasswordReset` | No | `selfServicePasswordReset` |
+| requirement <ApiLifecycle access="ie" /> | JSON object that contains Authenticator methods required to be verified if `access` is `ALLOW`. If access is `ALLOW` and `requirement` isn't specified, `recovery.factors` from the parent policy object is used to determine recovery factors. | [Self Service Password Reset Action Requirement object](#self-service-password-reset-action-requirement-object)  | No | |
+
+###### Self Service Password Reset Action Requirement object
+
+<ApiLifecycle access="ie" />
+
+Describes the initial and secondary (step-up) authenticator requirements a user needs to reset their password
+
+| Property | Description | Data Type | Required |
+| -------- | ----------- | --------- | -------- |
+| primary  | Defines the authenticators permitted for the initial authentication step of password recovery | [Self Service Password Reset Action Primary Requirement object](#self-service-password-reset-action-primary-requirement-object) | No |
+| stepUp  | Defines the authenticators permitted for the secondary authentication step of password recovery | [Self Service Password Reset Action Step-up Requirement object](#self-service-password-reset-action-step-up-requirement-object) | No |
+
+###### Self Service Password Reset Action Primary Requirement object
+
+<ApiLifecycle access="ie" />
+
+Defines the authenticators permitted for the initial authentication step of password recovery
+
+| Property | Description | Data Type | Supported Values | Required | Default |
+| -------- | ----------- | --------- | ---------------- | -------- | ------- |
+| methodConstraints | Constraints on the values specified in the `methods` array. Specifying a constraint limits methods to specific authenticators. Currently, Google OTP is the only accepted constraint. | [Self Service Password Reset Action Primary Requirement Constraint object](#self-service-password-reset-action-primary-requirement-constraint-object) | | No | |
+| methods | Authenticator methods allowed for the initial authentication step of password recovery. Method `otp` requires a constraint limiting it to a Google authenticator. | Array | `push`, `sms`, `voice`, `email`, `otp` | No | |
+
+###### Self Service Password Reset Action Primary Requirement Constraint object
+
+<ApiLifecycle access="ie" />
+
+Constraints on the values specified in the `requirement.primary.methods` array. Specifying a constraint limits methods to specific authenticators. Currently, Google OTP is the only accepted constraint.
+
+| Property | Description | Data Type | Supported Values | Required | Default |
+| -------- | ----------- | --------- | ---------------- | -------- | ------- |
+| allowedAuthenticators | Limits the authenticators that can be used for a given method. Currently, only the `otp` method supports constraints, and Google authenticator is the only allowed authenticator. | Array of [authenticator keys](/docs/reference/api/authenticators-admin/#authenticator-properties). | `[ { "key": "google_otp" } ]` | No | |
+| method  | Specifies the method that is limited to the specific authenticator in `allowedAuthenticators`. Currently, Google OTP is the only accepted constraint. | String | `otp` | No | |
+
+###### Self Service Password Reset Action Step-up Requirement object
+
+<ApiLifecycle access="ie" />
+
+Defines the secondary authenticators needed for password reset if `stepUp.required` is true. The following are three valid configurations:
+
+* `required` = false
+* `required` = true with no methods to use any SSO authenticator
+* `required` = true with `security_question` as the method
+
+| Property | Description | Data Type | Supported Values | Required | Default |
+| -------- | ----------- | --------- | ---------------- | -------- | ------- |
+| required  | Indicates if any step-up verification is required to recover a password that follows a primary methods verification | Boolean  |  `true`, `false` | Yes | |
+| methods | Authenticator methods required for secondary authentication step of password recovery.  Specify this value only when `required` is true and `security_question` is permitted for the secondary authentication. | Array of strings | `[ "security_question" ]` | No | |
 
 ##### Self Service Unlock Action object
 

--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -1830,7 +1830,7 @@ Constraints on the values specified in the `selfServicePasswordReset.requirement
 
 | Property | Description | Data Type | Supported Values | Required | Default |
 | -------- | ----------- | --------- | ---------------- | -------- | ------- |
-| allowedAuthenticators | Limits the authenticators that can be used for a given method. Currently, only the `OTP` method supports constraints and Google authenticator is the only allowed authenticator. | Array of [authenticator keys](/docs/reference/api/authenticators-admin/#authenticator-properties). | `[ { "key": "google_otp" } ]` | No | |
+| allowedAuthenticators | Limits the authenticators that can be used for a given method. Currently, only the `OTP` method supports constraints and Google authenticator is the only allowed authenticator. | Array of [authenticator keys](/docs/reference/api/authenticators-admin/#authenticator-properties) | `[ { "key": "google_otp" } ]` | No | |
 | method  | Specifies the method that is limited to the specific authenticator in `allowedAuthenticators`. Currently, Google OTP is the only accepted constraint. | String | `OTP` | No | |
 
 ###### Self Service Password Reset Action Step-up Requirement object

--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -1817,10 +1817,10 @@ Describes the initial and secondary (step-up) authenticator requirements a user 
 
 Defines the authenticators permitted for the initial authentication step of password recovery
 
-| Property | Description | Data Type | Supported Values | Required | Default |
-| -------- | ----------- | --------- | ---------------- | -------- | ------- |
-| methodConstraints | Specifies an authenticator-specific constraint on the values in the `methods` array. Currently, Google OTP is the only accepted constraint for the `OTP` method. | Array of [Self Service Password Reset Action Primary Requirement Constraint object](#self-service-password-reset-action-primary-requirement-constraint-object) | `[ {"method": "otp", "allowedAuthenticators": [ { "key": "google_otp" } ] } ]` | No | |
-| methods | Authenticator methods allowed for the initial authentication step of password recovery. The `OTP` method requires a constraint limiting it to the Google authenticator. | Array | `PUSH`, `SMS`, `VOICE`, `EMAIL`, and `OTP` | No | |
+| Property | Description | Data Type | Supported Values | Required |
+| -------- | ----------- | --------- | ---------------- | -------- |
+| methodConstraints | Specifies an authenticator-specific constraint on the values in the `methods` array. Currently, Google OTP is the only accepted constraint for the `OTP` method. | Array of [Self Service Password Reset Action Primary Requirement Constraint object](#self-service-password-reset-action-primary-requirement-constraint-object) | `[ {"method": "otp", "allowedAuthenticators": [ { "key": "google_otp" } ] } ]` | No |
+| methods | Authenticator methods allowed for the initial authentication step of password recovery. The `OTP` method requires a constraint limiting it to the Google authenticator. | Array | `PUSH`, `SMS`, `VOICE`, `EMAIL`, and `OTP` | No |
 
 ###### Self Service Password Reset Action Primary Requirement Constraint object
 
@@ -1828,10 +1828,10 @@ Defines the authenticators permitted for the initial authentication step of pass
 
 Constraints on the values specified in the `selfServicePasswordReset.requirement.primary.methods` array. Specifying a constraint limits methods to specific authenticators. Currently, Google OTP is the only accepted constraint.
 
-| Property | Description | Data Type | Supported Values | Required | Default |
-| -------- | ----------- | --------- | ---------------- | -------- | ------- |
-| allowedAuthenticators | Limits the authenticators that can be used for a given method. Currently, only the `OTP` method supports constraints and Google authenticator is the only allowed authenticator. | Array of [authenticator keys](/docs/reference/api/authenticators-admin/#authenticator-properties) | `[ { "key": "google_otp" } ]` | No | |
-| method  | Specifies the method that is limited to the specific authenticator in `allowedAuthenticators`. Currently, Google OTP is the only accepted constraint. | String | `OTP` | No | |
+| Property | Description | Data Type | Supported Values | Required |
+| -------- | ----------- | --------- | ---------------- | -------- |
+| allowedAuthenticators | Limits the authenticators that can be used for a given method. Currently, only the `OTP` method supports constraints and Google authenticator is the only allowed authenticator. | Array of [authenticator keys](/docs/reference/api/authenticators-admin/#authenticator-properties) | `[ { "key": "google_otp" } ]` | No |
+| method  | Specifies the method that is limited to the specific authenticator in `allowedAuthenticators`. Currently, Google OTP is the only accepted constraint. | String | `OTP` | No |
 
 ###### Self Service Password Reset Action Step-up Requirement object
 
@@ -1843,10 +1843,10 @@ Defines the secondary authenticators needed for password reset if `selfServicePa
 * `required` = true with no methods to use any SSO authenticator
 * `required` = true with `security_question` as the method
 
-| Property | Description | Data Type | Supported Values | Required | Default |
-| -------- | ----------- | --------- | ---------------- | -------- | ------- |
-| required  | Indicates if any step-up verification is required to recover a password that follows a primary methods verification | Boolean  |  `true`, `false` | No | |
-| methods | Authenticator methods required for secondary authentication step of password recovery.  When `required` is true, the only supported secondary authentication method is `security_question`. | Array of strings | `[ "security_question" ]` | No | |
+| Property | Description | Data Type | Supported Values | Required |
+| -------- | ----------- | --------- | ---------------- | -------- |
+| required  | Indicates if any step-up verification is required to recover a password that follows a primary methods verification | Boolean  |  `true`, `false` | No |
+| methods | Authenticator methods required for secondary authentication step of password recovery.  When `required` is true, the only supported secondary authentication method is `security_question`. | Array of strings | `[ "security_question" ]` | No |
 
 ##### Self Service Unlock Action object
 


### PR DESCRIPTION
## Description:
- **What's changed?** Add Password Policy changes: SSPR authenticators and constraints. This PR needs to be aligned with PR 404 in okta-oas3 repo.
- **Is this PR related to a Monolith release?** TBD (2023.06.0?)

### Preview:
https://643474c17272e412a24cf56d--reverent-murdock-829d24.netlify.app/docs/reference/api/policy/#password-rules-action-data
![image](https://user-images.githubusercontent.com/80703015/230992348-df3109c9-d71d-4a89-a426-c6a49843d2c4.png)

![image](https://user-images.githubusercontent.com/80703015/230992399-e920ce37-e640-4c68-9522-5595994d1d7a.png)

![image](https://user-images.githubusercontent.com/80703015/230992422-dd973166-ceaa-4d6f-9984-7e24cad52637.png)

![image](https://user-images.githubusercontent.com/80703015/230992453-ccbee038-56ea-47fb-b980-ff2f3a88afe8.png)

![image](https://user-images.githubusercontent.com/80703015/230992474-582d73bc-28da-4586-ab20-996a96416274.png)

### Resolves:

* [OKTA-596621](https://oktainc.atlassian.net/browse/OKTA-596621)
