### PR TITLE
User Type API - Update name parameter readonly value

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/user-types/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/user-types/index.md
@@ -336,7 +336,7 @@ The User Type object defines several properties:
 | ------------- | ------------------------------------------------- | -------------------------------------------------------------- | -------- | ------ | -------- |
 | id            | Unique key for the User Type                      | String                                                         | FALSE    | TRUE   | TRUE     |
 | displayName   | The display name for the type                     | String                                                         | FALSE    | FALSE  | FALSE    |
-| name          | The name for the type                             | String                                                         | FALSE    | TRUE   | TRUE     |
+| name          | The name for the type                             | String                                                         | FALSE    | TRUE   | FALSE    |
 | description   | A human-readable description of the type          | String                                                         | FALSE    | FALSE  | FALSE    |
 | createdBy     | The user ID of the creator of this type           | String                                                         | FALSE    | FALSE  | TRUE     |
 | lastUpdatedBy | The user ID of the last user to edit this type    | String                                                         | FALSE    | FALSE  | TRUE     |


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** The `name` parameter of the User Type object required an update to the readonly value: true to false.
- **Is this PR related to a Monolith release?**n/a

### Resolves:

* n/a
