### PR TITLE
Okta-516673: Add okta cli advisories

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/index.md
@@ -33,30 +33,32 @@ A [custom authorization server](/docs/concepts/auth-servers/#custom-authorizatio
 Set up your developer account and [Okta org](/docs/concepts/okta-organizations/). The Okta command-line interface (CLI) is the quickest way to do this. Alternatively, you can [manually sign up for a developer account](https://developer.okta.com/signup/).
 
 1. Install [Okta CLI](https://cli.okta.com/).
-1. Open your terminal.
-1. Run `okta register`, and enter your first name, last name, email address, and country.
-1. Click or tap **Activate** in the account activation email that is sent to the email address that you gave.
+1. If you don't already have a free Okta developer account:
+   1. Open your terminal.
+   {style="list-style-type:lower-alpha"}
+   1. Run `okta register`, and enter your first name, last name, email address, and country.
+   1. Click or tap **Activate** in the account activation email that is sent to the email address that you gave.
 
-   > **Tip**: If you don't receive the confirmation email sent as part of the creation process, check your spam filters for an email from `noreply@okta.com`
+      > **Tip**: If you don't receive the confirmation email sent as part of the creation process, check your spam filters for an email from `noreply@okta.com`
 
-1. After your domain is registered, look for output similar to this:
+   1. Find your new domain and a link to set your password in the email:
 
-   ```txt
-   Your Okta Domain: https://dev-xxxxxxx.okta.com
-   To set your password open this link:
-   https://dev-xxxxxxx.okta.com/welcome/xrqyNKPCZcvxL1ouKUoh
-   ```
+      ```txt
+      Your Okta Domain: https://dev-xxxxxxx.okta.com
+      To set your password open this link:
+      https://dev-xxxxxxx.okta.com/welcome/xrqyNKPCZcvxL1ouKUoh
+      ```
 
-1. Set the password for your org by opening the link and following the instructions. Your Okta domain is returned, similar to the following:
+   1. Set the password for your org by opening the link and following the instructions. Your Okta domain is returned, similar to the following:
 
-   ```txt
-   New Okta Account created!
-   Your Okta Domain: https://dev-xxxxxxx.okta.com
-   ```
+      ```txt
+      New Okta Account created!
+      Your Okta Domain: https://dev-xxxxxxx.okta.com
+      ```
 
-1. Make a note of your Okta domain. Use it wherever you see `${yourOktaDomain}` in the lab.
+   1. Make a note of your Okta domain. Use it wherever `${yourOktaDomain}` appears in this guide.
 
-> **Note**: If you're using an existing org, check API Access Management is enabled: Open your Admin Console, go to **Security** > **API**, and verify an **Authorization Servers** tab is present. If not, you can:
+> **Note**: If you're using an existing org, verify that API Access Management is enabled: Open your Admin Console, go to **Security** > **API**, and verify that an **Authorization Servers** tab is present. If not, choose one of the following:
 >
 > * Create a developer account and org with Okta CLI.
 > * Contact your support team to enable the feature in your org.

--- a/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/index.md
@@ -47,7 +47,7 @@ Set up your developer account and [Okta org](/docs/concepts/okta-organizations/)
    https://dev-xxxxxxx.okta.com/welcome/xrqyNKPCZcvxL1ouKUoh
    ```
 
-1. Set the password for your org by opening the link and following the instructions. Your Okta domain is returned, similar to the following.
+1. Set the password for your org by opening the link and following the instructions. Your Okta domain is returned, similar to the following:
 
    ```txt
    New Okta Account created!
@@ -56,7 +56,7 @@ Set up your developer account and [Okta org](/docs/concepts/okta-organizations/)
 
 1. Make a note of your Okta domain. Use it wherever you see `${yourOktaDomain}` in the lab.
 
-> Note: If you're using an existing org, check API Access Management is enabled: Open your Admin Console, go to **Security** > **API**, and verify an **Authorization Servers** tab is present. If not, you can:
+> **Note**: If you're using an existing org, check API Access Management is enabled: Open your Admin Console, go to **Security** > **API**, and verify an **Authorization Servers** tab is present. If not, you can:
 >
 > * Create a developer account and org with Okta CLI.
 > * Contact your support team to enable the feature in your org.

--- a/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/index.md
@@ -30,12 +30,16 @@ A [custom authorization server](/docs/concepts/auth-servers/#custom-authorizatio
 
 ## Set up Okta
 
-Set up your [Okta org](/docs/concepts/okta-organizations/). The CLI is the quickest way to work with your Okta org, so we recommend using it for the first few steps. If you don't want to install the CLI, you can [manually sign up for an org](https://developer.okta.com/signup/) instead. We provide non-CLI instructions along with the CLI steps below.
+Set up your developer account and [Okta org](/docs/concepts/okta-organizations/). The Okta command-line interface (CLI) is the quickest way to do this. Alternatively, you can [manually sign up for a developer account](https://developer.okta.com/signup/).
 
-1. Install the Okta command-line interface: [Okta CLI](https://cli.okta.com/).
-2. If you don't already have a free Okta developer account, create one by entering `okta register` on the command line.
-3. Make a note of the Okta Domain as you need that later.
-4. **IMPORTANT:** Set the password for your Okta developer org by opening the link that's shown after your domain is registered. Look for output similar to this:
+1. Install [Okta CLI](https://cli.okta.com/).
+1. Open your terminal.
+1. Run `okta register`, and enter your first name, last name, email address, and country.
+1. Click or tap **Activate** in the account activation email that is sent to the email address that you gave.
+
+   > **Tip**: If you don't receive the confirmation email sent as part of the creation process, check your spam filters for an email from `noreply@okta.com`
+
+1. After your domain is registered, look for output similar to this:
 
    ```txt
    Your Okta Domain: https://dev-xxxxxxx.okta.com
@@ -43,13 +47,21 @@ Set up your [Okta org](/docs/concepts/okta-organizations/). The CLI is the quick
    https://dev-xxxxxxx.okta.com/welcome/xrqyNKPCZcvxL1ouKUoh
    ```
 
-   > **Note**: If you don't receive the confirmation email sent as part of the creation process, check your spam filters for an email from `noreply@okta.com`
+1. Set the password for your org by opening the link and following the instructions. Your Okta domain is returned, similar to the following.
 
-5. Connect to your Okta developer org if you didn't create one in the last step (successfully creating an Okta org also signs you in) by running the following command. You need the URL of your org &mdash; which is your [Okta domain](/docs/guides/find-your-domain/) with `https://` prepended &mdash; and an [API/access token](/docs/guides/create-an-api-token/):
-
-   ```bash
-   okta login
+   ```txt
+   New Okta Account created!
+   Your Okta Domain: https://dev-xxxxxxx.okta.com
    ```
+
+1. Make a note of your Okta domain. Use it wherever you see `${yourOktaDomain}` in the lab.
+
+> Note: If you're using an existing org, check API Access Management is enabled: Open your Admin Console, go to **Security** > **API**, and verify an **Authorization Servers** tab is present. If not, you can:
+>
+> * Create a developer account and org with Okta CLI.
+> * Contact your support team to enable the feature in your org.
+>
+> All accounts created with Okta CLI are developer accounts and have API Access Management enabled by default.
 
 ## Create a REST API
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/index.md
@@ -10,8 +10,6 @@ Add embedded authentication to your SPA app with Okta Auth JS.
 
 <ApiLifecycle access="ie" /><br>
 
-<StackSelector />
-
 <StackSnippet snippet="nutrition" />
 
 ## About using Okta Auth JS with your SPA app

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/index.md
@@ -55,6 +55,8 @@ Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-lin
 
    1. Make a note of your Okta domain. Use it wherever you see `${yourOktaDomain}` in the lab.
 
+1. Run `okta login` to connect to your org if you didn't create one in the last step (successfully creating an Okta org also signs you in). You need the URL of your org &mdash; which is your [Okta domain](/docs/guides/find-your-domain/) with `https://` prepended &mdash; and an [API/access token](/docs/guides/create-an-api-token/).
+
 > **Note**: If you're using an existing org and want to use Okta CLI, check API Access Management is enabled: Open your Admin Console, go to **Security** > **API**, and verify an **Authorization Servers** tab is present. If not, you can:
 >
 > * Create a developer account and org with Okta CLI.
@@ -62,8 +64,6 @@ Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-lin
 > * Use the Admin Console to create your app integrations instead of the CLI.
 >
 > All accounts created with Okta CLI are developer accounts.
-
-1. Run `okta login` to connect to your org if you didn't create one in the last step (successfully creating an Okta org also signs you in). You need the URL of your org &mdash; which is your [Okta domain](/docs/guides/find-your-domain/) with `https://` prepended &mdash; and an [API/access token](/docs/guides/create-an-api-token/).
 
 ## Create an Okta integration for your app
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/index.md
@@ -27,26 +27,43 @@ Add authentication using the Okta [redirect model](https://developer.okta.com/do
 
 ## Set up Okta
 
-Set up your [Okta org](/docs/concepts/okta-organizations/). The CLI is by far the quickest way to work with your Okta org, so we recommend using it for the first few steps. If you don't want to install the CLI, you can [manually sign up for an org](https://developer.okta.com/signup/) instead. We provide non-CLI instructions along with the CLI steps below.
+Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-line interface (CLI) is the quickest way to work with your Okta org, so we recommend using it for the first few steps. If you don't want to install the CLI, you can [manually sign up for an org](https://developer.okta.com/signup/) instead.
 
-1. Install the Okta command-line interface: [Okta CLI](https://cli.okta.com/).
-2. If you don't already have a free Okta developer account, create one by entering `okta register` on the command line.
-3. Make a note of the Okta Domain as you need that later.
-4. **IMPORTANT:** Set the password for your Okta developer org by opening the link that's shown after your domain is registered. Look for output similar to this:
+1. Install [Okta CLI](https://cli.okta.com/).
+1. If you don't already have a free Okta developer account:
+   1. Open your terminal.
+   {style="list-style-type:lower-alpha"}
+   1. Run `okta register`, and enter your first name, last name, email address, and country.
+   1. Click or tap **Activate** in the account activation email that is sent to the email address that you gave.
 
-   ```
-   Your Okta Domain: https://dev-xxxxxxx.okta.com
-   To set your password open this link:
-   https://dev-xxxxxxx.okta.com/welcome/xrqyNKPCZcvxL1ouKUoh
-   ```
+      > **Tip**: If you don't receive the confirmation email sent as part of the creation process, check your spam filters for an email from `noreply@okta.com`
 
-   > **Note**: If you don't receive the confirmation email sent as part of the creation process, check your spam filters for an email from `noreply@okta.com`.
+   1. After your domain is registered, look for output similar to this:
 
-5. Connect to your Okta developer org if you didn't create one in the last step (successfully creating an Okta org also signs you in) by running the following command. You need the URL of your org &mdash; which is your [Okta domain](/docs/guides/find-your-domain/) with `https://` prepended &mdash; and an [API/access token](/docs/guides/create-an-api-token/).
+      ```txt
+      Your Okta Domain: https://dev-xxxxxxx.okta.com
+      To set your password open this link:
+      https://dev-xxxxxxx.okta.com/welcome/xrqyNKPCZcvxL1ouKUoh
+      ```
 
-   ```
-   okta login
-   ```
+   1. Set the password for your org by opening the link and following the instructions. Your Okta domain is returned, similar to the following.
+
+      ```txt
+      New Okta Account created!
+      Your Okta Domain: https://dev-xxxxxxx.okta.com
+      ```
+
+   1. Make a note of your Okta domain. Use it wherever you see `${yourOktaDomain}` in the lab.
+
+> **Note**: If you're using an existing org and want to use Okta CLI, check API Access Management is enabled: Open your Admin Console, go to **Security** > **API**, and verify an **Authorization Servers** tab is present. If not, you can:
+>
+> * Create a developer account and org with Okta CLI.
+> * Contact your support team to enable the feature in your org.
+> * Use the Admin Console to create your app integrations instead of the CLI.
+>
+> All accounts created with Okta CLI are developer accounts.
+
+1. Run `okta login` to connect to your org if you didn't create one in the last step (successfully creating an Okta org also signs you in). You need the URL of your org &mdash; which is your [Okta domain](/docs/guides/find-your-domain/) with `https://` prepended &mdash; and an [API/access token](/docs/guides/create-an-api-token/).
 
 ## Create an Okta integration for your app
 
@@ -56,9 +73,11 @@ To create your app integration in Okta using the CLI:
 
 1. Create the app integration by running:
 
-   ```
+   ```bash
    okta apps create native
    ```
+
+   > **Tip**: If Okta CLI returns an error "Your Okta Org is missing a feature required to use the Okta CLI: API Access Management," you are not using an Okta developer account. To resolve this, see [Set up Okta](#set-up-okta).
 
 2. Enter **Quickstart** when prompted for the app name.
 3. Specify the required redirect URI values:

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/index.md
@@ -27,7 +27,7 @@ Add authentication using the Okta [redirect model](https://developer.okta.com/do
 
 ## Set up Okta
 
-Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-line interface (CLI) is the quickest way to work with your Okta org, so we recommend using it for the first few steps. If you don't want to install the CLI, you can [manually sign up for an org](https://developer.okta.com/signup/) instead.
+Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-line interface (CLI) is the quickest way to do this. If you don't want to install the CLI, you can [manually sign up for an org](https://developer.okta.com/signup/) instead.
 
 1. Install [Okta CLI](https://cli.okta.com/).
 1. If you don't already have a free Okta developer account:
@@ -38,7 +38,7 @@ Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-lin
 
       > **Tip**: If you don't receive the confirmation email sent as part of the creation process, check your spam filters for an email from `noreply@okta.com`
 
-   1. After your domain is registered, look for output similar to this:
+   1. Find your new domain and a link to set your password in the email:
 
       ```txt
       Your Okta Domain: https://dev-xxxxxxx.okta.com
@@ -46,18 +46,18 @@ Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-lin
       https://dev-xxxxxxx.okta.com/welcome/xrqyNKPCZcvxL1ouKUoh
       ```
 
-   1. Set the password for your org by opening the link and following the instructions. Your Okta domain is returned, similar to the following.
+   1. Set the password for your org by opening the link and following the instructions. Your Okta domain is returned, similar to the following:
 
       ```txt
       New Okta Account created!
       Your Okta Domain: https://dev-xxxxxxx.okta.com
       ```
 
-   1. Make a note of your Okta domain. Use it wherever you see `${yourOktaDomain}` in the lab.
+   1. Make a note of your Okta domain. Use it wherever `${yourOktaDomain}` appears in this guide.
 
-1. Run `okta login` to connect to your org if you didn't create one in the last step (successfully creating an Okta org also signs you in). You need the URL of your org &mdash; which is your [Okta domain](/docs/guides/find-your-domain/) with `https://` prepended &mdash; and an [API/access token](/docs/guides/create-an-api-token/).
+1. Run `okta login` to connect to your org if you didn't create one in the previous step (successfully creating an Okta org also signs you in). You need the URL of your org, which is `https://` followed by your [Okta domain](/docs/guides/find-your-domain/), and an [API/access token](/docs/guides/create-an-api-token/).
 
-> **Note**: If you're using an existing org and want to use Okta CLI, check API Access Management is enabled: Open your Admin Console, go to **Security** > **API**, and verify an **Authorization Servers** tab is present. If not, you can:
+> **Note**: If you're using an existing org, verify that API Access Management is enabled: Open your Admin Console, go to **Security** > **API**, and verify that an **Authorization Servers** tab is present. If not, choose one of the following:
 >
 > * Create a developer account and org with Okta CLI.
 > * Contact your support team to enable the feature in your org.
@@ -77,7 +77,7 @@ To create your app integration in Okta using the CLI:
    okta apps create native
    ```
 
-   > **Tip**: If Okta CLI returns an error "Your Okta Org is missing a feature required to use the Okta CLI: API Access Management," you are not using an Okta developer account. To resolve this, see [Set up Okta](#set-up-okta).
+   > **Tip**: If Okta CLI returns the error "Your Okta Org is missing a feature required to use the Okta CLI: API Access Management," you're not using an Okta developer account. To resolve this, see [Set up Okta](#set-up-okta).
 
 2. Enter **Quickstart** when prompted for the app name.
 3. Specify the required redirect URI values:

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/index.md
@@ -28,7 +28,7 @@ Add authentication with Okta's [redirect model](https://developer.okta.com/docs/
 
 ## Set up Okta
 
-Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-line interface (CLI) is the quickest way to work with your Okta org, so we recommend using it for the first few steps. If you don't want to install the CLI, you can [manually sign up for an org](https://developer.okta.com/signup/) instead.
+Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-line interface (CLI) is the quickest way to do this. If you don't want to install the CLI, you can [manually sign up for an org](https://developer.okta.com/signup/) instead.
 
 1. Install [Okta CLI](https://cli.okta.com/).
 1. If you don't already have a free Okta developer account:
@@ -39,7 +39,7 @@ Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-lin
 
       > **Tip**: If you don't receive the confirmation email sent as part of the creation process, check your spam filters for an email from `noreply@okta.com`
 
-   1. After your domain is registered, look for output similar to this:
+   1. Find your new domain and a link to set your password in the email:
 
       ```txt
       Your Okta Domain: https://dev-xxxxxxx.okta.com
@@ -47,18 +47,18 @@ Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-lin
       https://dev-xxxxxxx.okta.com/welcome/xrqyNKPCZcvxL1ouKUoh
       ```
 
-   1. Set the password for your org by opening the link and following the instructions. Your Okta domain is returned, similar to the following.
+   1. Set the password for your org by opening the link and following the instructions. Your Okta domain is returned, similar to the following:
 
       ```txt
       New Okta Account created!
       Your Okta Domain: https://dev-xxxxxxx.okta.com
       ```
 
-   1. Make a note of your Okta domain. Use it wherever you see `${yourOktaDomain}` in the lab.
+   1. Make a note of your Okta domain. Use it wherever `${yourOktaDomain}` appears in this guide.
 
-1. Run `okta login` to connect to your org if you didn't create one in the last step (successfully creating an Okta org also signs you in). You need the URL of your org &mdash; which is your [Okta domain](/docs/guides/find-your-domain/) with `https://` prepended &mdash; and an [API/access token](/docs/guides/create-an-api-token/).
+1. Run `okta login` to connect to your org if you didn't create one in the last step (successfully creating an Okta org also signs you in). You need the URL of your org, which is `https://` followed by your [Okta domain](/docs/guides/find-your-domain/), and an [API/access token](/docs/guides/create-an-api-token/).
 
-> **Note**: If you're using an existing org and want to use Okta CLI, check API Access Management is enabled: Open your Admin Console, go to **Security** > **API**, and verify an **Authorization Servers** tab is present. If not, you can:
+> **Note**: If you're using an existing org, verify that API Access Management is enabled: Open your Admin Console, go to **Security** > **API**, and verify that an **Authorization Servers** tab is present. If not, choose one of the following:
 >
 > * Create a developer account and org with Okta CLI.
 > * Contact your support team to enable the feature in your org.
@@ -78,7 +78,7 @@ To create your app integration in Okta using the CLI:
    okta apps create spa
    ```
 
-   > **Tip**: If Okta CLI returns an error "Your Okta Org is missing a feature required to use the Okta CLI: API Access Management," you are not using an Okta developer account. To resolve this, see [Set up Okta](#set-up-okta).
+   > **Tip**: If Okta CLI returns the error "Your Okta Org is missing a feature required to use the Okta CLI: API Access Management," you're not using an Okta developer account. To resolve this, see [Set up Okta](#set-up-okta).
 
 2. Enter **Quickstart** when prompted for the app name.
 3. Specify the required redirect URI values:

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/index.md
@@ -56,6 +56,8 @@ Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-lin
 
    1. Make a note of your Okta domain. Use it wherever you see `${yourOktaDomain}` in the lab.
 
+1. Run `okta login` to connect to your org if you didn't create one in the last step (successfully creating an Okta org also signs you in). You need the URL of your org &mdash; which is your [Okta domain](/docs/guides/find-your-domain/) with `https://` prepended &mdash; and an [API/access token](/docs/guides/create-an-api-token/).
+
 > **Note**: If you're using an existing org and want to use Okta CLI, check API Access Management is enabled: Open your Admin Console, go to **Security** > **API**, and verify an **Authorization Servers** tab is present. If not, you can:
 >
 > * Create a developer account and org with Okta CLI.
@@ -63,8 +65,6 @@ Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-lin
 > * Use the Admin Console to create your app integrations instead of the CLI.
 >
 > All accounts created with Okta CLI are developer accounts.
-
-1. Run `okta login` to connect to your org if you didn't create one in the last step (successfully creating an Okta org also signs you in). You need the URL of your org &mdash; which is your [Okta domain](/docs/guides/find-your-domain/) with `https://` prepended &mdash; and an [API/access token](/docs/guides/create-an-api-token/).
 
 ## Create an Okta integration for your app
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/index.md
@@ -28,26 +28,43 @@ Add authentication with Okta's [redirect model](https://developer.okta.com/docs/
 
 ## Set up Okta
 
-Set up your [Okta org](/docs/concepts/okta-organizations/). The CLI is the quickest way to work with your Okta org, so we recommend using it for the first few steps. If you don't want to install the CLI, you can [manually sign up for an org](https://developer.okta.com/signup/) instead. We provide non-CLI instructions along with the CLI steps below.
+Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-line interface (CLI) is the quickest way to work with your Okta org, so we recommend using it for the first few steps. If you don't want to install the CLI, you can [manually sign up for an org](https://developer.okta.com/signup/) instead.
 
-1. Install the Okta command-line interface: [Okta CLI](https://cli.okta.com/).
-2. If you don't already have a free Okta developer account, create one by entering `okta register` on the command line.
-3. Make a note of the Okta Domain as you need that later.
-4. **IMPORTANT:** Set the password for your Okta developer org by opening the link that's shown after your domain is registered. Look for output similar to this:
+1. Install [Okta CLI](https://cli.okta.com/).
+1. If you don't already have a free Okta developer account:
+   1. Open your terminal.
+   {style="list-style-type:lower-alpha"}
+   1. Run `okta register`, and enter your first name, last name, email address, and country.
+   1. Click or tap **Activate** in the account activation email that is sent to the email address that you gave.
 
-   ```
-   Your Okta Domain: https://dev-xxxxxxx.okta.com
-   To set your password open this link:
-   https://dev-xxxxxxx.okta.com/welcome/xrqyNKPCZcvxL1ouKUoh
-   ```
+      > **Tip**: If you don't receive the confirmation email sent as part of the creation process, check your spam filters for an email from `noreply@okta.com`
 
-   > **Note**: If you don't receive the confirmation email sent as part of the creation process, check your spam filters for an email from `noreply@okta.com`
+   1. After your domain is registered, look for output similar to this:
 
-5. Connect to your Okta developer org if you didn't create one in the last step (successfully creating an Okta org also signs you in) by running the following command. You need the URL of your org &mdash; which is your [Okta domain](/docs/guides/find-your-domain/) with `https://` prepended &mdash; and an [API/access token](/docs/guides/create-an-api-token/):
+      ```txt
+      Your Okta Domain: https://dev-xxxxxxx.okta.com
+      To set your password open this link:
+      https://dev-xxxxxxx.okta.com/welcome/xrqyNKPCZcvxL1ouKUoh
+      ```
 
-   ```
-   okta login
-   ```
+   1. Set the password for your org by opening the link and following the instructions. Your Okta domain is returned, similar to the following.
+
+      ```txt
+      New Okta Account created!
+      Your Okta Domain: https://dev-xxxxxxx.okta.com
+      ```
+
+   1. Make a note of your Okta domain. Use it wherever you see `${yourOktaDomain}` in the lab.
+
+> **Note**: If you're using an existing org and want to use Okta CLI, check API Access Management is enabled: Open your Admin Console, go to **Security** > **API**, and verify an **Authorization Servers** tab is present. If not, you can:
+>
+> * Create a developer account and org with Okta CLI.
+> * Contact your support team to enable the feature in your org.
+> * Use the Admin Console to create your app integrations instead of the CLI.
+>
+> All accounts created with Okta CLI are developer accounts.
+
+1. Run `okta login` to connect to your org if you didn't create one in the last step (successfully creating an Okta org also signs you in). You need the URL of your org &mdash; which is your [Okta domain](/docs/guides/find-your-domain/) with `https://` prepended &mdash; and an [API/access token](/docs/guides/create-an-api-token/).
 
 ## Create an Okta integration for your app
 
@@ -57,9 +74,11 @@ To create your app integration in Okta using the CLI:
 
 1. Create the app integration by running:
 
-   ```
+   ```bash
    okta apps create spa
    ```
+
+   > **Tip**: If Okta CLI returns an error "Your Okta Org is missing a feature required to use the Okta CLI: API Access Management," you are not using an Okta developer account. To resolve this, see [Set up Okta](#set-up-okta).
 
 2. Enter **Quickstart** when prompted for the app name.
 3. Specify the required redirect URI values:

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app-redirect/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app-redirect/main/index.md
@@ -24,7 +24,7 @@ Add authentication with Okta's [redirect model](https://developer.okta.com/docs/
 
 ## Set up Okta
 
-Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-line interface (CLI) is the quickest way to work with your Okta org, so we recommend using it for the first few steps. If you don't want to install the CLI, you can [manually sign up for an org](https://developer.okta.com/signup/) instead.
+Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-line interface (CLI) is the quickest way to do this. If you don't want to install the CLI, you can [manually sign up for an org](https://developer.okta.com/signup/) instead.
 
 1. Install [Okta CLI](https://cli.okta.com/).
 1. If you don't already have a free Okta developer account:
@@ -35,7 +35,7 @@ Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-lin
 
       > **Tip**: If you don't receive the confirmation email sent as part of the creation process, check your spam filters for an email from `noreply@okta.com`
 
-   1. After your domain is registered, look for output similar to this:
+   1. Find your new domain and a link to set your password in the email:
 
       ```txt
       Your Okta Domain: https://dev-xxxxxxx.okta.com
@@ -43,18 +43,18 @@ Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-lin
       https://dev-xxxxxxx.okta.com/welcome/xrqyNKPCZcvxL1ouKUoh
       ```
 
-   1. Set the password for your org by opening the link and following the instructions. Your Okta domain is returned, similar to the following.
+   1. Set the password for your org by opening the link and following the instructions. Your Okta domain is returned, similar to the following:
 
       ```txt
       New Okta Account created!
       Your Okta Domain: https://dev-xxxxxxx.okta.com
       ```
 
-   1. Make a note of your Okta domain. Use it wherever you see `${yourOktaDomain}` in the lab.
+   1. Make a note of your Okta domain. Use it wherever `${yourOktaDomain}` appears in this guide.
 
-1. Run `okta login` to connect to your org if you didn't create one in the last step (successfully creating an Okta org also signs you in). You need the URL of your org &mdash; which is your [Okta domain](/docs/guides/find-your-domain/) with `https://` prepended &mdash; and an [API/access token](/docs/guides/create-an-api-token/).
+1. Run `okta login` to connect to your org if you didn't create one in the last step (successfully creating an Okta org also signs you in). You need the URL of your org, which is `https://` followed by your [Okta domain](/docs/guides/find-your-domain/), and an [API/access token](/docs/guides/create-an-api-token/).
 
-> **Note**: If you're using an existing org and want to use Okta CLI, check API Access Management is enabled: Open your Admin Console, go to **Security** > **API**, and verify an **Authorization Servers** tab is present. If not, you can:
+> **Note**: If you're using an existing org, verify that API Access Management is enabled: Open your Admin Console, go to **Security** > **API**, and verify that an **Authorization Servers** tab is present. If not, choose one of the following:
 >
 > * Create a developer account and org with Okta CLI.
 > * Contact your support team to enable the feature in your org.
@@ -74,7 +74,7 @@ To create your app integration in Okta using the CLI:
    okta apps create web
    ```
 
-   > **Tip**: If Okta CLI returns an error "Your Okta Org is missing a feature required to use the Okta CLI: API Access Management," you are not using an Okta developer account. To resolve this, see [Set up Okta](#set-up-okta).
+   > **Tip**: If Okta CLI returns the error "Your Okta Org is missing a feature required to use the Okta CLI: API Access Management," you're not using an Okta developer account. To resolve this, see [Set up Okta](#set-up-okta).
 
 2. Enter **Quickstart** when prompted for the app name.
 3. Specify the required Redirect URI values:

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app-redirect/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app-redirect/main/index.md
@@ -24,26 +24,43 @@ Add authentication with Okta's [redirect model](https://developer.okta.com/docs/
 
 ## Set up Okta
 
-Set up your [Okta org](/docs/concepts/okta-organizations/). The CLI is the quickest way to work with your Okta org, so we recommend using it for the first few steps. If you don't want to install the CLI, you can [manually sign up for an org](https://developer.okta.com/signup/) instead. We provide non-CLI instructions along with the CLI steps below.
+Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-line interface (CLI) is the quickest way to work with your Okta org, so we recommend using it for the first few steps. If you don't want to install the CLI, you can [manually sign up for an org](https://developer.okta.com/signup/) instead.
 
-1. Install the Okta command-line interface: [Okta CLI](https://cli.okta.com/).
-2. If you don't already have a free Okta developer account, create one by entering `okta register` on the command line.
-3. Make a note of the Okta Domain as you need that later.
-4. **IMPORTANT:** Set the password for your Okta developer org by opening the link that's shown after your domain is registered. Look for output similar to this:
+1. Install [Okta CLI](https://cli.okta.com/).
+1. If you don't already have a free Okta developer account:
+   1. Open your terminal.
+   {style="list-style-type:lower-alpha"}
+   1. Run `okta register`, and enter your first name, last name, email address, and country.
+   1. Click or tap **Activate** in the account activation email that is sent to the email address that you gave.
 
-   ``` bash
-   Your Okta Domain: https://dev-xxxxxxx.okta.com
-   To set your password open this link:
-   https://dev-xxxxxxx.okta.com/welcome/xrqyNKPCZcvxL1ouKUoh
-   ```
+      > **Tip**: If you don't receive the confirmation email sent as part of the creation process, check your spam filters for an email from `noreply@okta.com`
 
-   > **Note**: If you don't receive the confirmation email sent as part of the creation process, check your spam filters for an email from `noreply@okta.com`.
+   1. After your domain is registered, look for output similar to this:
 
-5. Connect to your Okta developer org if you didn't create one in the last step (successfully creating an Okta org also signs you in) by running the following command. You need the URL of your org &mdash; which is your [Okta domain](/docs/guides/find-your-domain/) with `https://` prepended &mdash; and an [API/access token](/docs/guides/create-an-api-token/).
+      ```txt
+      Your Okta Domain: https://dev-xxxxxxx.okta.com
+      To set your password open this link:
+      https://dev-xxxxxxx.okta.com/welcome/xrqyNKPCZcvxL1ouKUoh
+      ```
 
-   ``` bash
-   okta login
-   ```
+   1. Set the password for your org by opening the link and following the instructions. Your Okta domain is returned, similar to the following.
+
+      ```txt
+      New Okta Account created!
+      Your Okta Domain: https://dev-xxxxxxx.okta.com
+      ```
+
+   1. Make a note of your Okta domain. Use it wherever you see `${yourOktaDomain}` in the lab.
+
+> **Note**: If you're using an existing org and want to use Okta CLI, check API Access Management is enabled: Open your Admin Console, go to **Security** > **API**, and verify an **Authorization Servers** tab is present. If not, you can:
+>
+> * Create a developer account and org with Okta CLI.
+> * Contact your support team to enable the feature in your org.
+> * Use the Admin Console to create your app integrations instead of the CLI.
+>
+> All accounts created with Okta CLI are developer accounts.
+
+1. Run `okta login` to connect to your org if you didn't create one in the last step (successfully creating an Okta org also signs you in). You need the URL of your org &mdash; which is your [Okta domain](/docs/guides/find-your-domain/) with `https://` prepended &mdash; and an [API/access token](/docs/guides/create-an-api-token/).
 
 ## Create an Okta integration for your app
 
@@ -56,6 +73,8 @@ To create your app integration in Okta using the CLI:
    ``` bash
    okta apps create web
    ```
+
+   > **Tip**: If Okta CLI returns an error "Your Okta Org is missing a feature required to use the Okta CLI: API Access Management," you are not using an Okta developer account. To resolve this, see [Set up Okta](#set-up-okta).
 
 2. Enter **Quickstart** when prompted for the app name.
 3. Specify the required Redirect URI values:

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-web-app-redirect/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-web-app-redirect/main/index.md
@@ -52,6 +52,8 @@ Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-lin
 
    1. Make a note of your Okta domain. Use it wherever you see `${yourOktaDomain}` in the lab.
 
+1. Run `okta login` to connect to your org if you didn't create one in the last step (successfully creating an Okta org also signs you in). You need the URL of your org &mdash; which is your [Okta domain](/docs/guides/find-your-domain/) with `https://` prepended &mdash; and an [API/access token](/docs/guides/create-an-api-token/).
+
 > **Note**: If you're using an existing org and want to use Okta CLI, check API Access Management is enabled: Open your Admin Console, go to **Security** > **API**, and verify an **Authorization Servers** tab is present. If not, you can:
 >
 > * Create a developer account and org with Okta CLI.
@@ -59,8 +61,6 @@ Set up your [Okta org](/docs/concepts/okta-organizations/). The Okta command-lin
 > * Use the Admin Console to create your app integrations instead of the CLI.
 >
 > All accounts created with Okta CLI are developer accounts.
-
-1. Run `okta login` to connect to your org if you didn't create one in the last step (successfully creating an Okta org also signs you in). You need the URL of your org &mdash; which is your [Okta domain](/docs/guides/find-your-domain/) with `https://` prepended &mdash; and an [API/access token](/docs/guides/create-an-api-token/).
 
 ## Create an Okta integration for your app
 


### PR DESCRIPTION
## Description:
- **What's changed?**
- Added warnings to quickstarts that Okta CLI will not work unless developer edition orgs or orgs with API AM enabled are being used. 
- Also deleted a duplicate stackselector I spotted in a quickstart.

- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-516673](https://oktainc.atlassian.net/browse/OKTA-516673)
* [OKTA-441211](https://oktainc.atlassian.net/browse/OKTA-441211)

Preview at: https://645119d0e0b9430e3a28a535--reverent-murdock-829d24.netlify.app/docs/guides/sign-into-web-app-redirect/asp-net-core-3/main/
