### PR TITLE
OKTA-604559 Add application type to SAML 2.0 Assertion grant type

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/saml2assert/setup-app.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/saml2assert/setup-app.md
@@ -6,8 +6,8 @@
 
     > **Note:** The refresh token lifetime depends on the assertion lifetime and the [API Access Management policies](#configure-the-authorization-server-policy). The lowest of both of these defined values is the refresh token max lifetime.
 
-8. Click **Save**.
-9. On the **General** tab, make note of the **Client ID** and **Client secret** listed in the **Client Credentials** section. You need these credentials in the SAML 2.0 Assertion [flow specifics](#flow-specifics) section.
+9. Click **Save**.
+10. On the **General** tab, make note of the **Client ID** and **Client secret** listed in the **Client Credentials** section. You need these credentials in the SAML 2.0 Assertion [flow specifics](#flow-specifics) section.
 
 > **Note:** You can use either an existing OpenID Connect app integration or create a new one. In the previous instruction, we are creating a Native app using the Admin Console. You must use the [Dynamic Client Registration API](/docs/reference/api/oauth-clients/#client-application-object) to create a SPA or Web client application for use with the SAML 2.0 Assertion grant type.
 

--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/saml2assert/setup-app.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/saml2assert/setup-app.md
@@ -1,7 +1,8 @@
-4. Enter a name for your app integration. In the **Sign-in redirect URIs** box, specify the callback location where Okta returns the browser (along with the token).
-5. Click **Save** to create the app.
-6. On the **General** tab that appears, scroll to the **General Settings** section and click **Edit**.
-7. Select **Refresh Token** and **SAML 2.0 Assertion** as the **Allowed grant types**. These selections enable you to exchange an assertion for the access token and also request a refresh token.
+4. Select **Native Application** as the **Application type**, then click **Next**.
+5. Enter a name for your app integration. In the **Sign-in redirect URIs** box, specify the callback location where Okta returns the browser (along with the token).
+6. Click **Save** to create the app.
+7. On the **General** tab that appears, scroll to the **General Settings** section and click **Edit**.
+8. Select **Refresh Token** and **SAML 2.0 Assertion** as the **Allowed grant types**. These selections enable you to exchange an assertion for the access token and also request a refresh token.
 
     > **Note:** The refresh token lifetime depends on the assertion lifetime and the [API Access Management policies](#configure-the-authorization-server-policy). The lowest of both of these defined values is the refresh token max lifetime.
 


### PR DESCRIPTION
## Description:
- **What's changed?** Add step for selecting application type to Implement the "SAML 2.0 Assertion" grant type. This is a doc gap identified by identity-engine-ciam channel.
- **Is this PR related to a Monolith release?**No

### Preview:
https://645e4fc9ee19a40067a1f7b8--reverent-murdock-829d24.netlify.app/docs/guides/implement-grant-type/saml2assert/main/#grant-type-flow

### Resolves:

* [OKTA-604559](https://oktainc.atlassian.net/browse/OKTA-604559)
