### PR TITLE
OKTA-610870 Deprecate the Mappings API

### DIFF
--- a/packages/@okta/vuepress-site/docs/concepts/user-profiles/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/user-profiles/index.md
@@ -33,7 +33,7 @@ In addition to storing user profiles and app user profiles, the Universal Direct
 
 See also [About attribute mappings](https://help.okta.com/okta_help.htm?id=ext-usgp-about-attribute-mappings)
 
-You can manage the Universal Directory mappings between profiles using the Admin Console or the [Mappings API](/docs/reference/api/mappings/).
+You can manage the Universal Directory mappings between profiles using the Admin Console or the [Profile Mappings API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/ProfileMapping/).
 
 ## User Profile types
 

--- a/packages/@okta/vuepress-site/docs/guides/secure-oauth-between-orgs/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/secure-oauth-between-orgs/main/index.md
@@ -228,7 +228,7 @@ curl -X POST \
 }' "https://${yourSpokeOrgDomain}/api/v1/apps/${yourOrg2OrgAppId}/connections/default?activate=TRUE"
 ```
 
-> **Note**: After you enable provisioning, if you want to enable app features or edit Org2Org attribute mappings, you can use the [App features operation](/docs/reference/api/apps/#list-features-for-application) and the [Mappings API](/docs/reference/api/mappings/). Alternatively, you can go to the Org2Org app **Provisioning** > **To App** settings from the Okta Admin Console and edit the **Provisioning To App** or the **Okta Org2Org Attribute Mappings** sections.
+> **Note**: After you enable provisioning, if you want to enable app features or edit Org2Org attribute mappings, you can use the [App features operation](/docs/reference/api/apps/#list-features-for-application) and the [Profile Mappings API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/ProfileMapping/). Alternatively, you can go to the Org2Org app **Provisioning** > **To App** settings from the Okta Admin Console and edit the **Provisioning To App** or the **Okta Org2Org Attribute Mappings** sections.
 
 ### Assign users and groups in the Org2Org app
 

--- a/packages/@okta/vuepress-site/docs/reference/api/mappings/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/mappings/index.md
@@ -5,7 +5,7 @@ category: management
 
 # Mappings API
 
-The Mappings API reference is now available at the new [Okta API reference portal](/docs/api/openapi/okta-management/management/tag/ProfileMapping/) as Profile Mappings.
+The Mappings API reference is now available at the new [Okta API reference portal](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/ProfileMapping/) as Profile Mappings.
 
 Explore the [Okta Public API Collections](https://www.postman.com/okta-eng/workspace/okta-public-api-collections/overview) workspace to get started with the Profile Mappings API Postman collection.
 

--- a/packages/@okta/vuepress-site/docs/reference/api/mappings/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/mappings/index.md
@@ -5,6 +5,12 @@ category: management
 
 # Mappings API
 
+The Mappings API reference is now available at the new [Okta API reference portal](/docs/api/openapi/okta-management/management/tag/ProfileMapping/) as Profile Mappings.
+
+Explore the [Okta Public API Collections](https://www.postman.com/okta-eng/workspace/okta-public-api-collections/overview) workspace to get started with the Profile Mappings API Postman collection.
+
+<!--
+
 The Okta Mappings API provides operations to manage the mapping of properties between an Okta User's and an App User's
 [Profile properties](/docs/reference/api/users/#profile-object) using [Okta Expression Language](/docs/reference/okta-expression-language).
 More information on Okta User and App User Profiles can be found in
@@ -528,3 +534,4 @@ Consists of a target property, in String form, that maps to a valid [JSON Schema
 | pushStatus  | Indicates whether to update target properties on user create and update or just on create | `DONT_PUSH` or `PUSH`         | FALSE    | FALSE  | FALSE    |           |
 
 > **Note:** Having a pushStatus of `PUSH` causes properties in the target to be updated on create and update. Having a pushStatus of `DONT_PUSH` causes properties in the target to be updated only on create.
+-->

--- a/packages/@okta/vuepress-site/docs/reference/api/uischema/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/uischema/index.md
@@ -5,7 +5,12 @@ category: management
 
 # UI Schema API
 
-<ApiLifecycle access="ie" />
+The UI Schema API reference is now available at the new [Okta API reference portal](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/UISchema/).
+
+Explore the [Okta Public API Collections](https://www.postman.com/okta-eng/workspace/okta-public-api-collections/overview) workspace to get started with the UI Schema API Postman collection.
+
+<!--
+<<ApiLifecycle access="ie" />
 
 The Okta UI Schema API allows you to control how inputs appear on an enrollment form.
 
@@ -746,3 +751,4 @@ The UI Schema Element Options object specifies how the input appears. The suppor
   "format": "select"
 }
 ```
+-->

--- a/packages/@okta/vuepress-site/docs/release-notes/2021/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2021/index.md
@@ -79,7 +79,7 @@ The Upload Logo for Org endpoint (`/org/logo`) is deprecated. Use the [Upload Th
 
 #### User Types API and Mappings API support OAuth 2.0
 
-The [User Types API](/docs/reference/api/user-types/) and [Mappings API](/docs/reference/api/mappings/) have been updated to support OAuth 2.0. You can grant access to the User Types API by using the `okta.userTypes.manage` and `okta.userTypes.read` scopes. You can grant access to the Mappings API by using the `okta.profileMappings.manage` and `okta.profileMappings.read scopes`. See [Scopes and supported endpoints](/docs/guides/implement-oauth-for-okta/main/#scopes-and-supported-endpoints). <!--OKTA-436385-->
+The [User Types API](/docs/reference/api/user-types/) and [Profile Mappings API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/ProfileMapping/) have been updated to support OAuth 2.0. You can grant access to the User Types API by using the `okta.userTypes.manage` and `okta.userTypes.read` scopes. You can grant access to the Mappings API by using the `okta.profileMappings.manage` and `okta.profileMappings.read scopes`. See [Scopes and supported endpoints](/docs/guides/implement-oauth-for-okta/main/#scopes-and-supported-endpoints). <!--OKTA-436385-->
 
 #### Bugs fixed in 2021.12.0
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** As per our ongoing Redocly migration, deprecating the [Mappings API](https://developer.okta.com/docs/reference/api/mappings/) on VuePress to point to the Redocly version: [Profile Mappings](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/ProfileMapping/).
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-610870](https://oktainc.atlassian.net/browse/OKTA-610870)
