### PR TITLE
Remove the restriction that passing Context object only applies to trusted web applications

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
@@ -70,8 +70,8 @@ As part of the authentication call either the username and password or the token
 | Parameter                                      | Description                                                                                                      | Param Type | DataType                          | Required | MaxLength |
 |------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------|:-----------|:----------------------------------|:---------|:----------|
 | audience <ApiLifecycle access="deprecated" />  | App ID of the target app the user is signing into                                                                | Body       | String                            | FALSE    |           |
-| context                                        | Provides additional context for the authentication transaction                                                   | Body       | [Context object](#context-object) | FALSE    |           |
 | options                                        | Opt-in features for the authentication transaction                                                               | Body       | [Options object](#options-object) | FALSE    |           |
+| context                                        | Provides additional context for the authentication transaction                                                   | Body       | [Context object](#context-object) | FALSE    |           |
 | password                                       | User's password credential                                                                                       | Body       | String                            | FALSE    |           |
 | token                                          | Token received as part of activation user request                                                                | Body       | String                            | FALSE    |           |
 | username                                       | User's non-qualified short-name (for example: dade.murphy) or unique fully-qualified sign in name (for example: dade.murphy@example.com) | Body       | String                            | FALSE    |           |
@@ -87,9 +87,7 @@ The authentication transaction [state machine](#transaction-state) can be modifi
 
 ##### Context object
 
-The context object allows [trusted web applications](#trusted-application) such as an external portal to pass additional context for the authentication or recovery transaction.
-
-> **Note:** Overriding context such as `deviceToken` is a highly privileged operation limited to trusted web applications and requires making authentication or recovery requests with a valid *administrator API token*. If an API token is not provided, the `deviceToken` will be ignored.
+The context object allows applications, such as an external portal, to pass additional context for the authentication or recovery transaction.
 
 > **Caution:** The `deviceToken` parameter isn't shared between the Authentication API and the Okta Identity Engine-specific APIs. See [Upgrade to Okta Identity Engine](https://developer.okta.com/docs/guides/oie-upgrade-overview/main/).
 
@@ -568,7 +566,6 @@ Authenticates a user through a [trusted application](#trusted-application) or pr
 
 **Notes:**
 
-* Specifying your own `deviceToken` is a highly privileged operation limited to trusted web applications and requires making authentication requests with a valid *API token*. If an API token is not provided, the `deviceToken` will be ignored.
 * The **public IP address** of your [trusted application](#trusted-application) must be [allowed as a gateway IP address](/docs/reference/core-okta-api/#ip-address) to forward the user agent's original IP address with the `X-Forwarded-For` HTTP header.
 
 ##### Request example for trusted application
@@ -624,7 +621,6 @@ Authenticates a user through a [trusted application](#trusted-application) or pr
 
 **Notes:**
 
-* Specifying your own `deviceToken` is a highly privileged operation limited to trusted web applications and requires making authentication requests with a valid *API token*. If an API token is not provided, the `deviceToken` is ignored.
 * The **public IP address** of your [trusted application](#trusted-application) must be [allowed as a gateway IP address](/docs/reference/core-okta-api/#ip-address) to forward the user agent's original IP address with the `X-Forwarded-For` HTTP header.
 * The ```Authorization: SSWS ${api_token}``` header is optional, in case of a SPA (Single Page app) this header can be omitted.
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
-- Remove the restriction that passing Context object only applies to trusted web applications (Remove the blue parts)
<img width="905" alt="Screenshot 2023-06-01 at 1 45 02 PM" src="https://github.com/okta/okta-developer-docs/assets/90656320/ac269db2-4849-4ea7-b3c2-0bf04cf1af60">
<img width="921" alt="Screenshot 2023-06-01 at 1 45 24 PM" src="https://github.com/okta/okta-developer-docs/assets/90656320/5e17c688-3176-4bd9-9902-d8bea28b6064">
<img width="909" alt="Screenshot 2023-06-01 at 1 45 32 PM" src="https://github.com/okta/okta-developer-docs/assets/90656320/89feaac5-f0ab-4022-9e23-02da4afb517a">

-- Reverse the order for context and options parameters to keep the order consistent (Reverse the red part)
<img width="894" alt="Screenshot 2023-06-01 at 1 47 56 PM" src="https://github.com/okta/okta-developer-docs/assets/90656320/9ae50a04-c127-4885-bdf4-8fac830528f5">

- **Is this PR related to a Monolith release?** <!-- If so, which one? -->
-- No

### Resolves:

* [OKTA-615259](https://oktainc.atlassian.net/browse/OKTA-615259)
