### PR TITLE
OKTA-620520 - Event Hook update on lag

### DIFF
--- a/packages/@okta/vuepress-site/docs/concepts/event-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/event-hooks/index.md
@@ -65,7 +65,7 @@ Okta delivers events on a best-effort basis. Events are delivered at least once.
 
 There is no guarantee of maximum delay between event occurrence and delivery.
 
-> **Note:** Don't contact Okta support for event hook calls that are delayed for less than 60 minutes. In most cases, these delays are resolved before that time.
+> **Note:** Contact Okta support only if you're seeing event hook call delays greater than 60 minutes. In most cases, these delays are resolved before that time.
 
 ### Timeout and retry
 

--- a/packages/@okta/vuepress-site/docs/concepts/event-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/event-hooks/index.md
@@ -65,6 +65,8 @@ Okta delivers events on a best-effort basis. Events are delivered at least once.
 
 There is no guarantee of maximum delay between event occurrence and delivery.
 
+> **Note:** Don't contact Okta support for event hook calls that are delayed for less than 60 minutes. In most cases, these delays are resolved before that time.
+
 ### Timeout and retry
 
 When Okta calls your external service, it enforces a default timeout of 3 seconds. Okta attempts at most one retry. Responses with a 4xx status code aren't retried.


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** As per team, added a note to the Event Hook concept to only contact support for event hook calls delayed over sixty minutes
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* [OKTA-620520](https://oktainc.atlassian.net/browse/OKTA-620520)
