### PR TITLE
OKTA-567461 - Updates to Trusted Origins API filter parameters and example

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/trusted-origins/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/trusted-origins/index.md
@@ -404,7 +404,7 @@ A subset of Trusted Origins that match a supported filter expression or query cr
 
 | Parameter    | Description                                                                                                                                       | Param Type   | DataType   | Required |
 | :----------- | :------------------------------------------------------------------------------------------------------------------------------------------------ | :----------- | :--------- | :------- |
-| filter       | [Filter](/docs/reference/core-okta-api/#filter) Trusted Origins with a supported expression for a subset of properties. You can filter on the following properties: `name`, `origin`, `status`, and `type` (that is, the `type` of `scopes`)   | Query        | String     | No       |
+| filter       | [Filter](/docs/reference/core-okta-api/#filter) Trusted Origins with a supported expression for a subset of properties. You can filter on the following properties: `name`, `origin`, `status`, and `type` (that is, the `type` of `scopes`).   | Query        | String     | No       |
 | limit        | Specifies the number of results. The maximum number of results returned is 200.                                                                                                          | Query        | Integer    | No       |
 
 ##### Response parameters
@@ -557,7 +557,7 @@ curl -X GET \
 
 Lists all Trusted Origins that match the filter criteria. You can filter on the following properties: `name`, `origin`, `status`, and `type` (that is, the `type` of `scopes`).
 
-his operation requires [URL encoding](/docs/reference/core-okta-api/#filter). For example, `filter=(name eq "Example Trusted Origin" or name eq "Another Trusted Origin")` is encoded as `filter=%28id+eq+%22Example+Trusted+Origin%22+or+id+eq+%22Another+Trusted+Origin%22%29`.
+This operation requires [URL encoding](/docs/reference/core-okta-api/#filter). For example, `filter=(name eq "Example Trusted Origin" or name eq "Another Trusted Origin")` is encoded as `filter=%28id+eq+%22Example+Trusted+Origin%22+or+id+eq+%22Another+Trusted+Origin%22%29`.
 
 See [Filtering](/docs/reference/core-okta-api/#filter) for more information on the expressions used in filtering.
 

--- a/packages/@okta/vuepress-site/docs/reference/api/trusted-origins/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/trusted-origins/index.md
@@ -404,7 +404,7 @@ A subset of Trusted Origins that match a supported filter expression or query cr
 
 | Parameter    | Description                                                                                                                                       | Param Type   | DataType   | Required |
 | :----------- | :------------------------------------------------------------------------------------------------------------------------------------------------ | :----------- | :--------- | :------- |
-| filter       | [Filter](/docs/reference/core-okta-api/#filter) Trusted Origins with a supported expression for a subset of properties. You can filter on the following properties: `name`, `origin`, `status`, and `type` (that is, the `type` of `scopes`).   | Query        | String     | No       |
+| filter       | [Filter](/docs/reference/core-okta-api/#filter) Trusted Origins with a supported expression for a subset of properties. You can filter on the following properties: `name`, `origin`, `status`, and `type` (type of scopes).   | Query        | String     | No       |
 | limit        | Specifies the number of results. The maximum number of results returned is 200.                                                                                                          | Query        | Integer    | No       |
 
 ##### Response parameters

--- a/packages/@okta/vuepress-site/docs/reference/api/trusted-origins/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/trusted-origins/index.md
@@ -137,7 +137,7 @@ curl -X POST \
   "scopes": [
     {
       "type": "IFRAME_EMBED",
-      "allowedOktaApps": [“OKTA_ENDUSER”]
+      "allowedOktaApps": ["OKTA_ENDUSER"]
     }
   ]
 }' "https://${yourOktaDomain}/api/v1/trustedOrigins"
@@ -404,7 +404,7 @@ A subset of Trusted Origins that match a supported filter expression or query cr
 
 | Parameter    | Description                                                                                                                                       | Param Type   | DataType   | Required |
 | :----------- | :------------------------------------------------------------------------------------------------------------------------------------------------ | :----------- | :--------- | :------- |
-| filter       | [Filter](/docs/reference/core-okta-api/#filter) Trusted Origins with a supported expression for a subset of properties            | Query        | String     | No       |
+| filter       | [Filter](/docs/reference/core-okta-api/#filter) Trusted Origins with a supported expression for a subset of properties. You can filter on the following properties: `name`, `origin`, `status`, and `type` (that is, the `type` of `scopes`)   | Query        | String     | No       |
 | limit        | Specifies the number of results. The maximum number of results returned is 200.                                                                                                          | Query        | Integer    | No       |
 
 ##### Response parameters
@@ -555,9 +555,9 @@ curl -X GET \
 
 #### List Trusted Origins with a filter
 
-Lists all Trusted Origins that match the filter criteria
+Lists all Trusted Origins that match the filter criteria. You can filter on the following properties: `name`, `origin`, `status`, and `type` (that is, the `type` of `scopes`).
 
-This operation requires [URL encoding](/docs/reference/core-okta-api/#filter). For example, `filter=(id eq "tosue7JvguwJ7U6kz0g3" or id eq "tos10hzarOl8zfPM80g4")` is encoded as `filter=%28id+eq+%22tosue7JvguwJ7U6kz0g3%22+or+id+eq+%22tos10hzarOl8zfPM80g4%22%29`.
+his operation requires [URL encoding](/docs/reference/core-okta-api/#filter). For example, `filter=(name eq "Example Trusted Origin" or name eq "Another Trusted Origin")` is encoded as `filter=%28id+eq+%22Example+Trusted+Origin%22+or+id+eq+%22Another+Trusted+Origin%22%29`.
 
 See [Filtering](/docs/reference/core-okta-api/#filter) for more information on the expressions used in filtering.
 
@@ -568,7 +568,7 @@ curl -X GET \
 -H "Accept: application/json" \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
-"https://${yourOktaDomain}/api/v1/trustedOrigins?limit=100&filter=%28id+eq+%22tosue7JvguwJ7U6kz0g3%22+or+id+eq+%22tos10hzarOl8zfPM80g4%22%29"
+"https://${yourOktaDomain}/api/v1/trustedOrigins?filter=%28name+eq+%22Example+Trusted+Origin%22+or+id+eq+%22Another+Trusted+Origin%22%29"
 ```
 
 ##### Response example


### PR DESCRIPTION
## Description:
- **What's changed?** Added filter parameters for the **List all Trusted Origins** API call, updated the **List Trusted Origins with a filter** curl example, and fixed double-quotes update from this PR( #[3884](https://github.com/okta/okta-developer-docs/pull/3884))
- **Is this PR related to a Monolith release?** 2023.07.0 (the `status` filter parameter will be fixed by this release; currently returns an error).

### Resolves:

* [OKTA-567461](https://oktainc.atlassian.net/browse/OKTA-567461)

<img width="1041" alt="Screen Shot 2023-07-06 at 11 58 26 AM" src="https://github.com/okta/okta-developer-docs/assets/70648001/5f5cd72f-8e15-44f8-9afd-fe6d5d0c4363">

<img width="1045" alt="Screen Shot 2023-07-06 at 11 58 40 AM" src="https://github.com/okta/okta-developer-docs/assets/70648001/24380e0b-f401-48c3-984e-835e789ff517">
