### PR TITLE
OKTA-443965 Updated curl calls to use org auth server

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/authcode/use-flow.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/authcode/use-flow.md
@@ -2,10 +2,10 @@ The following sections outline the main requests required to implement the Autho
 
 ### Request an authorization code
 
-To get an authorization code, your app redirects the user to your [authorization server's](/docs/concepts/auth-servers/) `/authorize` endpoint. If you are using the default custom authorization server, then your request URL would look something like this:
+To get an authorization code, your app redirects the user to your [authorization server's](/docs/concepts/auth-servers/) `/authorize` endpoint. If you are using the org authorization server, then your request URL would look something like this:
 
 ```bash
-https://${yourOktaDomain}/oauth2/default/v1/authorize?client_id=0oabucvy
+https://${yourOktaDomain}/oauth2/v1/authorize?client_id=0oabucvy
 c38HLL1ef0h7&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fexample.com&state=state-296bc9a0-a2a2-4a57-be1a-d0e2fd9bb601
 ```
 
@@ -29,11 +29,11 @@ This code remains valid for 300 seconds, during which it can be exchanged for to
 
 ### Exchange the code for tokens
 
-To exchange this code for access and ID tokens, you pass it to your [authorization server's](/docs/concepts/auth-servers/) `/token` endpoint. If you are using the default custom authorization server, then your request would look something like this:
+To exchange this code for access and ID tokens, you pass it to your [authorization server's](/docs/concepts/auth-servers/) `/token` endpoint. If you are using the org authorization server, then your request would look something like this:
 
 ```bash
 curl --request POST \
-  --url https://${yourOktaDomain}/oauth2/default/v1/token \
+  --url https://${yourOktaDomain}/oauth2/v1/token \
   --header 'accept: application/json' \
   --header 'authorization: Basic MG9hY...' \
   --header 'content-type: application/x-www-form-urlencoded' \

--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/authcodepkce/use-flow.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/authcodepkce/use-flow.md
@@ -24,10 +24,10 @@ The `code_challenge` is a Base64URL-encoded SHA256 hash of the `code_verifier`. 
 
 ### Request an authorization code
 
-If you are using the [default custom authorization server](/docs/concepts/auth-servers/#default-custom-authorization-server), then your request URL would look something like this:
+If you are using the org authorization server, then your request URL would look something like this:
 
 ```bash
-https://${yourOktaDomain}/oauth2/default/v1/authorize?client_id=0oabygpxgk9lXaMgF0h7&response_type=code&scope=openid&redirect_uri=yourApp%3A%2Fcallback&state=state-8600b31f-52d1-4dca-987c-386e3d8967e9&code_challenge_method=S256&code_challenge=qjrzSW9gMiUgpUvqgEPE4_-8swvyCtfOVvg55o5S_es
+https://${yourOktaDomain}/oauth2/v1/authorize?client_id=0oabygpxgk9lXaMgF0h7&response_type=code&scope=openid&redirect_uri=yourApp%3A%2Fcallback&state=state-8600b31f-52d1-4dca-987c-386e3d8967e9&code_challenge_method=S256&code_challenge=qjrzSW9gMiUgpUvqgEPE4_-8swvyCtfOVvg55o5S_es
 ```
 
 Note the parameters that are being passed:
@@ -56,7 +56,7 @@ To exchange the authorization code for access and ID tokens, you pass it to your
 
 ```bash
 curl --request POST \
-  --url https://${yourOktaDomain}/oauth2/default/v1/token \
+  --url https://${yourOktaDomain}/oauth2/v1/token \
   --header 'accept: application/json' \
   --header 'cache-control: no-cache' \
   --header 'content-type: application/x-www-form-urlencoded' \

--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/implicit/use-flow.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/implicit/use-flow.md
@@ -4,10 +4,10 @@ Without using existing libraries, you can make a direct request to Okta's [OIDC 
 
 This flow is very similar to the [Authorization Code flow](/docs/guides/implement-grant-type/authcode/main/#authorization-code-flow), except that the `response_type` is `token` and/or `id_token` instead of `code`.
 
-Your application redirects the user's browser to your authorization server's](/docs/concepts/auth-servers/) `/authorize` endpoint. If you are using the default custom authorization server, then your request URL would look something like this:
+Your application redirects the user's browser to your [authorization server's](/docs/concepts/auth-servers/) `/authorize` endpoint. If you are using the org authorization server, then your request URL would look something like this:
 
 ```bash
-https://${yourOktaDomain}/oauth2/default/v1/authorize?client_id=0oabv6kx4qq6h1U5l0h7&response_type=token&scope=openid&redirect_uri=&redirect_uri=https%3A%2F%2Fexample.com&state=state-296bc9a0-a2a2-4a57-be1a-d0e2fd9bb601&nonce=foo'
+https://${yourOktaDomain}/oauth2/v1/authorize?client_id=0oabv6kx4qq6h1U5l0h7&response_type=token&scope=openid&redirect_uri=&redirect_uri=https%3A%2F%2Fexample.com&state=state-296bc9a0-a2a2-4a57-be1a-d0e2fd9bb601&nonce=foo'
 ```
 
 Note the parameters that are being passed:

--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/ropassword/use-flow.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/ropassword/use-flow.md
@@ -2,11 +2,11 @@ If implementing the Resource Owner Password flow is your only option, you need t
 
 ### Request for tokens
 
-Before you can begin this flow, collect the user's password in a manner of your choosing. After you collect the credentials, all that is required is a single API call to the [authorization server's](/docs/concepts/auth-servers/) `/token` endpoint. If you are using the [default custom authorization server](/docs/concepts/auth-servers/#default-custom-authorization-server), then your request would look something like this:
+Before you can begin this flow, collect the user's password in a manner of your choosing. After you collect the credentials, all that is required is a single API call to the [authorization server's](/docs/concepts/auth-servers/) `/token` endpoint. If you are using the org authorization server, then your request would look something like this:
 
 ```bash
 curl --request POST \
-  --url https://${yourOktaDomain}/oauth2/default/v1/token \
+  --url https://${yourOktaDomain}/oauth2/v1/token \
   --header 'accept: application/json' \
   --header 'authorization: Basic MG9hYn...' \
   --header 'content-type: application/x-www-form-urlencoded' \

--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/saml2assert/use-flow.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/saml2assert/use-flow.md
@@ -4,10 +4,10 @@ Before you can begin this flow, you must collect the SAML assertion from the Ide
 
 ### Request example
 
-If you are using the default custom authorization server, then your request would look something like this:
+If you are using the org authorization server, then your request would look something like this:
 
 ```bash
-curl --location --request POST 'https://${yourOktaDomain}/oauth2/default/v1/token' \
+curl --location --request POST 'https://${yourOktaDomain}/oauth2/v1/token' \
 --header 'Accept: application/json' \
 --header 'Content-Type: application/x-www-form-urlencoded' \
 --header 'Authorization: Basic MG9hb....' \

--- a/packages/@okta/vuepress-site/docs/guides/refresh-tokens/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/refresh-tokens/main/index.md
@@ -128,7 +128,7 @@ See [Obtain an authorization grant from a User](/docs/reference/api/oidc/#author
 The following is an example request to the `/authorize` endpoint for an [authorization code](/docs/guides/implement-grant-type/authcode/main/) flow and includes the `offline_access` scope.
 
 ```bash
-curl -x GET https://${yourOktaDomain}/oauth2/default/v1/authorize
+curl -x GET https://${yourOktaDomain}/oauth2/v1/authorize
 ?client_id=${clientId}
 &response_type=code
 &scope=openid%20offline_access
@@ -139,7 +139,7 @@ curl -x GET https://${yourOktaDomain}/oauth2/default/v1/authorize
 The following is an example request to the `/authorize` endpoint for an [authorization code with PKCE](/docs/guides/implement-grant-type/authcodepkce/main/#request-an-authorization-code) flow and includes the `offline_access` scope.
 
 ```bash
-curl -x GET https://${yourOktaDomain}/oauth2/default/v1/authorize
+curl -x GET https://${yourOktaDomain}/oauth2/v1/authorize
 ?client_id=${clientId}
 &response_type=code
 &scope=openid%20offline_access
@@ -154,7 +154,7 @@ curl -x GET https://${yourOktaDomain}/oauth2/default/v1/authorize
 The following is an example request to the `/token` endpoint to obtain an access token, an ID token (by including the `openid` scope), and a refresh token for the [Authorization Code flow](/docs/guides/implement-grant-type/authcode/main/). The value for `code` is the authorization code that you receive in the response from the request to the `/authorize` endpoint.
 
 ```bash
-curl --location --request POST 'https://${yourOktaDomain}/oauth2/default/v1/token' \
+curl --location --request POST 'https://${yourOktaDomain}/oauth2/v1/token' \
 -H 'Accept: application/json' \
 -H 'Authorization: Basic ${Base64(${clientId}:${clientSecret})}' \
 -H 'Content-Type: application/x-www-form-urlencoded' \
@@ -168,7 +168,7 @@ curl --location --request POST 'https://${yourOktaDomain}/oauth2/default/v1/toke
 The following is an example request to the `/token` endpoint to obtain an access token, an ID token (by including the `openid` scope), and a refresh token for the [Authorization Code with PKCE flow](/docs/guides/implement-grant-type/authcodepkce/main/#exchange-the-code-for-tokens). The value for `code` is the code that you receive in the response from the request to the `/authorize` endpoint.
 
 ```bash
-curl --location --request POST 'https://${yourOktaDomain}/oauth2/default/v1/token' \
+curl --location --request POST 'https://${yourOktaDomain}/oauth2/v1/token' \
 -H 'Accept: application/json' \
 -H 'Content-Type: application/x-www-form-urlencoded' \
 -d 'grant_type=authorization_code' \
@@ -204,7 +204,7 @@ See [Request a token](/docs/reference/api/oidc/#token) and [Implementing the res
 With the `password` grant type, you can include an `openid` scope alongside the `offline_access` scope to also get back an ID token.
 
 ```bash
-curl --location --request POST 'https://${yourOktaDomain}/oauth2/default/v1/token' \
+curl --location --request POST 'https://${yourOktaDomain}/oauth2/v1/token' \
 -H 'Accept: application/json' \
 -H 'Authorization: Basic ${Base64(${clientId}:${clientSecret})}' \
 -H 'Content-Type: application/x-www-form-urlencoded' \
@@ -245,7 +245,7 @@ The introduction of browser privacy controls such as Intelligent Tracking Preven
 To refresh your access token as well as an ID token, you send a token request with a `grant_type` of `refresh_token`. Be sure to include the `openid` scope when you want to refresh the ID token.
 
 ```bash
-http --form POST https://${yourOktaDomain}/oauth2/default/v1/token \
+http --form POST https://${yourOktaDomain}/oauth2/v1/token \
   accept:application/json \
   authorization:'Basic MG9hYmg3M...' \
   cache-control:no-cache \


### PR DESCRIPTION
## Description:
- **What's changed?** 
- Updated implement grant type and refresh tokens articles to use CURL calls to org server rather than custom org server.
- NOTE: Will address acrolinx scores in subsequent PR with updated images for IGT articles.

- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-443965](https://oktainc.atlassian.net/browse/OKTA-443965)
