### PR TITLE
OKTA-610874 - Deprecate UI Schema API on VuePress

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/uischema/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/uischema/index.md
@@ -5,7 +5,12 @@ category: management
 
 # UI Schema API
 
-<ApiLifecycle access="ie" />
+The UI Schema API reference is now available at the new [Okta API reference portal](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/UISchema/).
+
+Explore the [Okta Public API Collections](https://www.postman.com/okta-eng/workspace/okta-public-api-collections/overview) workspace to get started with the UI Schema API Postman collection.
+
+<!--
+<<ApiLifecycle access="ie" />
 
 The Okta UI Schema API allows you to control how inputs appear on an enrollment form.
 
@@ -746,3 +751,4 @@ The UI Schema Element Options object specifies how the input appears. The suppor
   "format": "select"
 }
 ```
+-->


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Updating VuePress [UI Schema API ](https://developer.okta.com/docs/reference/api/uischema/)reference to point to Redocly version of the [UI Schema API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/UISchema/). All content from existing VuePress site migrated to Redocly platform.
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* [OKTA-610874](https://oktainc.atlassian.net/browse/OKTA-610874)
