### PR TITLE
Custom domain: add a WebAuthn note

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -79,7 +79,7 @@ The third generation of the Okta Sign-In Widget doesn’t guarantee the stabilit
 
 * When you implement a custom domain, users aren't automatically rerouted from the original URL to the new custom URL. You must communicate the new custom domain to your users.
 
-* If you configure the [FIDO2 (WebAuthn) authenticator](https://help.okta.com/okta_help.htm?type=oie&id=csh-configure-webauthn) in your org and create a custom domain, your users first need to re-enroll with another authenticator. For example, Okta Verify or email. Then, your users can re-enroll with WebAuthn. Communicate the new URL to your users so that Okta prompts them to re-enroll. Every domain a user accesses requires re-enrollment because each set of their credentials is scoped to a separate domain.
+* If you configure the [FIDO2 (WebAuthn) authenticator](https://help.okta.com/okta_help.htm?type=oie&id=csh-configure-webauthn) in your org and create a custom domain, your users first need to re-enroll with another authenticator (for example, Okta Verify or email). Then, your users can re-enroll with WebAuthn. Communicate the new URL to your users so that Okta prompts them to re-enroll. Every domain that a user accesses requires re-enrollment because each set of their credentials is scoped to a separate domain.
 
 * When an admin signs in to the custom domain and then accesses the Admin Console from their user dashboard, the org domain changes from the custom domain to the Okta domain.
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -79,7 +79,7 @@ The third generation of the Okta Sign-In Widget doesn’t guarantee the stabilit
 
 * When you implement a custom domain, users aren't automatically rerouted from the original URL to the new custom URL. You must communicate the new custom domain to your users. One way to communicate the change is to [create a custom notification](https://help.okta.com/okta_help.htm?id=ext_Dashboard_End_User_Notifications) that appears on each user's dashboard.
 
-* If you configure the [FIDO2 (WebAuthn) authenticator](https://help.okta.com/okta_help.htm?type=oie&id=csh-configure-webauthn) in your org and create a custom domain, your users need to re-enroll with WebAuthn. Communicate the new URL to your users so that Okta prompts them to re-enroll.
+* If you configure the [FIDO2 (WebAuthn) authenticator](https://help.okta.com/okta_help.htm?type=oie&id=csh-configure-webauthn) in your org and create a custom domain, your users need to re-enroll with WebAuthn. Communicate the new URL to your users so that Okta prompts them to re-enroll. Your users need to re-enroll for every domain they access because their each set of credentials is scoped to a separate domain.
 
 * When an admin signs in to the custom domain and then accesses the Admin Console from their user dashboard, the org domain changes from the custom domain to the Okta domain.
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -79,7 +79,7 @@ The third generation of the Okta Sign-In Widget doesn’t guarantee the stabilit
 
 * When you implement a custom domain, users aren't automatically rerouted from the original URL to the new custom URL. You must communicate the new custom domain to your users.
 
-* If you configure the [FIDO2 (WebAuthn) authenticator](https://help.okta.com/okta_help.htm?type=oie&id=csh-configure-webauthn) in your org and create a custom domain, your users need to re-enroll with WebAuthn. Communicate the new URL to your users so that Okta prompts them to re-enroll. Every domain a user accesses requires re-enrollment because each set of their credentials is scoped to a separate domain.
+* If you configure the [FIDO2 (WebAuthn) authenticator](https://help.okta.com/okta_help.htm?type=oie&id=csh-configure-webauthn) in your org and create a custom domain, your users first need to re-enroll with another authenticator. For example, Okta Verify or email. Then, your users can re-enroll with WebAuthn. Communicate the new URL to your users so that Okta prompts them to re-enroll. Every domain a user accesses requires re-enrollment because each set of their credentials is scoped to a separate domain.
 
 * When an admin signs in to the custom domain and then accesses the Admin Console from their user dashboard, the org domain changes from the custom domain to the Okta domain.
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -73,9 +73,11 @@ The third generation of the Okta Sign-In Widget doesn’t guarantee the stabilit
 
 * Okta currently only supports 2048-bit keys for the private key that you upload. However, your certificate chain can use keys of any size.
 
-* If your org has configured any SAML or WS-Fed integrated apps, review the setup instructions for [SAML SSO](/docs/guides/build-sso-integration/saml2/main/) or [WS-Fed SSO](https://help.okta.com/okta_help.htm?id=ext_Apps_Configuring_WS_Federation). If you want your customers to see the new custom domain rather than the Okta org domain, update those SAML or WS-Fed Service Provider integrations to use the new custom URL in the metadata.
+* If you configure any SAML or WS-Fed integrated apps in your org, review the setup instructions for [SAML SSO](/docs/guides/build-sso-integration/saml2/main/) or [WS-Fed SSO](https://help.okta.com/okta_help.htm?id=ext_Apps_Configuring_WS_Federation). If you want your customers to see the new custom domain rather than the Okta org domain, update those SAML or WS-Fed Service Provider integrations to use the new custom URL in the metadata.
 
 * If you sign a user in with your new custom domain and they try to SSO into previous OIDC integrations made with the org domain, your user is prompted to sign in again. To avoid this, you need to change the issuer in these integrations to your custom URL in both the Okta dashboard and your codebase.
+
+* If you configure the WebAuthn authenticator in your org and create a custom domain, your users need to re-enroll with WebAuthn. Update your app integration to use the new custom URL in the metadata. Okta prompts users to re-enroll.
 
 * When you implement a custom domain, users aren't automatically rerouted from the original URL to the new custom URL. You must communicate the new custom domain to your users. One way to communicate the change is to [create a custom notification](https://help.okta.com/okta_help.htm?id=ext_Dashboard_End_User_Notifications) that appears on each user's dashboard.
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -77,9 +77,9 @@ The third generation of the Okta Sign-In Widget doesn’t guarantee the stabilit
 
 * If you sign a user in with your new custom domain and they try to SSO into previous OIDC integrations made with the org domain, your user is prompted to sign in again. To avoid this, you need to change the issuer in these integrations to your custom URL in both the Okta dashboard and your codebase.
 
-* If you configure the [WebAuthn authenticator](https://help.okta.com/okta_help.htm?type=oie&id=csh-configure-webauthn) in your org and create a custom domain, your users need to re-enroll with WebAuthn. Update your app integration to use the new custom URL in the metadata. Okta prompts users to re-enroll.
-
 * When you implement a custom domain, users aren't automatically rerouted from the original URL to the new custom URL. You must communicate the new custom domain to your users. One way to communicate the change is to [create a custom notification](https://help.okta.com/okta_help.htm?id=ext_Dashboard_End_User_Notifications) that appears on each user's dashboard.
+
+* If you configure the [FIDO2 (WebAuthn) authenticator](https://help.okta.com/okta_help.htm?type=oie&id=csh-configure-webauthn) in your org and create a custom domain, your users need to re-enroll with WebAuthn. Communicate the new URL to your users so that Okta prompts them to re-enroll.
 
 * When an admin signs in to the custom domain and then accesses the Admin Console from their user dashboard, the org domain changes from the custom domain to the Okta domain.
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -77,7 +77,7 @@ The third generation of the Okta Sign-In Widget doesn’t guarantee the stabilit
 
 * If you sign a user in with your new custom domain and they try to SSO into previous OIDC integrations made with the org domain, your user is prompted to sign in again. To avoid this, you need to change the issuer in these integrations to your custom URL in both the Okta dashboard and your codebase.
 
-* If you configure the WebAuthn authenticator in your org and create a custom domain, your users need to re-enroll with WebAuthn. Update your app integration to use the new custom URL in the metadata. Okta prompts users to re-enroll.
+* If you configure the [WebAuthn authenticator](https://help.okta.com/okta_help.htm?type=oie&id=csh-configure-webauthn) in your org and create a custom domain, your users need to re-enroll with WebAuthn. Update your app integration to use the new custom URL in the metadata. Okta prompts users to re-enroll.
 
 * When you implement a custom domain, users aren't automatically rerouted from the original URL to the new custom URL. You must communicate the new custom domain to your users. One way to communicate the change is to [create a custom notification](https://help.okta.com/okta_help.htm?id=ext_Dashboard_End_User_Notifications) that appears on each user's dashboard.
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -77,9 +77,9 @@ The third generation of the Okta Sign-In Widget doesn’t guarantee the stabilit
 
 * If you sign a user in with your new custom domain and they try to SSO into previous OIDC integrations made with the org domain, your user is prompted to sign in again. To avoid this, you need to change the issuer in these integrations to your custom URL in both the Okta dashboard and your codebase.
 
-* When you implement a custom domain, users aren't automatically rerouted from the original URL to the new custom URL. You must communicate the new custom domain to your users. One way to communicate the change is to [create a custom notification](https://help.okta.com/okta_help.htm?id=ext_Dashboard_End_User_Notifications) that appears on each user's dashboard.
+* When you implement a custom domain, users aren't automatically rerouted from the original URL to the new custom URL. You must communicate the new custom domain to your users.
 
-* If you configure the [FIDO2 (WebAuthn) authenticator](https://help.okta.com/okta_help.htm?type=oie&id=csh-configure-webauthn) in your org and create a custom domain, your users need to re-enroll with WebAuthn. Communicate the new URL to your users so that Okta prompts them to re-enroll. Your users need to re-enroll for every domain they access because their each set of credentials is scoped to a separate domain.
+* If you configure the [FIDO2 (WebAuthn) authenticator](https://help.okta.com/okta_help.htm?type=oie&id=csh-configure-webauthn) in your org and create a custom domain, your users need to re-enroll with WebAuthn. Communicate the new URL to your users so that Okta prompts them to re-enroll. Every domain a user accesses requires re-enrollment because each set of their credentials is scoped to a separate domain.
 
 * When an admin signs in to the custom domain and then accesses the Admin Console from their user dashboard, the org domain changes from the custom domain to the Okta domain.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7971,10 +7971,10 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@2.2.3, json5@^1.0.1, json5@^2.1.2, json5@^2.2.1:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
-  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+json5@2.2.2, json5@^1.0.1, json5@^2.1.2, json5@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.2.tgz#64471c5bdcc564c18f7c1d4df2e2297f2457c5ab"
+  integrity sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==
 
 jsonfile@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Description:
- **What's changed?** Adds a note about re-enrolling in the WebAuthn authenticator when a new custom domain is configured.
- **Is this PR related to a Monolith release?** Nope.

### Resolves:

* [OKTA-521214](https://oktainc.atlassian.net/browse/OKTA-521214)
