### PR TITLE
OKTA-627743 Change image div class to appropriate classes

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/mfaoob/flow-diagram.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/mfaoob/flow-diagram.md
@@ -1,6 +1,6 @@
 ### Direct Authentication MFA OOB flow
 
-<div class="original">
+<div class="three-quarter">
 
 ![Sequence diagram that displays the back and forth between the resource owner, client app, and authorization server for MFA OOB flow"](/img/authorization/oauth-mfaoob-grant-flow.png)
 

--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/mfaoob/flow-diagram.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/mfaoob/flow-diagram.md
@@ -1,6 +1,6 @@
 ### Direct Authentication MFA OOB flow
 
-<div class="three-quarters">
+<div class="original">
 
 ![Sequence diagram that displays the back and forth between the resource owner, client app, and authorization server for MFA OOB flow"](/img/authorization/oauth-mfaoob-grant-flow.png)
 

--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/mfaotp/flow-diagram.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/mfaotp/flow-diagram.md
@@ -1,6 +1,6 @@
 ### Direct Authentication MFA OTP flow
 
-<div class="three-quarters">
+<div class="original">
 
 ![Sequence diagram that displays the back and forth between the resource owner, client app, and authorization server for MFA OTP flow"](/img/authorization/oauth-mfaotp-grant-flow.png)
 

--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/mfaotp/flow-diagram.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/mfaotp/flow-diagram.md
@@ -1,6 +1,6 @@
 ### Direct Authentication MFA OTP flow
 
-<div class="original">
+<div class="three-quarter">
 
 ![Sequence diagram that displays the back and forth between the resource owner, client app, and authorization server for MFA OTP flow"](/img/authorization/oauth-mfaotp-grant-flow.png)
 

--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/oob/flow-diagram.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/oob/flow-diagram.md
@@ -1,6 +1,6 @@
 ### Direct authentication OOB flow
 
-<div class="three-quarters">
+<div class="original">
 
 ![Sequence diagram that displays the back and forth between the resource owner, client app, and authorization server for OOB flow"](/img/authorization/oauth-oob-grant-flow.png)
 

--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/oob/flow-diagram.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/oob/flow-diagram.md
@@ -1,6 +1,6 @@
 ### Direct authentication OOB flow
 
-<div class="original">
+<div class="three-quarter">
 
 ![Sequence diagram that displays the back and forth between the resource owner, client app, and authorization server for OOB flow"](/img/authorization/oauth-oob-grant-flow.png)
 

--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/otp/flow-diagram.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/otp/flow-diagram.md
@@ -1,6 +1,6 @@
 ### Direct Authentication OTP flow
 
-<div class="three-quarters">
+<div class="original">
 
 ![Sequence diagram that displays the back and forth between the resource owner, client app, and authorization server for OTP flow"](/img/authorization/oauth-otp-grant-flow.png)
 

--- a/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/otp/flow-diagram.md
+++ b/packages/@okta/vuepress-site/docs/guides/implement-grant-type/main/otp/flow-diagram.md
@@ -1,6 +1,6 @@
 ### Direct Authentication OTP flow
 
-<div class="original">
+<div class="three-quarter">
 
 ![Sequence diagram that displays the back and forth between the resource owner, client app, and authorization server for OTP flow"](/img/authorization/oauth-otp-grant-flow.png)
 

--- a/packages/@okta/vuepress-site/docs/guides/oin-lifecycle-mgmt-overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oin-lifecycle-mgmt-overview/index.md
@@ -7,7 +7,7 @@ meta:
 
 Lifecycle management refers to the process of provisioning and deprovisioning application access as a user moves through an organization. Onboarding, role change, transfer, and offboarding employee processes require provisioning user accounts in workforce applications and enforcing corporate security policies in a timely manner.
 
-<div class="original">
+<div>
 
 ![Lifecycle management](/img/oin/scim_lifecycle.png "User lifecycle diagram: 1 - new employee 2 - provision applications 3 - enforce security 4 - update user information 5 - off-board")
 

--- a/packages/@okta/vuepress-site/docs/guides/oin-lifecycle-mgmt-overview/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oin-lifecycle-mgmt-overview/index.md
@@ -7,7 +7,7 @@ meta:
 
 Lifecycle management refers to the process of provisioning and deprovisioning application access as a user moves through an organization. Onboarding, role change, transfer, and offboarding employee processes require provisioning user accounts in workforce applications and enforcing corporate security policies in a timely manner.
 
-<div class="three-quarters">
+<div class="original">
 
 ![Lifecycle management](/img/oin/scim_lifecycle.png "User lifecycle diagram: 1 - new employee 2 - provision applications 3 - enforce security 4 - update user information 5 - off-board")
 

--- a/packages/@okta/vuepress-site/docs/guides/pwd-optional-overview/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/pwd-optional-overview/main/index.md
@@ -12,7 +12,7 @@ Most hacking-related breaches involve weak or stolen passwords and credential se
 
 Replace the password with a password-optional sign-in experience. Give your users the ability to authenticate with a fingerprint, YubiKey, email, phone, or another authenticator. These authenticators are all more secure &mdash; it's harder to steal a fingerprint than a password &mdash; and more convenient since users no longer have to memorize and manage their passwords.
 
-<div class="three-quarters">
+<div class="three-quarter">
 
 ![Diagram illustrating how password-optional authentication, when compared to other password authentications, is convenient and secure.](/img/pwd-optional/pwd-optional-overview-xy-diagram.png)
 

--- a/packages/@okta/vuepress-site/docs/guides/pwd-optional-overview/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/pwd-optional-overview/main/index.md
@@ -12,7 +12,7 @@ Most hacking-related breaches involve weak or stolen passwords and credential se
 
 Replace the password with a password-optional sign-in experience. Give your users the ability to authenticate with a fingerprint, YubiKey, email, phone, or another authenticator. These authenticators are all more secure &mdash; it's harder to steal a fingerprint than a password &mdash; and more convenient since users no longer have to memorize and manage their passwords.
 
-<div class="three-quarter">
+<div>
 
 ![Diagram illustrating how password-optional authentication, when compared to other password authentications, is convenient and secure.](/img/pwd-optional/pwd-optional-overview-xy-diagram.png)
 

--- a/packages/@okta/vuepress-site/docs/guides/submit-app/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/submit-app/main/index.md
@@ -100,7 +100,7 @@ The OIN Manager shows the current status of your integration.
 
 The following flowchart outlines the entire process:
 
-<div class="three-quarters">
+<div class="three-quarter">
 
 ![ISV Submission process flow](/img/oin/isv-portal_submission_flow.png)
 

--- a/packages/@okta/vuepress-site/docs/guides/submit-app/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/submit-app/main/index.md
@@ -100,7 +100,7 @@ The OIN Manager shows the current status of your integration.
 
 The following flowchart outlines the entire process:
 
-<div class="three-quarter">
+<div>
 
 ![ISV Submission process flow](/img/oin/isv-portal_submission_flow.png)
 

--- a/packages/@okta/vuepress-site/docs/reference/architecture-center/directory-coexistence/lab-azure-ad/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/architecture-center/directory-coexistence/lab-azure-ad/index.md
@@ -17,7 +17,7 @@ In this tutorial, you migrate all the users in a simple Azure Active Directory i
 
 At the end of the tutorial, when a user attempts to sign in to the application, their authorization request is redirected to Okta and then delegated to Azure AD to match the user and authenticate them.
 
-<div class="full">
+<div class="three-quarter">
 
   ![An architecture diagram showing the authorization flow from user to Okta to Azure Active Directory and back again.](/img/architecture/directory-coexistence/ad-to-okta-flow-diagram.png)
 
@@ -151,7 +151,7 @@ To run the sample application and connect directly to the Okta sign-in dialog:
 
 1. Sign in with your Okta org account credentials. You should see the following:
 
-   <div class="three-quarters border">
+   <div class="original border">
 
    ![Sign-in response with welcome home successful authentication response](/img/architecture/directory-coexistence/ad-to-okta-signin-response.png)
 

--- a/packages/@okta/vuepress-site/docs/reference/architecture-center/directory-coexistence/lab-azure-ad/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/architecture-center/directory-coexistence/lab-azure-ad/index.md
@@ -151,7 +151,7 @@ To run the sample application and connect directly to the Okta sign-in dialog:
 
 1. Sign in with your Okta org account credentials. You should see the following:
 
-   <div class="original border">
+   <div class="border">
 
    ![Sign-in response with welcome home successful authentication response](/img/architecture/directory-coexistence/ad-to-okta-signin-response.png)
 

--- a/packages/@okta/vuepress-site/docs/reference/architecture-center/directory-coexistence/lab-generic-database/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/architecture-center/directory-coexistence/lab-generic-database/index.md
@@ -63,7 +63,7 @@ Create the initial environment for the tutorial where an application authenticat
 
 1. Sign in with username **`user1@example.com`** and password **password**. The following dialog appears after successful authentication:
 
-   <div class="original border">
+   <div class="border">
 
    ![Sign-in response with welcome home successful authentication response](/img/architecture/directory-coexistence/db-to-okta-successful-signin.png)
 
@@ -194,7 +194,7 @@ Now that the users are mirrored in Universal Directory, you can reconfigure the 
 
    When the user is authenticated by Okta, the following appears:
 
-   <div class="original border">
+   <div class="border">
 
    ![Successful sign-in response](/img/architecture/directory-coexistence/db-to-okta-successful-signin.png)
 

--- a/packages/@okta/vuepress-site/docs/reference/architecture-center/directory-coexistence/lab-generic-database/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/architecture-center/directory-coexistence/lab-generic-database/index.md
@@ -63,7 +63,7 @@ Create the initial environment for the tutorial where an application authenticat
 
 1. Sign in with username **`user1@example.com`** and password **password**. The following dialog appears after successful authentication:
 
-   <div class="three-quarters border">
+   <div class="original border">
 
    ![Sign-in response with welcome home successful authentication response](/img/architecture/directory-coexistence/db-to-okta-successful-signin.png)
 
@@ -194,7 +194,7 @@ Now that the users are mirrored in Universal Directory, you can reconfigure the 
 
    When the user is authenticated by Okta, the following appears:
 
-   <div class="three-quarters border">
+   <div class="original border">
 
    ![Successful sign-in response](/img/architecture/directory-coexistence/db-to-okta-successful-signin.png)
 

--- a/packages/@okta/vuepress-site/docs/reference/architecture-center/directory-coexistence/lab-ldap-server/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/architecture-center/directory-coexistence/lab-ldap-server/index.md
@@ -74,7 +74,7 @@ Create the initial environment for the tutorial where an application authenticat
 
    The OpenLDAP directory contains three users defined in the `ldifs\users.ldif` file. At the prompt, sign in with username **user01** and password **password1**. The following dialog appears after successful authentication:
 
-   <div class="original border">
+   <div class="border">
 
    ![Sign-in response with welcome home successful authentication response](/img/architecture/directory-coexistence/ldap-to-okta-signin-response.png)
 

--- a/packages/@okta/vuepress-site/docs/reference/architecture-center/directory-coexistence/lab-ldap-server/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/architecture-center/directory-coexistence/lab-ldap-server/index.md
@@ -18,7 +18,7 @@ In this tutorial, you create a sample web application that authenticates directl
 
 At the end of step 4, when a user attempts to sign in to the application, their authorization request is redirected to Okta and then delegated to the LDAP directory. At the end of step 5, their authorization request is handled entirely by Okta.
 
-<div class="full">
+<div class="three-quarter">
 
   ![An architecture diagram showing the authorization flow from user to Okta to an OpenLDAP Directory server and back again.](/img/architecture/directory-coexistence/ldap-to-okta-flow-diagram.png)
 
@@ -74,7 +74,7 @@ Create the initial environment for the tutorial where an application authenticat
 
    The OpenLDAP directory contains three users defined in the `ldifs\users.ldif` file. At the prompt, sign in with username **user01** and password **password1**. The following dialog appears after successful authentication:
 
-   <div class="three-quarters border">
+   <div class="original border">
 
    ![Sign-in response with welcome home successful authentication response](/img/architecture/directory-coexistence/ldap-to-okta-signin-response.png)
 

--- a/packages/@okta/vuepress-site/docs/release-notes/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/index.md
@@ -15,7 +15,7 @@ We release first to preview orgs and then production orgs. Dates for preview rel
 
 To verify the current release and Okta solution for an org (Identity Engine or Classic), check the footer of the Admin Console. The version number is appended with E for Identity Engine orgs and C for Classic Engine orgs. If necessary, click **Admin** to navigate to your Admin Console. <br>
 
-<div class="original">
+<div>
 
 ![Release Number in Footer](/img/release_notes/version_footer.png)
 

--- a/packages/@okta/vuepress-site/docs/release-notes/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/index.md
@@ -15,7 +15,7 @@ We release first to preview orgs and then production orgs. Dates for preview rel
 
 To verify the current release and Okta solution for an org (Identity Engine or Classic), check the footer of the Admin Console. The version number is appended with E for Identity Engine orgs and C for Classic Engine orgs. If necessary, click **Admin** to navigate to your Admin Console. <br>
 
-<div class="three-quarters">
+<div class="original">
 
 ![Release Number in Footer](/img/release_notes/version_footer.png)
 


### PR DESCRIPTION
## Description:
- **What's changed?** We were using div="three-quarters" class in some pages, which is not correct. Turns out that the correct CSS is "three-quarter". However, this produced some huge images that were fuzzy. For these scaled images, "original" place-holder class was used which is just no class at all, with no scaling.
- **Is this PR related to a Monolith release?** No

### Preview: 
1. https://64b049e3f4c883396931fae1--reverent-murdock-829d24.netlify.app/docs/guides/implement-grant-type/mfaoob/main/#grant-type-flow
2. Preview that uses `three-quarter` for Direct Auth, and `<div>` for no scaling: https://64b6a2366382c60534df6ee2--reverent-murdock-829d24.netlify.app/docs/guides/implement-grant-type/mfaoob/main/#grant-type-flow

### Resolves:

* [OKTA-627743](https://oktainc.atlassian.net/browse/OKTA-627743)
