### PR TITLE
MyAccount API: deprecate the API docs

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/configure-ciba/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/configure-ciba/main/index.md
@@ -192,7 +192,7 @@ Use the Devices SDK and your app to enroll a Custom Authenticator for the test u
    The sample app is set up to include the **Enable CIBA transactions** option by default for the user to enable CIBA themselves in the mobile app. However, you can implement CIBA in your app any way that you want, for example, create an enrollment flow that turns CIBA on by default, making it transparent to users.
 8. Click **Ok** at the success dialog and close the Security Settings screen.
 9. Leave your test user signed in to the authentication device (the Magenta Bank app on the Xcode simulator).
-  <!-- **Note:** See the [MyAccount API](/docs/reference/api/myaccount/) for examples of [enrolling](?link to new api operation?) and [updating](?link to new api operation?) a custom app authenticator to use CIBA by adding `CIBA` to the `transactionTypes` array. -->
+  <!-- **Note:** See the [MyAccount API](https://developer.okta.com/docs/api/openapi/okta-myaccount/guides/overview/) for examples of [enrolling](?link to new api operation?) and [updating](?link to new api operation?) a custom app authenticator to use CIBA by adding `CIBA` to the `transactionTypes` array. -->
 
 ## Test the CIBA flow
 

--- a/packages/@okta/vuepress-site/docs/guides/configure-user-scoped-account-management/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/configure-user-scoped-account-management/main/index.md
@@ -271,4 +271,4 @@ Returns an HTTP 201 status code response, with a location URL referring to the n
 
 ## See also
 
-* [MyAccount API](/docs/reference/api/myaccount/) reference documentation
+* [MyAccount API](https://developer.okta.com/docs/api/openapi/okta-myaccount/guides/overview/) reference documentation

--- a/packages/@okta/vuepress-site/docs/guides/pwd-optional-change-email/main/react/allcontent.md
+++ b/packages/@okta/vuepress-site/docs/guides/pwd-optional-change-email/main/react/allcontent.md
@@ -21,7 +21,7 @@ Allowing a user to change their primary email is a critical task when they only 
 
 The SDK contains a series of [methods](https://github.com/okta/okta-auth-js/blob/master/docs/myaccount/modules.md) that update the user's primary email address and other profile information. These methods are secure and can be safely used in browser-based SPA applications. In this guide, you learn how to use these methods to integrate the change email functionality in your app.
 
->**Note**: These SDK methods use the [MyAccount API](/docs/reference/api/myaccount/) to update the user's profile information.
+>**Note**: These SDK methods use the [MyAccount API](https://developer.okta.com/docs/api/openapi/okta-myaccount/guides/overview/) to update the user's profile information.
 
 ## Update configurations
 
@@ -42,4 +42,4 @@ The following summarizes the steps involved when a user changes their primary em
 
 * [Okta Auth Javascript SDK](https://github.com/okta/okta-auth-js)
 * [MyAccount SDK interface specification](https://github.com/okta/okta-auth-js/blob/master/docs/myaccount/modules.md)
-* [MyAccount API reference](/docs/reference/api/myaccount/)
+* [MyAccount API reference](https://developer.okta.com/docs/api/openapi/okta-myaccount/guides/overview/)

--- a/packages/@okta/vuepress-site/docs/reference/api/archive-myaccount/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/archive-myaccount/index.md
@@ -5,7 +5,7 @@ category: management
 
 # MyAccount API v1 (Deprecated)
 
-> **Note:** This version of the MyAccount API is deprecated. For the latest version of the API, see the [reference documentation](/docs/reference/api/myaccount/).
+> **Note:** This version of the MyAccount API is deprecated. For the latest version of the API, see the [reference documentation](https://developer.okta.com/docs/api/openapi/okta-myaccount/guides/overview/).
 
 <ApiLifecycle access="deprecated" />
 

--- a/packages/@okta/vuepress-site/docs/reference/api/myaccount-migration/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/myaccount-migration/index.md
@@ -7,7 +7,7 @@ category: management
 
 <ApiLifecycle access="ie" />
 
-This guide describes how to migrate from the `v1` version to the `idp` version of the MyAccount API. See [MyAccount API](/docs/reference/api/myaccount/) for the reference documentation of the latest version.
+This guide describes how to migrate from the `v1` version to the `idp` version of the MyAccount API. See [MyAccount API](https://developer.okta.com/docs/api/openapi/okta-myaccount/guides/overview/) for the reference documentation of the latest version.
 
 ## OIE migration
 
@@ -96,4 +96,4 @@ The new version of the API comes with new error messages. Examples include:
 * invalid email ID
 * email operation not enabled in your org
 
-See [Update My User Profile - Error responses](/docs/reference/api/myaccount/#error-responses-8).
+See [Update My User Profile - Error responses](https://developer.okta.com/docs/api/openapi/okta-myaccount/myaccount/tag/Profile/).

--- a/packages/@okta/vuepress-site/docs/reference/api/myaccount/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/myaccount/index.md
@@ -5,6 +5,12 @@ category: management
 
 # MyAccount API
 
+The MyAccount API reference is now available at the new [Okta API reference portal](https://developer.okta.com/docs/api/openapi/okta-myaccount/guides/overview/).
+
+Explore the [Okta Public API Collections](https://www.postman.com/okta-eng/workspace/okta-public-api-collections/overview) workspace to get started with the MyAccount API Postman collection.
+
+<!--
+
 <ApiLifecycle access="ie" />
 
 > **Note:** This document provides reference material for an enhanced MyAccount API, accessible at `/idp/myaccount`. The `/api/v1/myaccount` endpoint is deprecated. See [MyAccount API (deprecated)](/docs/reference/api/archive-myaccount/) for the docs for the older version of the API.
@@ -1859,3 +1865,4 @@ The My Password object has several properties:
   }
 }
 ```
+-->

--- a/packages/@okta/vuepress-site/docs/release-notes/2020/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2020/index.md
@@ -152,7 +152,7 @@ For API requests that return a Group or a list of Groups, the Group object inclu
 
 #### MyAccount API is now in Early Access (EA)
 
-The [MyAccount API](/docs/reference/api/myaccount/) enables non-administrator end users to fetch their Okta user profiles. To enable this EA feature, contact [Support](https://support.okta.com/help/open_case). <!--OKTA-342090-->
+The [MyAccount API](https://developer.okta.com/docs/api/openapi/okta-myaccount/myaccount/tag/Profile/) enables non-administrator end users to fetch their Okta user profiles. To enable this EA feature, contact [Support](https://support.okta.com/help/open_case). <!--OKTA-342090-->
 
 #### Bug fixed in 2020.11.0
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2022-okta-identity-engine/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2022-okta-identity-engine/index.md
@@ -581,7 +581,7 @@ You can now edit the secondary factor in the default rule of the global session 
 
 #### Improved error messages for MyAccount API
 
-The [MyAccount API](/docs/reference/api/myaccount/) includes improved error messages for end users to identify why email and phone operations couldn't be completed or accessed. <!-- OKTA-484080 -->
+The [MyAccount API](https://developer.okta.com/docs/api/openapi/okta-myaccount/guides/overview/) includes improved error messages for end users to identify why email and phone operations couldn't be completed or accessed. <!-- OKTA-484080 -->
 
 #### Developer documentation updates in 2022.08.0
 
@@ -675,7 +675,7 @@ You can now choose which origins can embed Okta sign-in pages and the Okta End-U
 
 #### User-scoped MyAccount API is GA in Production
 
-The MyAccount API now provides user-scoped endpoints that don't require admin tokens. The new endpoint is `/idp/myaccount`. End users only need a bearer token to update their email and phone authenticators. Additionally, app developers can call the MyAccount API for active users outside of the authentication context. For example, after a user enrolls in the mandatory email factor and completes authentication, app developers can call the API to enroll the active user with the optional phone authenticator. See [MyAccount API](/docs/reference/api/myaccount/). <!-- OKTA-508478 -->
+The MyAccount API now provides user-scoped endpoints that don't require admin tokens. The new endpoint is `/idp/myaccount`. End users only need a bearer token to update their email and phone authenticators. Additionally, app developers can call the MyAccount API for active users outside of the authentication context. For example, after a user enrolls in the mandatory email factor and completes authentication, app developers can call the API to enroll the active user with the optional phone authenticator. See [MyAccount API](https://developer.okta.com/docs/api/openapi/okta-myaccount/guides/overview/). <!-- OKTA-508478 -->
 
 #### Developer documentation updates in 2022.07.0
 
@@ -821,7 +821,7 @@ While Okta provides out-of-the-box telephony functionality, many customers need 
 
 #### User-scoped MyAccount API is GA in Preview
 
-The MyAccount API now provides user-scoped endpoints that don't require admin tokens. The new endpoint is `/idp/myaccount`. End users only need a bearer token to update their email and phone authenticators. In addition, app developers can call the MyAccount API for active users outside of the authentication context. For example, after a user enrolls in the mandatory email factor and completes authentication, app developers can call the API to enroll the active user with the optional phone authenticator. See [MyAccount API](/docs/reference/api/myaccount/). <!-- OKTA-496877 -->
+The MyAccount API now provides user-scoped endpoints that don't require admin tokens. The new endpoint is `/idp/myaccount`. End users only need a bearer token to update their email and phone authenticators. In addition, app developers can call the MyAccount API for active users outside of the authentication context. For example, after a user enrolls in the mandatory email factor and completes authentication, app developers can call the API to enroll the active user with the optional phone authenticator. See [MyAccount API](https://developer.okta.com/docs/api/openapi/okta-myaccount/guides/overview/). <!-- OKTA-496877 -->
 
 #### Bugs fixed in 2022.06.0
 
@@ -862,7 +862,7 @@ The MyAccount API now provides user-scoped endpoints that don't require admin to
 
 #### User-scoped MyAccount API is EA in Preview
 
-The MyAccount API now provides user-scoped endpoints that don't require admin tokens. The new endpoint is `/idp/myaccount`. End users only need a bearer token to update their email and phone authenticators. In addition, app developers can call the MyAccount API for active users outside of the authentication context. For example, after a user enrolls in the mandatory email factor and completes authentication, app developers can call the API to enroll the active user with the optional phone authenticator. See [MyAccount API](/docs/reference/api/myaccount/).
+The MyAccount API now provides user-scoped endpoints that don't require admin tokens. The new endpoint is `/idp/myaccount`. End users only need a bearer token to update their email and phone authenticators. In addition, app developers can call the MyAccount API for active users outside of the authentication context. For example, after a user enrolls in the mandatory email factor and completes authentication, app developers can call the API to enroll the active user with the optional phone authenticator. See [MyAccount API](https://developer.okta.com/docs/api/openapi/okta-myaccount/guides/overview/).
 
 #### Progressive Enrollment is EA in Preview
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2022/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2022/index.md
@@ -650,7 +650,7 @@ The `/factors` endpoint has a new optional request parameter for the [Reset Fact
 
 #### Bugs fixed in 2022.05.3
 
-* If the new `/idp` version of the [MyAccount API](/docs/reference/api/myaccount/) wasn't enabled, [Add My Phone](/docs/reference/api/myaccount/#add-my-phone) or [Challenge My Phone](/docs/reference/api/myaccount/#challenge-my-phone) operations performed on the `/idp/myaccount/` endpoint returned inconsistent exception errors. (OKTA-494004)
+* If the new `/idp` version of the [MyAccount API](https://developer.okta.com/docs/api/openapi/okta-myaccount/myaccount/tag/Profile/) wasn't enabled, [Add My Phone](https://developer.okta.com/docs/api/openapi/okta-myaccount/myaccount/tag/Phone/#tag/Phone/operation/createPhone) or [Challenge My Phone](https://developer.okta.com/docs/api/openapi/okta-myaccount/myaccount/tag/Phone/#tag/Phone/operation/sendPhoneChallenge) operations performed on the `/idp/myaccount/` endpoint returned inconsistent exception errors. (OKTA-494004)
 
 * Post calls to the Org API endpoint that creates an email bounces remove list (`/org/email/bounces/remove-list`) sometimes returned an HTTP 500 Internal Server Error. (OKTA-497859)
 


### PR DESCRIPTION
## Description:
- **What's changed?** Deprecates the MyAccount API docs from VuePress. 
- **Is this PR related to a Monolith release?** No.

### Resolves:

* [OKTA-628414](https://oktainc.atlassian.net/browse/OKTA-628414)
