### PR TITLE
Updated text for for setting is_oie

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/terraform-manage-user-access/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/terraform-manage-user-access/main/index.md
@@ -140,7 +140,7 @@ Configure the email authenticator and then create a group, global session policy
 1. Add an `okta_policy_mfa` resource to create an authenticator enrollment policy.
 
    1. Set `status` to `ACTIVE`.
-   1. Set `is_oie` to `true` if you’re using the Okta Identity Engine.
+   1. Set `is_oie` to `true`. Okta Classic supports only setting `okta_password` to `REQUIRED`.
    1. Set `groups_included` to the passwordless group ID.
    1. Set `okta_email` to `REQUIRED` to require users to enroll in the email authenticator.
    1. Set `okta_password` to `NOT_ALLOWED` to prevent users from enrolling in the password authenticator.
@@ -310,7 +310,7 @@ This example requires the same scopes as the passwordless sign-in example: `okta
 1. Add an `okta_policy_mfa` resource to create an authenticator enrollment policy.
 
    1. Set `status` to `ACTIVE`.
-   1. Set `is_oie` to `true` if you’re using the Identity Engine.
+   1. Set `is_oie` to `true`. Okta Classic supports only setting `okta_password` to `REQUIRED`.
    1. Set `groups_included` to the multifactor group ID.
    1. Set `okta_email` to `REQUIRED` to require users to enroll in the email authenticator.
    1. Set `okta_verify` to `OPTIONAL` to allow users to enroll in Okta Verify.


### PR DESCRIPTION
## Description:
Updated the text for the two instances of setting is_oie when okta_password is also set to a value other than `REQUIRED`.

A simple fix with one line updated in two places.
Original line:
Set `is_oie` to `true` if you’re using the Identity Engine.`
New line:
Set `is_oie` to `true`. Okta Classic supports only setting `okta_password` to `REQUIRED`.

Updated sections:
- https://developer.okta.com/docs/guides/terraform-manage-user-access/main/#configure-a-passwordless-sign-in-flow
Step 5, sub-step 2
- https://developer.okta.com/docs/guides/terraform-manage-user-access/main/#configure-a-multifactor-sign-in-flow
Step 3, sub-step 2
### Resolves:
* [OKTA-633840](https://oktainc.atlassian.net/browse/OKTA-633840)
