### PR TITLE
OKTA-593826 - Remove EA tags for access policy simulation 

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/policy-simulation/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/policy-simulation/main/index.md
@@ -4,8 +4,6 @@ excerpt: Provides documentation on testing your policies using the Policy APIs s
 layout: Guides
 ---
 
-<ApiLifecycle access="ea" />
-
 This guide explains how to test your access policies by using the `/simulate` endpoint of the Policy API.
 
 ---
@@ -19,7 +17,6 @@ This guide explains how to test your access policies by using the `/simulate` en
 
 * [Okta Preview organization](https://developer.okta.com/login)
 * An app to test your access policies
-* The Early Access self-service Access Test Tool feature enabled on your org. See [Early Access](/docs/reference/releases-at-okta/#early-access-ea).
 
 **Sample code**
 

--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -313,9 +313,8 @@ Array of [Application objects](/docs/reference/api/apps/#application-object)
 
 ## Policy simulation operations
 <ApiLifecycle access="ie" />
-<ApiLifecycle access="ea" />
 
-> **Note:** This self-service Early Access feature is only available as a part of the Identity Engine. To enable this feature, see [Early Access](/docs/reference/releases-at-okta/#early-access-ea). For information on the Identity Engine, [contact support](mailto:dev-inquiries@okta.com).
+> **Note:** This feature is only available as a part of the Identity Engine. For information on the Identity Engine, [contact support](mailto:dev-inquiries@okta.com).
 
 ### Access simulation
 


### PR DESCRIPTION

<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Removed the EA tags from the [Policy API](https://developer.okta.com/docs/reference/api/policy/#policy-simulation-operations) and the [Test your policies with access simulations ](https://developer.okta.com/docs/guides/policy-simulation/main/)guide.
- **Is this PR related to a Monolith release?** 2023.08.0

### Resolves:

* [OKTA-593826](https://oktainc.atlassian.net/browse/OKTA-593826)
