### PR TITLE
Update SignUp.vue to correct free trial access length

### DIFF
--- a/packages/@okta/vuepress-theme-prose/global-components/SignUp.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/SignUp.vue
@@ -68,7 +68,7 @@
                   Free Trial
                 </div>
                 <div class="signup__rate__text">
-                  Get access for 22 days
+                  Get access for 30 days
                 </div>
               </div>
               <div class="signup__content">


### PR DESCRIPTION
## Description:
- **What's changed?** Updated the Signup page free trial term to 30 days (it incorrectly said it was 22 days) at request from Yon Xiao (PM).

### Resolves:

* [OKTA-634186](https://oktainc.atlassian.net/browse/OKTA-634186)
