### PR TITLE
Update index.md adding traditional pkcs flag

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/terraform-design-access-security/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/terraform-design-access-security/main/index.md
@@ -43,6 +43,7 @@ With this flow, Terraform uses credentials to request access to your org. The se
 The credentials used for this flow are a public/private key pair. Okta stores the public key in the service app, and Terraform uses the private key in the configuration. You can [generate the key pair](/docs/guides/implement-oauth-for-okta-serviceapp) in the Okta service app or with your own secure internal methods. See [Create access credentials](/docs/guides/terraform-enable-org-access/main/#create-access-credentials).
 
 > **Note:** The Okta Terraform Provider requires the private key to use PKCS#1 encoding.
+You may have to use the following command to convert the key to a 'traditional' RSA format `openssl pkey -in {ORIGINAL_PRIVATE_KEY} -out {CONVERTED_PRIVATE_KEY} -traditional`
 Okta recommends storing the private key in a separate and secure location and using a secrets and encryption management system, such as Hashicorp Vault. You can use input variables and environment variables to provide credentials to Terraform.
 
 > **Note:** Don't store credentials as plain text in your Terraform configuration.

--- a/packages/@okta/vuepress-site/docs/guides/terraform-enable-org-access/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/terraform-enable-org-access/main/index.md
@@ -85,7 +85,7 @@ Check that the generated private key is in PKCS#1 format, which is the format re
    * `ORIGINAL_PRIVATE_KEY`: The file that contains the key generated earlier.
    * `CONVERTED_PRIVATE_KEY`: The file that contains the converted key.
 
-> **Note:** The file that contains the converted private key must begin with `-----BEGIN RSA PRIVATE KEY-----`. If not, try step two again.
+> **Note:** The file that contains the converted private key must begin with `-----BEGIN RSA PRIVATE KEY-----`. You may have to use the following command to convert the key to a 'traditional' RSA format `openssl pkey -in {ORIGINAL_PRIVATE_KEY} -out {CONVERTED_PRIVATE_KEY} -traditional`
 
 ## Add credentials to Terraform
 


### PR DESCRIPTION
I found I had to use this alternative syntax to convert my private key into a usable format

<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** New alternative syntax to enable private key auth to work.