### PR TITLE
Add promo banner to dev.okta.com hero for workshops & Oktane

### DIFF
--- a/packages/@okta/vuepress-theme-prose/components/Hero.vue
+++ b/packages/@okta/vuepress-theme-prose/components/Hero.vue
@@ -1,5 +1,9 @@
 <template>
-  <section class="hero">
+  <!-- Remove style attribute from .hero section when removing promo banner -->
+  <section
+    class="hero"
+    style="padding-top: 28px; padding-bottom: 28px;"
+  >
     <div class="hero__wrapper wrapper">
       <h1 class="hero__title dont-break-out">
         Okta developer
@@ -7,6 +11,19 @@
       <p class="hero__paragraph dont-break-out">
         Our developer portal enables you to deploy auth that protects your users, apps, APIs, and infrastructure.
       </p>
+      <!-- Start workshops & Oktane promo banner -->
+      <p style="color: white; font-size: 18px; line-height: 1.4; max-width: 500px;">
+        Get your app <a
+          style="color: white; text-decoration: underline;"
+          href="https://regionalevents.okta.com/enterprisereadyworkshops"
+          target="_blank"
+        >enterprise-ready with free virtual workshops</a>, then <a
+          style="color: white; text-decoration: underline;"
+          href="https://www.okta.com/oktane/developers/"
+          target="_blank"
+        >join us for Developer Day</a> at Oktane on Oct. 5!
+      </p>
+      <!-- End workshops & Oktane promo banner -->
     </div>
   </section>
 </template>


### PR DESCRIPTION
## Description:
- **What's changed?** Promo text / links added to the dev.okta landing page hero promoting Developer Advocacy enterprise-ready workshops and registration for Developer Day at Oktane 2023, as per [banner update wiki instructions](https://oktawiki.atlassian.net/wiki/spaces/DOC/pages/2711619131/Add+a+banner+to+the+home+page). Also added supporting inline CSS styles to fix layout to accommodate banner.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-638902](https://oktainc.atlassian.net/browse/OKTA-638902)
