### PR TITLE
Update WIC free trial link as requested

### DIFF
--- a/packages/@okta/vuepress-theme-prose/global-components/SignUp.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/SignUp.vue
@@ -84,7 +84,7 @@
               </div>
               <div class="signup__link">
                 <a 
-                  href="http://www.okta.com/free-trial" 
+                  href="https://okta.com/free-trial/workforce-identity" 
                   target="_blank"
                 >
                   <span>Try Workforce Identity Cloud <i>→</i></span>


### PR DESCRIPTION
## Description:
- **What's changed?** Update WIC trial URL on Sign Up page per request.

URL changed from `https://www.okta.com/free-trial` to `https://okta.com/free-trial/workforce-identity`

### Resolves:

* [OKTA-641496](https://oktainc.atlassian.net/browse/OKTA-641496)
