### PR TITLE
OKTA-638115 Small updates to System Log API and core operators table

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
@@ -663,7 +663,7 @@ The following example expressions are supported for events with the `filter` que
 
 See [Filtering](/docs/reference/core-okta-api/#filter) for more information on expressions.
 
-The following are examples of common filter expressions:
+The following are examples of filter expressions:
 
 * Events that are published for a target user
 ```javascript
@@ -693,6 +693,21 @@ filter=eventType eq "app.auth.sso" and target.id eq "00uxc78lMKUMVIHLTAXY" and t
 * Events that are published for a given IP address
 ```javascript
 filter=client.ipAddress eq "184.73.186.14"
+```
+
+* Events that start with event_hook
+```javascript
+filter=eventType sw "event_hook"
+```
+
+* Events that contain session
+```javascript
+filter=eventType co "session"
+```
+
+* Events that end with token
+```javascript
+filter=eventType ew "token"
 ```
 
 ###### Keyword filter

--- a/packages/@okta/vuepress-site/docs/reference/core-okta-api/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/core-okta-api/index.md
@@ -284,6 +284,16 @@ Most of the operators listed in the [SCIM Protocol Specification](https://www.rf
 
 > **Note:** All `Date` values use the ISO 8601 format `YYYY-MM-DDTHH:mm:ss.SSSZ`.
 
+> **Note:** The [System Log](/docs/reference/api/system-log#filtering-results) API can use the operators contains (`co`) and ends with (`ew`).
+
+> **Notes:**
+
+    * xyz
+
+    * xyz
+
+    * xyz
+
 #### Attribute operators
 
 | Operator | Description | Behavior                                                         |

--- a/packages/@okta/vuepress-site/docs/reference/core-okta-api/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/core-okta-api/index.md
@@ -278,21 +278,11 @@ Most of the operators listed in the [SCIM Protocol Specification](https://www.rf
 | `pr`       | present (has value)   | If the attribute has a non-empty value or if it contains a non-empty node for complex attributes, there is a match.                                                                                                                                                           |
 | `sw`       | starts with           | The entire operand value must be a substring of the attribute value that starts at the beginning of the attribute value. This criterion is satisfied if the two strings are identical.                                                                                         |
 
-> **Note:** Some objects don't support all the listed operators.
-
-> **Note:** The `ne` (not equal) operator isn't supported for some objects, but you can obtain the same result by using `lt ... or ... gt`. For example, to see all user agents except for "iOS", use `(client.userAgent.os lt "iOS" or client.userAgent.os gt "iOS")`.
-
-> **Note:** All `Date` values use the ISO 8601 format `YYYY-MM-DDTHH:mm:ss.SSSZ`.
-
-> **Note:** The [System Log](/docs/reference/api/system-log#filtering-results) API can use the operators contains (`co`) and ends with (`ew`).
-
 > **Notes:**
-
-    * xyz
-
-    * xyz
-
-    * xyz
+> * Some objects don't support all the listed operators.
+> * The `ne` (not equal) operator isn't supported for some objects, but you can obtain the same result by using `lt ... or ... gt`. For example, to see all user agents except for "iOS", use `(client.userAgent.os lt "iOS" or client.userAgent.os gt "iOS")`.
+> * All `Date` values use the ISO 8601 format `YYYY-MM-DDTHH:mm:ss.SSSZ`.
+> * The [System Log API](/docs/reference/api/system-log/#filtering-results) supports the operators contains (`co`) and ends with (`ew`).
 
 #### Attribute operators
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Added 3 additional filter examples using `co` and `ew`; added a note on [core okta api operators table](https://developer.okta.com/docs/reference/core-okta-api/#operators) noting that system log api supports `co` and `ew`.
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* [OKTA-638115](https://oktainc.atlassian.net/browse/OKTA-638115)
