### PR TITLE
OKTA-642005 Global Session Policy default rule properties read-only

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/shared-sso-android-ios/main/ios/enablesso.md
+++ b/packages/@okta/vuepress-site/docs/guides/shared-sso-android-ios/main/ios/enablesso.md
@@ -28,7 +28,7 @@ Before you begin, be sure to:
     ```
 
 7. In the response, locate the rule that you want to modify, copy its `id` value, and copy the `actions` property section of the JSON payload.
-    > **Note:** The rule named `Default Rule` cannot be modified. Therefore, copy the `id` value of a custom rule instead. If you only see a `Default Rule` in the response, then you should first [create a custom rule](/docs/guides/customize-authz-server/create-rules-for-policy/).
+    > **Note:** You can't modify the `Default Rule` properties `usePersistentCookie` or `maxSessionLifetimeMinutes`. Copy the `id` value of a custom rule instead. If you only see a `Default Rule` in the response, then you should first [create a custom rule](/docs/guides/customize-authz-server/create-rules-for-policy/).
 
     > **Tip:** You can also highlight the rule ID, right-click, and set it as the value for the `ruleId` variable in your environment.
 8. Click the **Update Global Session Policy rule** request to open it.

--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -887,7 +887,9 @@ Each Policy may contain one or more Rules. Rules, like Policies, contain conditi
 
 ### Default Rules
 
-* Only the default Policy contains a default Rule. In Okta Classic Engine, you can't delete or edit default rules. In Okta Identity Engine, you can't delete default rules, but can edit them except for the properties `maxSessionLifetimeMinutes` and `usePersistentCookie` of the Global session policy. Default rules on the Authenticator Enrollment policy and the Identity Provider Routing also can't be edited.
+* Only the default Policy contains a default Rule. In Okta Classic Engine, you can't delete or edit default rules. In Okta Identity Engine, you can't delete default rules, but can edit them except for:
+  * The properties `maxSessionLifetimeMinutes` and `usePersistentCookie` of the default Global session policy's default rule, which are read-only.
+  * The default rules on the Authenticator Enrollment policy and the Identity Provider Routing, which are also read-only.
 * The default Rule is required and always is the last Rule in the priority order. If you add Rules to the default Policy, they have a higher priority than the default Rule.
 * The `system` attribute determines whether a Rule is created by a system or by a user. The default Rule is the only Rule that has this attribute.
 

--- a/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/policy/index.md
@@ -887,9 +887,9 @@ Each Policy may contain one or more Rules. Rules, like Policies, contain conditi
 
 ### Default Rules
 
- - Only the default Policy contains a default Rule. In Okta Classic Engine, you can't delete or edit default rules. In Okta Identity Engine, you can't delete default rules, but can edit them except in the case of the default rule on the Authenticator Enrollment policy and the Identity Provider Routing.
- - The default Rule is required and always is the last Rule in the priority order. If you add Rules to the default Policy, they have a higher priority than the default Rule.
- - The `system` attribute determines whether a Rule is created by a system or by a user. The default Rule is the only Rule that has this attribute.
+* Only the default Policy contains a default Rule. In Okta Classic Engine, you can't delete or edit default rules. In Okta Identity Engine, you can't delete default rules, but can edit them except for the properties `maxSessionLifetimeMinutes` and `usePersistentCookie` of the Global session policy. Default rules on the Authenticator Enrollment policy and the Identity Provider Routing also can't be edited.
+* The default Rule is required and always is the last Rule in the priority order. If you add Rules to the default Policy, they have a higher priority than the default Rule.
+* The `system` attribute determines whether a Rule is created by a system or by a user. The default Rule is the only Rule that has this attribute.
 
 ### Rule priority
 
@@ -1395,8 +1395,8 @@ The following conditions may be applied to the global session policy.
 | Property                  | Description                                                                                                                                                                                                                                                               | Data Type | Required | Default |
 | ---                       | ---                                                                                                                                                                                                                                                                       | ---       | ---      | ---     |
 | maxSessionIdleMinutes     | Maximum number of minutes that a User session can be idle before the session is ended.                                                                                                                                                                                    | Integer   | No       | 120     |
-| maxSessionLifetimeMinutes | Maximum number of minutes from User sign in that a user's session is active. Set this to force Users to sign in again after the number of specified minutes. Disable by setting to `0`.                                                                                  | Integer   | No       | 0       |
-| usePersistentCookie       | If set to `false`, User session cookies only last the length of a browser session. If set to `true`, User session cookies last across browser sessions. This setting doesn't impact Okta Administrator users who can *never* have persistant session cookies. | Boolean   | No       | false   |
+| maxSessionLifetimeMinutes | Maximum number of minutes from User sign in that a user's session is active. Set this to force Users to sign in again after the number of specified minutes. Disable by setting to `0`. This property is read-only for the default rule of the default Global session policy.                                                                                 | Integer   | No       | 0       |
+| usePersistentCookie       | If set to `false`, User session cookies only last the length of a browser session. If set to `true`, User session cookies last across browser sessions. This setting doesn't impact Okta Administrator users who can *never* have persistent session cookies. This property is read-only for the default rule of the default Global session policy. | Boolean   | No       | false   |
 
 ### Rules conditions
 


### PR DESCRIPTION

## Description:
- **What's changed?** Updated the Policy API and one guide with details on the `maxSessionLifetimeMinutes` and `usePersistentCookie` properties being read-only for the default policy's default rule
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* [OKTA-642005](https://oktainc.atlassian.net/browse/OKTA-642005)
