### PR TITLE
[Editing test for Andreea Jurj] Initial editorial pass

### DIFF
--- a/packages/@okta/vuepress-site/docs/concepts/oie-intro/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/oie-intro/index.md
@@ -2,13 +2,13 @@
 title: Generating Dynamic Email by Using the Okta Identity Engine
 meta:
   - name: description
-    content: This section explains how you can use the Okta Identity Engine to customize the style and content of email messages dynamically based on the app that triggers the email notification.
+    content: This page explains the main features of Okta Identity Engine, including the authentication deployment models, the Interaction Code grant type, authentication policies, app context, and app intent links. It also provides SDKs and sample apps that can help you explore these features.
 ---
 
 <ApiLifecycle access="ie" />
 
 # How Okta Identity Engine works
-This page explains the key concepts and features of [Okta Identity Engine](https://help.okta.com/oie/en-us/content/topics/identity-engine/oie-index.htm) and the areas in which it differs from [Okta Classic Engine](/docs/guides/archive-overview/main/).
+This page explains the main features of [Okta Identity Engine](https://help.okta.com/oie/en-us/content/topics/identity-engine/oie-index.htm), including the authentication deployment models, the Interaction Code grant type, authentication policies, app context, and app intent links. It also explains some of the areas in which Okta Identity Engine differs from [Okta Classic Engine](/docs/guides/archive-overview/main/) and provides links to SDKs and sample apps that can help you explore these features.
 
 > **Notes:**
 > * From March 1, 2022, all new [Okta organizations](/docs/concepts/okta-organizations/) use Identity Engine.

--- a/packages/@okta/vuepress-site/docs/concepts/oie-intro/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/oie-intro/index.md
@@ -8,7 +8,7 @@ meta:
 <ApiLifecycle access="ie" />
 
 # How Okta Identity Engine works
-Okta Identity Engine lets users customize the style and content of emails dynamically, based on the app that triggers the email notification. This page explains the key concepts and features of [Okta Identity Engine](https://help.okta.com/oie/en-us/content/topics/identity-engine/oie-index.htm) and the areas in which it differs from [Okta Classic Engine](/docs/guides/archive-overview/main/).
+This page explains the key concepts and features of [Okta Identity Engine](https://help.okta.com/oie/en-us/content/topics/identity-engine/oie-index.htm) and the areas in which it differs from [Okta Classic Engine](/docs/guides/archive-overview/main/).
 
 > **Notes:**
 > * From March 1, 2022, all new [Okta organizations](/docs/concepts/okta-organizations/) use Identity Engine.
@@ -17,7 +17,7 @@ Okta Identity Engine lets users customize the style and content of emails dynami
 >     
 >   * Current Classic Engine users can continue to use the Classic Engine organization, and the v1 APIs and SDKs. For information about upgrading your Classic Engine instance to Identity Engine, see [Identity Engine upgrade overview](/docs/guides/oie-upgrade-overview/main/) on the Okta Developer Portal.
 >     
-> * Documentation that covers features exclusive to Identity Engine begins with a blue **Identity Engine** badge.
+> * Documentation that covers features exclusive to Identity Engine begins with a blue <span class="api-label api-label-ie">Identity Engine</span> badge.
 
 
 <a id="authentication-deployment-models"></a>
@@ -59,7 +59,7 @@ Identity Engine also lets you create flexible apps that can change their authent
 
 <a id="app-context"></a>
 ## App context
-When a user begins to authenticate to a system, Identity Engine provides an _app context_, which comprises the variables from email templates that allow the customization of email messages. For more information, see the following resources on the Okta Developer Portal:
+When a user begins to authenticate to a system, Identity Engine provides an _app context_, functionality which uses the variables from email templates to enable the customization of the style and content of email messages based on the app that triggers the email notification. For more information, see the following resources on the Okta Developer Portal:
 
 * [Use customizable email templates](/docs/guides/custom-email/main/#use-customizable-email-templates)
   

--- a/packages/@okta/vuepress-site/docs/concepts/oie-intro/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/oie-intro/index.md
@@ -1,90 +1,118 @@
 ---
-title: Okta Identity Engine overview
+title: Generating Dynamic Email by Using the Okta Identity Engine
 meta:
   - name: description
-    content: Find out more about Okta's Identity Engine authentication flow, what developer features it unlocks, and how to use it.
+    content: This section explains how you can use the Okta Identity Engine to customize the style and content of email messages dynamically based on the app that triggers the email notification.
 ---
-# Okta Identity Engine overview
 
 <ApiLifecycle access="ie" />
 
-Okta Identity Engine is Okta's new authentication pipeline that provides valuable new features and a more flexible approach to your auth needs. This article provides a high-level introduction.
+# How Okta Identity Engine works
+Okta Identity Engine lets users customize the style and content of emails dynamically, based on the app that triggers the email notification. This page explains the key concepts and features of [Okta Identity Engine](https://help.okta.com/oie/en-us/content/topics/identity-engine/oie-index.htm) and the areas in which it differs from [Okta Classic Engine](/docs/guides/archive-overview/main/).
 
-Below we explain what new features Identity Engine brings to the table, we discuss the deployment models that make use of these features and show how our documentation experience is changing to support it.
+> **Notes:**
+> * From March 1, 2022, all new [Okta organizations](/docs/concepts/okta-organizations/) use Identity Engine.
+>   
+>   * To identify your Okta solution, see the version in the footer of your Admin Console. The letter **E** following the version denotes Identity Engine, while the letter **C** denotes Classic Engine.
+>     
+>   * Current Classic Engine users can continue to use the Classic Engine organization, and the v1 APIs and SDKs. For information about upgrading your Classic Engine instance to Identity Engine, see [Identity Engine upgrade overview](/docs/guides/oie-upgrade-overview/main/) on the Okta Developer Portal.
+>     
+> * Documentation that covers features exclusive to Identity Engine begins with a blue **Identity Engine** badge.
 
-> **Note**: If you are an admin, or are looking for product docs related to Identity Engine, see the Identity Engine [Get started page](https://help.okta.com/okta_help.htm?type=oie&id=ext-get-started-oie) over in the Okta Help Center.
 
-## Identity Engine new features
-
-Identity Engine unlocks many new capabilities.
-
-### App context in email templates
-
-Identity Engine makes the app context available when a user enters an authentication flow. Context variables are available in our email templates, allowing customers to dynamically customize email style and content based on the app that an email notification is triggered from.
-
-See [Customize email notifications > Use app context](/docs/guides/custom-email/main/#use-app-context).
-
-### App intent links
-
-App intent links are used to signal intent to access an application. These links are protocol-specific endpoints that you can use to initiate a sign-in flow to an application. Both Identity Provider and Service Provider initiated flows are supported.
-
-Example app intent link for a SAML application:
-`http://${yourOktaDomain}/app/mysamlapp_1/${appInstanceID}/sso/saml`
-
-Prior to Okta Identity Engine, these endpoints were accessible only with a session. Unauthenticated traffic was redirected to a centralized sign-in page (`/login/login.htm`) with a `fromUri` that represented the app that was originally attempted (the app intent link). This occurred before the request was assessed for rate limiting. A session was established and the request was processed. The user was then redirected to the relevant app intent link through an intermediate redirect to the generic app single-sign on endpoint (`/app/${app}/${instanceId}/${linkName}`). The app intent link endpoint validated that the user was assigned to the application, and then enforced the app sign-on policy.
-
-Okta Identity Engine changed the way Okta processes these requests. Identity Engine no longer forwards requests to the centralized sign-in page (`/login/login.htm`). Instead, the app intent links location hosts the widget/sign-in experience for the app that the user is attempting to access and evaluate the Global Session Policy, authentication policy, and all other policies relevant to the sign-in experience. Since each app intent link is responsible for hosting the sign-in experience on Identity Engine, they share a common app intent link rate limit bucket/group similar to what existed for the centralized sign-in page on Classic Engine.
-
-### Authentication policies
-
-Authentication policies are [security policy frameworks](https://csrc.nist.gov/publications/detail/sp/800-63b/final) that allow organizations to model security outcomes for an app. These policies are shareable across applications. For example, you can automatically step up authentication to a strong non-phishable factor when elevated risk is detected. Additionally, Identity Engine allows you to create flexible apps that can change their authentication methods without having to alter a line of code.
-
-* [Configure a global session policy and authentication policies](/docs/guides/configure-signon-policy/)
-
-* [Authentication policies](https://help.okta.com/okta_help.htm?type=oie&id=ext-about-asop)
-
-* [Policies (high-level concept)](/docs/concepts/policies/)
-
-### CAPTCHA
-
-CAPTCHA is a well-known strategy for mitigating attacks by bots. Identity Engine offers registration, sign-in, and account recovery integration of the two market-leading CAPTCHA services: [hCAPTCHA](https://www.hcaptcha.com/) and [reCAPTCHA](https://www.google.com/recaptcha/about/). These are usable through the Okta-hosted and embedded Sign-In Widgets, but not SDKs.
-
-### Interaction code grant type for embedded authentication
-
-To enable a more customized user authentication experience, Okta introduces an extension to the [OAuth 2.0 and OpenID Connect](/docs/concepts/oauth-openid) standard called the [Interaction Code grant type](/docs/concepts/interaction-code/). This grant type allows apps using an embedded Okta Sign-In Widget and/or SDK to manage user interactions with the authorization server directly, rather than relying on a browser-based redirect to an authentication component (such as the Sign-In Widget).
-
+<a id="authentication-deployment-models"></a>
 ## Authentication deployment models
+Identity Engine uses three user authentication deployment models:
 
-You can divide the Identity Engine user authentication deployment model into three approaches:
+* **Redirect Okta-hosted Sign-In Widget**: Use the widget to authenticate your users, then redirect them back to your app.
 
-* **Okta-hosted (redirect) Sign-In Widget**: Use the redirect (Okta-hosted) Sign-In Widget to authenticate your users, then redirect back to your app. This is the recommended approach as it's the most secure and fastest to implement.
-* **Embedded Sign-In Widget**: Embed the Sign-In Widget into your own code base to handle the authentication on your servers. This provides a balance between complexity and customization.
-* **Embedded SDK-driven sign-in flow**: Use our SDKs to create a completely custom authentication experience. This option is the most complex and leaves you with the most responsibility, but offers the most control.
+  > **Tip:** We strongly recommend this approach because it is the most secure and the fastest to implement.
+  
+* **Embedded Sign-In Widget**: To enable the handling of authentication on your own server, embed the Sign-In Widget into your code.
+  
+* **Embedded SDK-driven sign-in flow**: To create a completely custom authentication experience, use the Okta SDKs.
 
-See [Okta deployment models &mdash; redirect vs. embedded](/docs/concepts/redirect-vs-embedded/) for an overview of the different deployment models, and see [Sign users in](/docs/guides/sign-in-overview/) for practical implementation details.
+For more information, see the following resources on the Okta Developer Portal:
 
+* [Okta deployment models: redirect and embedded](/docs/concepts/redirect-vs-embedded/)
+  
+* [User sign-in overview](/docs/guides/sign-in-overview/main/)
+
+
+<a id="interaction-code-grant-type-embedded-authentication"></a>
+### Interaction Code grant type for embedded authentication
+The [Interaction Code grant type](/docs/concepts/interaction-code/) is an extension for the [OAuth 2.0 and OpenID Connect standards](/docs/concepts/oauth-openid/) that enables a custom user authentication experience.
+
+This grant type lets apps manage user interactions with the authorization server directly by using an embedded Okta Sign-In Widget or SDK (rather than by relying on a browser-based redirect to an authentication component).
+
+
+<a id="authentication-policies"></a>
+## Authentication policies
+Authentication policies are [security policy frameworks](https://www.okta.com/resources/whitepaper/okta-security-technical-white-paper/) that let organizations model security outcomes for an app. Identity Engine lets you share these policies across apps. For example, if the system detects an elevated risk, you can increase authentication to a factor that resists [phishing](https://en.wikipedia.org/wiki/Phishing).
+
+Identity Engine also lets you create flexible apps that can change their authentication methods without changing any of the underlying code. For more information, see the following resources:
+
+* [What are policies](/docs/concepts/policies/) and [Configure a global session policy and authentication policies](/docs/guides/configure-signon-policy/main/) on the Okta Developer Portal
+
+* [Authentication policies](https://help.okta.com/okta_help.htm?type=oie&id=ext-about-asop) in the Okta Help Center
+
+
+<a id="app-context"></a>
+## App context
+When a user begins to authenticate to a system, Identity Engine provides an _app context_, which comprises the variables from email templates that allow the customization of email messages. For more information, see the following resources on the Okta Developer Portal:
+
+* [Use customizable email templates](/docs/guides/custom-email/main/#use-customizable-email-templates)
+  
+* [Customization example](/docs/guides/custom-email/main/#customization-example)
+
+<a id="app-intent-links"></a>
+
+## App intent links
+_App intent_ links are protocol-specific endpoints that signal a system's intent to access an app. You can use app intent links to initiate sign-in flow to an app.
+
+> **Tip:**
+> 
+> * Identity Provider and Service Provider flows support app intent links.
+>
+> * Similarly to Classic Engine, Identity Engine provides a centralized sign-in page with its own rate limit to help control traffic and prevent abuse.
+
+The following is an example app intent link for a SAML app:
+
+```
+http://${yourOktaDomain}/app/mysamlapp_1/${appInstanceID}/sso/saml
+```
+
+The location of the app intent link hosts the widget or sign-in experience for the app that the user attempts to access and evaluates the global session policy, authentication policy, and any other policies that might be relevant to the sign-in experience.
+
+
+<a id="app-intent-links-differences-from-classic-engine"></a>
+### Differences from Okta Classic Engine functionality
+[Okta Classic Engine](https://help.okta.com/en-us/content/index-admin.htm) allows access to these endpoints only by establishing a session and processing a request:
+
+1. Before the system assesses the request for rate-limiting purposes, it redirects unauthenticated traffic to a centralized sign-in page (for example, `/login/login.html`).
+
+   The `fromUri` query parameter contains the link to the app that the system attempts to access.
+   
+1. The system performs an intermediate redirect to a generic app SSO endpoint (`/app/${app}/${instanceId}/${linkName}` and then brings the user to the correct app intent link.
+   
+1. The app intent link endpoint validates that the user is authorized to access the app and then enforces the app sign-on policy.
+
+
+<a id="captcha"></a>
+## CAPTCHA (Bot Detection)
+[CAPTCHA](https://en.wikipedia.org/wiki/CAPTCHA) is a strategy that lets you mitigate automated (bot) attacks by verifying that the user is human. Identity Engine integrates with the following CAPTCHA services by using Okta-hosted and embedded Sign-In Widgets:
+
+* [hCAPTCHA](https://www.hcaptcha.com/)
+  
+* [reCAPTCHA](https://www.google.com/recaptcha/about/)
+
+> **Note:** Currently, it isn't possible to use Okta SDKs for CAPTCHA integration.
+
+
+<a id="sdks-sample-apps"></a>
 ## SDKs and sample apps
+To get started with integrating Identity Engine with your app and to work with example apps, see the following resources on the Okta Developer Portal:
 
-We have a whole host of SDKs available for integrating new Identity Engine features into your apps using the deployment models described above and sample apps to show them in action.
-
-* [Browse our SDKs and samples](/code/)
-* [Set up and explore our Identity Engine sample apps](/docs/guides/oie-embedded-common-download-setup-app/)
-
-## Identity Engine versus Classic Engine documentation approach
-
-In our documentation, we are moving towards supporting Identity Engine by default, while still providing information for Classic Engine users.
-
-* Pages and page sections covering features that only work in Identity Engine have a blue Identity Engine banner at the top.
-* Content that works in both Identity Engine and Classic Engine have no banner. Any slight differences are covered in the page text.
-* Content written for Classic Engine, that won't work in Identity Engine, has a note at the top that explains what the issue is, and, if appropriate, where Identity Engine users can go to find support.
-* For guides that were extensively updated to support Identity Engine, we keep the Classic Engine version in the [Okta Classic Engine](/docs/guides/archive-overview/) section, so it's still accessible if needed.
-
-> **Note**: See [Identify your Okta solution](https://help.okta.com/okta_help.htm?type=oie&id=ext-oie-version) to determine your Okta version.
-
-## Access and upgrade to Identity Engine
-
-On March 1, 2022, all new [Okta orgs](/docs/concepts/okta-organizations/) are Identity Engine orgs, so that all new customers can take advantage of the new features.
-
-If you are a Classic Engine customer who wants to upgrade their apps to use Identity Engine, go to [Identity Engine upgrade overview](/docs/guides/oie-upgrade-overview/).
-
-For Classic Engine customers who don't yet want to upgrade, your existing functionality continues to work for now, including your Classic Engine org, v1 API, and SDKs.
+* [SDKs and tools](/code/)
+  
+* [Download and set up the SDK, Sign-In Widget, and sample apps](/docs/guides/oie-embedded-common-download-setup-app/android/main/)

--- a/packages/@okta/vuepress-site/docs/concepts/oie-intro/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/oie-intro/index.md
@@ -1,5 +1,5 @@
 ---
-title: Generating Dynamic Email by Using the Okta Identity Engine
+title: Managing Authentication with Okta Identity Engine
 meta:
   - name: description
     content: This page explains the main features of Okta Identity Engine, including the authentication deployment models, the Interaction Code grant type, authentication policies, app context, and app intent links. It also provides SDKs and sample apps that can help you explore these features.
@@ -8,7 +8,7 @@ meta:
 <ApiLifecycle access="ie" />
 
 # How Okta Identity Engine works
-This page explains the main features of [Okta Identity Engine](https://help.okta.com/oie/en-us/content/topics/identity-engine/oie-index.htm), including the authentication deployment models, the Interaction Code grant type, authentication policies, app context, and app intent links. It also explains some of the areas in which Okta Identity Engine differs from [Okta Classic Engine](/docs/guides/archive-overview/main/) and provides links to SDKs and sample apps that can help you explore these features.
+[Okta Identity Engine](https://help.okta.com/oie/en-us/content/topics/identity-engine/oie-index.htm) is a set of customizable elements for establishing an identity service for your organization. This page explains the main features of Identity Engine, including the authentication deployment models, the Interaction Code grant type, authentication policies, app context, and app intent links. It also explains some of the areas in which Identity Engine differs from [Okta Classic Engine](/docs/guides/archive-overview/main/) and provides links to SDKs and sample apps that can help you explore these features.
 
 > **Notes:**
 > * From March 1, 2022, all new [Okta organizations](/docs/concepts/okta-organizations/) use Identity Engine.


### PR DESCRIPTION
Suggested Improvements
* Title: Needs to be task-driven: What is the Okta Identity Engine *for*? What can the user hope to accomplish?
* Meta description tag: We need to give a little bit more information to guide the user and improve page SEO
* I don't fully understand what this does, but <ApiLifecycle access="ie" /> appears to be a way to tage the topic for identity engine. The tag "ie" could be more explicit. Is this for the blue banner?
* To remove the initial "speed bump" for the reader, it's best to eschew headings such as "overview"; that provide no good content or context. In this case, "How Okta Identity Engine Works" seems to strike a good balance.
* It isn't a good idea to advertise or promise present or future features; documentation isn't marketing materials and such sections should be removed.
* As much as possible, introductory materials need to tie together the basics, so as to help the user to get the necessary information up-front, rather than force the user to "hunt" for the necessary details.
* Colloquialisms such as "over in" must be minimized.
* Structured writing ought to ensure familiar and repeatable, but friendly language as signposts for readers (for instance, "For more information about Foo, see Bar in the Baz guide.")
* A mixture of relative and absolute links can be problematic.
* I wasn't entire sure how admonitions (notes) should be formatted.
* If the build system supports it, Markdown for code blocks should specify the language used to enable syntax highlighting.
* Wherever possible, examples should look real, by using IP addresses or domains as specified in RFC 5737 and RFC 3849. Does ${yourOktaDomain} insert the real example dynamically?
* Is it necessary to document previous behaviour? I greatly reduced this content and placed the remainder within a note, but it could be easily removed.
* When documenting processes, auto-numbering (1. 1. 1. ...) ought to be used.
* There was something wonky with the heading hierarchy in the listing of features, where H3 began to be munged with H2, possibly.
* Documentation strategy changes should be as "thin," minimal, and transparent to the user as possible.
* It's best not to bury important noticwes at the bottom of a doc and to retire or remove them after a set period.
* The fact that there is help.okta.com and developer.okta.com is disorienting and more than a little bewildering. For this reason, it is important to prevent user surprise by indicating after a link on which website they can expect to find the resource.
* Many URLs are not optimized for SEO at all. https://developer.okta.com/code/ makes no sense to me—it ought to be https://developer.okta.com/sdk-tools/
* I saw an inconsistent use of "app" and "application" and erred on the side of using the former to be more conversational.
* I have reorganized the sections for what I hope is a better overall flow for the document, from the highly conceptual to the specific and practical.
* While it's a good idea to use contractions to sound conversational, using the contraction "it's" is problematic for various reasons, including confusion between "it is" and "it has."
* I hate to be overly critical, but the title of the page here is a little...unusual: "Sign users in overview" https://developer.okta.com/docs/guides/sign-in-overview/main/ May I recommend at least "User sign-in overview"?
* In the real-world-scenario, the TOC would be generated automatically
* A thought: How do you handle redirects for renamed pages or pages whose URLs have changed?

<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
I performed a full editorial pass, as instructed by the editing test exercise.
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->
No

### Resolves:

N/A
