### PR TITLE
Update info for openssl and public keys

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/terraform-enable-org-access/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/terraform-enable-org-access/main/index.md
@@ -19,7 +19,7 @@ Create an Okta application and credentials that Terraform uses to manage the obj
 * Familiarity with Terraform terms: configuration, resources, state, and commands. See [Terraform overview](/docs/guides/terraform-overview).
 * [Okta Developer Edition organization](https://developer.okta.com/signup)
 * [Super admin permissions](https://help.okta.com/en-us/Content/Topics/Security/administrators-super-admin.htm?cshid=ext_superadmin)
-* [OpenSSL command line program](https://github.com/openssl/openssl#download)
+* [OpenSSL command line program](https://github.com/openssl/openssl#download). Some operating systems already include `openssl` or `openssl-rsa`.
 * [A Terraform installation](https://www.terraform.io/)
 
 ---
@@ -74,13 +74,17 @@ This guide uses Okta to generate the public/private key pair:
    > **Note:** The private key only appears in this dialog once. Losing the private key requires generating a new pair of keys.
 1. Click **Done**, **Save**, and then **Save** again.
 
-> **Note:** Use only one active public key at a time in the service app. Set the status of the public key used by Terraform to **Active**, and set the status of the other public keys to **Inactive**.
+> **Note:** Set the status of any public key currently used by Terraform to **Active**, and set the status of the other public keys to **Inactive**.
 
-Check that the generated private key is in PKCS#1 format, which is the format required by the Okta Terraform Provider. In that format, the file that contains the private key begins with `-----BEGIN RSA PRIVATE KEY-----`. You can convert the key to the correct format using the OpenSSL command line program:
+Check that the generated private key is in PKCS#1 format, which is the format required by the Okta Terraform Provider. In that format, the file that contains the private key begins with `-----BEGIN RSA PRIVATE KEY-----`.
+
+If the key isn't in the right format, convert it to the correct format using the OpenSSL command line program:
 
 1. In a terminal, go to the file path where you saved the original private key.
-1. Run the following command:
+1. Run OpenSSL to convert the key. One of the following command lines should work depending on your operating system and version of OpenSSL:
+`openssl rsa -in {ORIGINAL_PRIVATE_KEY} -out {CONVERTED_PRIVATE_KEY} -traditional`
 `openssl rsa -in {ORIGINAL_PRIVATE_KEY} -out {CONVERTED_PRIVATE_KEY}`
+`openssl-rsa -in {ORIGINAL_PRIVATE_KEY} -out {CONVERTED_PRIVATE_KEY}`
 
    * `ORIGINAL_PRIVATE_KEY`: The file that contains the key generated earlier.
    * `CONVERTED_PRIVATE_KEY`: The file that contains the converted key.


### PR DESCRIPTION
## Latest preview build (9/14/23 5pm Eastern)

https://65036c3b7c682f0983181ffe--reverent-murdock-829d24.netlify.app/docs/guides/terraform-enable-org-access/main/

## Description:

### What's changed?
Updated the explanation of using the OpenSSL command line in Enable Terraform access for your Okta org:

- Added CLI variations (e.g. openssl, openssl-rsa)
- Updated wording to make it clear that the generated key could be in the right format
- Updated wording on deactivating unused public keys EVERYONE -->

### Is this PR related to a Monolith release?
No

### Resolves:

* [OKTA-640695](https://oktainc.atlassian.net/browse/OKTA-640695)
