### PR TITLE
Handoff of editing test from John Hedtke

### DIFF
--- a/packages/@okta/vuepress-site/docs/concepts/oie-intro/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/oie-intro/index.md
@@ -2,25 +2,23 @@
 title: Okta Identity Engine overview
 meta:
   - name: description
-    content: Find out more about Okta's Identity Engine authentication flow, what developer features it unlocks, and how to use it.
+    content: Find out more about the Okta Identity Engine authentication flow, what developer features it unlocks, and how to use it.
 ---
 # Okta Identity Engine overview
 
 <ApiLifecycle access="ie" />
 
-Okta Identity Engine is Okta's new authentication pipeline that provides valuable new features and a more flexible approach to your auth needs. This article provides a high-level introduction.
+Okta Identity Engine is Okta's new authentication pipeline that provides valuable new features and a more flexible approach to your auth needs. This article provides a high-level introduction, including what new features Identity Engine brings to the table, the deployment models that make use of these features, and how Okta's documentation experience is changing to support it.
 
-Below we explain what new features Identity Engine brings to the table, we discuss the deployment models that make use of these features and show how our documentation experience is changing to support it.
+> **Note**: If you are an admin or are looking for product docs related to Identity Engine, see the Identity Engine [Get started page](https://help.okta.com/okta_help.htm?type=oie&id=ext-get-started-oie) in the Okta Help Center.
 
-> **Note**: If you are an admin, or are looking for product docs related to Identity Engine, see the Identity Engine [Get started page](https://help.okta.com/okta_help.htm?type=oie&id=ext-get-started-oie) over in the Okta Help Center.
-
-## Identity Engine new features
+## Identity Engine's new features
 
 Identity Engine unlocks many new capabilities.
 
 ### App context in email templates
 
-Identity Engine makes the app context available when a user enters an authentication flow. Context variables are available in our email templates, allowing customers to dynamically customize email style and content based on the app that an email notification is triggered from.
+Identity Engine makes the app context available when a user enters an authentication flow. Context variables are available in Okta email templates, allowing customers to dynamically customize email style and content based on the app that an email notification is triggered from.
 
 See [Customize email notifications > Use app context](/docs/guides/custom-email/main/#use-app-context).
 
@@ -28,12 +26,12 @@ See [Customize email notifications > Use app context](/docs/guides/custom-email/
 
 App intent links are used to signal intent to access an application. These links are protocol-specific endpoints that you can use to initiate a sign-in flow to an application. Both Identity Provider and Service Provider initiated flows are supported.
 
-Example app intent link for a SAML application:
+Example app intent link for a SAML application: 
 `http://${yourOktaDomain}/app/mysamlapp_1/${appInstanceID}/sso/saml`
 
-Prior to Okta Identity Engine, these endpoints were accessible only with a session. Unauthenticated traffic was redirected to a centralized sign-in page (`/login/login.htm`) with a `fromUri` that represented the app that was originally attempted (the app intent link). This occurred before the request was assessed for rate limiting. A session was established and the request was processed. The user was then redirected to the relevant app intent link through an intermediate redirect to the generic app single-sign on endpoint (`/app/${app}/${instanceId}/${linkName}`). The app intent link endpoint validated that the user was assigned to the application, and then enforced the app sign-on policy.
+Prior to Identity Engine, these endpoints were accessible only with a session. Unauthenticated traffic was redirected to a centralized sign-in page (`/login/login.htm`) with a `fromUri` that represented the app that was originally attempted (the app intent link). This occurred before the request was assessed for rate limiting. A session was established and the request was processed. The user was then redirected to the relevant app intent link through an intermediate redirect to the generic app single sign-on endpoint (`/app/${app}/${instanceId}/${linkName}`). The app intent link endpoint validated that the user was assigned to the application and then enforced the app sign-on policy.
 
-Okta Identity Engine changed the way Okta processes these requests. Identity Engine no longer forwards requests to the centralized sign-in page (`/login/login.htm`). Instead, the app intent links location hosts the widget/sign-in experience for the app that the user is attempting to access and evaluate the Global Session Policy, authentication policy, and all other policies relevant to the sign-in experience. Since each app intent link is responsible for hosting the sign-in experience on Identity Engine, they share a common app intent link rate limit bucket/group similar to what existed for the centralized sign-in page on Classic Engine.
+Identity Engine changed the way Okta processes these requests. Identity Engine no longer forwards requests to the centralized sign-in page (`/login/login.htm`). Instead, the location of the app intent links also hosts the widget/sign-in experience for the app that the user is attempting to access and evaluates the Global Session Policy, authentication policy, and all other policies relevant to the sign-in experience. Since each app intent link is responsible for hosting the sign-in experience on Identity Engine, they have an app intent link rate limit bucket/group in common, similar to what existed for the centralized sign-in page on Okta Classic Engine.
 
 ### Authentication policies
 
@@ -43,48 +41,48 @@ Authentication policies are [security policy frameworks](https://csrc.nist.gov/p
 
 * [Authentication policies](https://help.okta.com/okta_help.htm?type=oie&id=ext-about-asop)
 
-* [Policies (high-level concept)](/docs/concepts/policies/)
+* [What are policies](/docs/concepts/policies/)
 
 ### CAPTCHA
 
-CAPTCHA is a well-known strategy for mitigating attacks by bots. Identity Engine offers registration, sign-in, and account recovery integration of the two market-leading CAPTCHA services: [hCAPTCHA](https://www.hcaptcha.com/) and [reCAPTCHA](https://www.google.com/recaptcha/about/). These are usable through the Okta-hosted and embedded Sign-In Widgets, but not SDKs.
+CAPTCHA is a well-known strategy for mitigating attacks by bots. Identity Engine offers registration, sign-in, and account recovery integration of the two market-leading CAPTCHA services: [hCAPTCHA](https://www.hcaptcha.com/) and [reCAPTCHA](https://www.google.com/recaptcha/about/). These are usable through the Okta-hosted and embedded Sign-In Widgets, but not through SDKs.
 
 ### Interaction code grant type for embedded authentication
 
-To enable a more customized user authentication experience, Okta introduces an extension to the [OAuth 2.0 and OpenID Connect](/docs/concepts/oauth-openid) standard called the [Interaction Code grant type](/docs/concepts/interaction-code/). This grant type allows apps using an embedded Okta Sign-In Widget and/or SDK to manage user interactions with the authorization server directly, rather than relying on a browser-based redirect to an authentication component (such as the Sign-In Widget).
+To enable a more customized user authentication experience, Okta introduces an extension to the [OAuth 2.0 and OpenID Connect overview](/docs/concepts/oauth-openid) standard called the [Interaction Code grant type](/docs/concepts/interaction-code/). This grant type allows apps using an embedded Sign-In Widget and/or SDK to manage user interactions with the authorization server directly, rather than relying on a browser-based redirect to an authentication component (such as the Sign-In Widget).
 
 ## Authentication deployment models
 
 You can divide the Identity Engine user authentication deployment model into three approaches:
 
-* **Okta-hosted (redirect) Sign-In Widget**: Use the redirect (Okta-hosted) Sign-In Widget to authenticate your users, then redirect back to your app. This is the recommended approach as it's the most secure and fastest to implement.
+* **Okta-hosted (redirect) Sign-In Widget**: Use the Okta-hosted (redirect) Sign-In Widget to authenticate your users, then redirect back to your app. This is the recommended approach as it's the most secure and fastest to implement.
 * **Embedded Sign-In Widget**: Embed the Sign-In Widget into your own code base to handle the authentication on your servers. This provides a balance between complexity and customization.
-* **Embedded SDK-driven sign-in flow**: Use our SDKs to create a completely custom authentication experience. This option is the most complex and leaves you with the most responsibility, but offers the most control.
+* **Embedded SDK-driven sign-in flow**: Use Okta's SDKs to create a completely custom authentication experience. This option is the most complex and leaves you with the most responsibility, but offers the most control.
 
-See [Okta deployment models &mdash; redirect vs. embedded](/docs/concepts/redirect-vs-embedded/) for an overview of the different deployment models, and see [Sign users in](/docs/guides/sign-in-overview/) for practical implementation details.
+See [Okta deployment models &mdash; redirect vs. embedded](/docs/concepts/redirect-vs-embedded/) for an overview of the different deployment models. See [Sign users in overview](/docs/guides/sign-in-overview/) for practical implementation details.
 
 ## SDKs and sample apps
 
-We have a whole host of SDKs available for integrating new Identity Engine features into your apps using the deployment models described above and sample apps to show them in action.
+There is a wide range of SDKs available for integrating new Identity Engine features into your apps using the deployment models described above accompanied by sample apps to show them in action.
 
-* [Browse our SDKs and samples](/code/)
-* [Set up and explore our Identity Engine sample apps](/docs/guides/oie-embedded-common-download-setup-app/)
+* [SDKs and tools](/code/)
+* [Download and set up the SDK, Sign-In Widget, and sample apps](/docs/guides/oie-embedded-common-download-setup-app/)
 
 ## Identity Engine versus Classic Engine documentation approach
 
-In our documentation, we are moving towards supporting Identity Engine by default, while still providing information for Classic Engine users.
+The documentation is moving towards supporting Identity Engine by default while still providing information for Classic Engine users.
 
 * Pages and page sections covering features that only work in Identity Engine have a blue Identity Engine banner at the top.
 * Content that works in both Identity Engine and Classic Engine have no banner. Any slight differences are covered in the page text.
-* Content written for Classic Engine, that won't work in Identity Engine, has a note at the top that explains what the issue is, and, if appropriate, where Identity Engine users can go to find support.
-* For guides that were extensively updated to support Identity Engine, we keep the Classic Engine version in the [Okta Classic Engine](/docs/guides/archive-overview/) section, so it's still accessible if needed.
+* Content written for Classic Engine that won't work in Identity Engine has a note at the top that explains what the issue is and, if appropriate, where Identity Engine users can go to find support.
+* For guides that were extensively updated to support Identity Engine, the Classic Engine version appears in the [Okta Classic Engine overview](/docs/guides/archive-overview/), so it's still accessible if needed.
 
-> **Note**: See [Identify your Okta solution](https://help.okta.com/okta_help.htm?type=oie&id=ext-oie-version) to determine your Okta version.
+> **Note**: See [Get started](https://help.okta.com/okta_help.htm?type=oie&id=ext-oie-version) to identify your Okta version.
 
 ## Access and upgrade to Identity Engine
 
-On March 1, 2022, all new [Okta orgs](/docs/concepts/okta-organizations/) are Identity Engine orgs, so that all new customers can take advantage of the new features.
+On March 1, 2022, all new [Okta organizations](/docs/concepts/okta-organizations/) are Identity Engine orgs, so that all new customers can take advantage of the new features.
 
-If you are a Classic Engine customer who wants to upgrade their apps to use Identity Engine, go to [Identity Engine upgrade overview](/docs/guides/oie-upgrade-overview/).
+If you are a Classic Engine customer who wants to upgrade your apps to use Identity Engine, go to [Identity Engine upgrade overview](/docs/guides/oie-upgrade-overview/).
 
-For Classic Engine customers who don't yet want to upgrade, your existing functionality continues to work for now, including your Classic Engine org, v1 API, and SDKs.
+For Classic Engine customers who don't yet want to upgrade, your existing functionality will continue to work for now, including your Classic Engine org, v1 API, and SDKs.


### PR DESCRIPTION
* Link text has been changed in a few places to match the article/page that appears when you click the link. 

* Some of the links in the Style Guide are inaccessible to me as an outsider, notably the Best Practices document and a few others. In addition, all the Github reference links (such as "endpoint") gave me 404s. Again, could be that I don't have the right token to pass into the system. I gleaned style and usage information where I needed some from the other documents in the cluster. 

* "Global Session Policy" appears in other documents both as a proper noun and a generic noun. I've left it capped based on the majority of proper noun occurrences.

* There was an instance of the phrase "widget/sign-in experience" about one screen into the document. I'm sorry; I don't have enough context to know if this reference to "widget" refers to the "Okta-hosted Sign-In Widget" or just any old widget lying around. I've left it alone.

* I see that sign-in is the preferred usage, but several other documents have "sign-on policy" (independent of SSO discussions). I left "sign-on policy" as is near the front of the document.

<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
