### PR TITLE
Updating dark theme "Country/Region" select option style on sign-up page

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/themes/dark/_signUp.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/themes/dark/_signUp.scss
@@ -76,6 +76,10 @@
   border-color: var(--c-green-300);
 }
 
+.signup__form__input option {
+  color: var(--c-lightgray-450);
+}
+
 .signup__form__recaptcha {
   color: var(--c-lightgray-450);
 }


### PR DESCRIPTION
## Description:
When selecting "Country/Region" on the sign-up page (with dark theme enabled), the options are not visible unless hovered over

![1](https://github.com/okta/okta-developer-docs/assets/111794971/4d6509c2-5039-415e-ad7c-bc6a0fbef7b0)

### Resolves:

![2](https://github.com/okta/okta-developer-docs/assets/111794971/7a9dbf20-9338-42fc-82b2-e1b3845d69f0)

Also verified this doesn't change the style of the select box when light theme is enabled
![3](https://github.com/okta/okta-developer-docs/assets/111794971/5a235f3b-43a7-4d17-8686-dc5869c7857e)

:)