### PR TITLE
Fix SAML 2.0 Settings object formatting

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/idps/index.md
@@ -5233,7 +5233,7 @@ Determines the [IdP Key Credential](#identity-provider-key-credential-object) us
 ##### SAML 2.0 Settings object
 
 | Property   | Description                       | DataType    | Nullable | Readonly | Default     |
-| ---------- | ---------------------             | ----------- | -------- | -------- | -------------------------------------------------------------------- | ----------------------------------------------        |
+| ---------- | ---------------------             | ----------- | -------- | -------- | -------------------------------------------------------------------- |
 | nameFormat | The name identifier format to use. See [SAML 2.0 Name Identifier Formats](#saml-2-0-name-identifier-formats). | String      | TRUE     | FALSE    | urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified |
 | honorPersistentNameId | Determines if the IdP should persist account linking when the incoming assertion NameID format is `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent`| Boolean | TRUE | FALSE | FALSE|
 


### PR DESCRIPTION




<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- This PR fixes the incorrect markdown for the attribute table for SAML 2.0 Settings object which rendered gibberish (see before and after screenshots)

### [Preview Link](https://github.com/okta/okta-developer-docs/blob/15a47bf9b3f6af87dc3f8b796cc790bb2e2c0e19/packages/%40okta/vuepress-site/docs/reference/api/idps/index.md#saml-20-settings-object)

### Before
<img width="1051" alt="image" src="https://github.com/okta/okta-developer-docs/assets/13501594/24db15db-70b0-4710-af86-61846edd9f45">


### After
<img width="1072" alt="image" src="https://github.com/okta/okta-developer-docs/assets/13501594/7bbb4485-e95d-4a87-a76f-efd422473750">

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
