### PR TITLE
Update Hero.vue to remove mention of Dev Day since Dev Day is now over

### DIFF
--- a/packages/@okta/vuepress-theme-prose/components/Hero.vue
+++ b/packages/@okta/vuepress-theme-prose/components/Hero.vue
@@ -11,19 +11,15 @@
       <p class="hero__paragraph dont-break-out">
         Our developer portal enables you to deploy auth that protects your users, apps, APIs, and infrastructure.
       </p>
-      <!-- Start workshops & Oktane promo banner -->
+      <!-- Start workshops promo banner -->
       <p style="color: white; font-size: 18px; line-height: 1.4; max-width: 500px;">
         Get your app <a
           style="color: white; text-decoration: underline;"
           href="https://regionalevents.okta.com/enterprisereadyworkshops"
           target="_blank"
-        >enterprise-ready with free virtual workshops</a>, then <a
-          style="color: white; text-decoration: underline;"
-          href="https://www.okta.com/oktane/developers/"
-          target="_blank"
-        >join us for Developer Day</a> at Oktane on Oct. 5!
+        >enterprise-ready with free virtual workshops</a>!
       </p>
-      <!-- End workshops & Oktane promo banner -->
+      <!-- End workshops promo banner -->
     </div>
   </section>
 </template>


### PR DESCRIPTION
## Description:
- Removed mention of Dev Day from dev.okta hero banner since Dev Day concluded on October 5

### Resolves:

* [OKTA-655687](https://oktainc.atlassian.net/browse/OKTA-655687)
