### PR TITLE
Update import format for SCIM Tests

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/scim-provisioning-integration-prepare/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/scim-provisioning-integration-prepare/main/index.md
@@ -159,7 +159,7 @@ To get started using Runscope to test your SCIM API:
 1. You should now see a screen titled **API Tests**.
 1. In the lower left of your screen, click **Import Test**.
 1. A new screen appears, titled **Import Tests into &#x2026;**
-1. Select **Runscope API Tests** as the import format.
+1. Select **API Monitoring Tests** as the import format.
 1. Click **Choose File** and select the JSON file that you saved in Step 1.
 1. Click **Import API Test**.
 1. After the import is finished, click **All Tests** on the left hand side of your screen.


### PR DESCRIPTION
## Description:
I was just following these steps to test SCIM API. I think that the 'Runscope API Tests' is not an option (maybe it used to be?). I was able to use 'API Monitoring Tests' so I guess that it has been renamed/rebranded as 'API Monitoring Tests' within Blazemeter.

![image](https://github.com/okta/okta-developer-docs/assets/663330/f6789a9a-52f4-461e-ad08-b5784744e3c4)
