### PR TITLE
OKTA-656373 Add specific use case where refresh tokens aren't supported in OIN

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/submit-app-prereq/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/submit-app-prereq/main/index.md
@@ -396,7 +396,7 @@ You can't publish integrations with the following Okta features in the OIN catal
 
 * **Okta SDKs and validating access tokens:** You can't use the Okta SDKs to validate access tokens with the [org authorization server](/docs/concepts/auth-servers/#org-authorization-server).
 
-* **Refresh token:**  Refresh tokens aren't supported for integrations published in the OIN.
+* **Refresh token:**  Refresh tokens aren't supported for SSO OIDC integrations published in the OIN.
 
 * **Unsupported scopes:**
 


### PR DESCRIPTION
## Description:
- **What's changed?** Add condition where refresh tokens aren't supported in the OIN. Currently we have a blanket statement saying integrations in OIN don't support refresh tokens. However, it's been confirmed that we support refresh tokens for the SCIM service use case.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-656373](https://oktainc.atlassian.net/browse/OKTA-656373)
