### PR TITLE
Initialize anchors when document is loaded

### DIFF
--- a/packages/@okta/vuepress-theme-prose/components/ContentPage.vue
+++ b/packages/@okta/vuepress-theme-prose/components/ContentPage.vue
@@ -25,10 +25,10 @@ export default {
     }
   },
   mounted() {
-    this.anchors = this.getAnchors(``);
     document.onreadystatechange = () => {
       if (document.readyState === "complete") {
         this.$nextTick(function() {
+          this.anchors = this.getAnchors();
           this.onPageChange();
         });
       }


### PR DESCRIPTION
## Description:
- postpone anchors initialization till the page is loaded

currently on prod https://developer.okta.com/docs/guides/manage-orgs-okta-aerial
preview with the fix https://654d0df960340f13dbc948f5--reverent-murdock-829d24.netlify.app/docs/guides/manage-orgs-okta-aerial

### Resolves:
* [OKTA-665369](https://oktainc.atlassian.net/browse/OKTA-665369)

## Reviewer:
- @paulwallace-okta 
