### PR TITLE
Fixes chevron

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_menuItem.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_menuItem.scss
@@ -175,13 +175,13 @@ ul.menu--items > li.expandable > span:after {
   width: 8px;
   height: 4px;
 
-  background-image: url("/img/icons/chevron-down-white.svg");
+  background-image: url("/img/icons/chevron-down-gray.svg");
   background-repeat: no-repeat;
 }
 
 @include media("<desktop") {
   ul.menu--items > li.expandable > a:after,
   ul.menu--items > li.expandable > span:after {
-    background-image: url("/img/icons/chevron-down-white.svg");
+    background-image: url("/img/icons/chevron-down-gray.svg");
   }
 }


### PR DESCRIPTION
## Description:
- uses gray chevron for a white theme

preview: https://6555253523fb865ae2e82f61--reverent-murdock-829d24.netlify.app/

<img width="1002" alt="image" src="https://github.com/okta/okta-developer-docs/assets/4158731/0a34a0a6-8929-4588-bef4-01d98464cd7b">
<img width="989" alt="image" src="https://github.com/okta/okta-developer-docs/assets/4158731/f94d736a-fbf4-4d31-82b3-fdf530a262b2">


### Resolves:
* [OKTA-666204](https://oktainc.atlassian.net/browse/OKTA-666204)

## Reviewer:
- @paulwallace-okta 