### PR TITLE
Updates url for signup page with the parameters

### DIFF
--- a/packages/@okta/vuepress-theme-prose/enhanceApp.js
+++ b/packages/@okta/vuepress-theme-prose/enhanceApp.js
@@ -3,6 +3,22 @@ import pageComponents from '@internal/page-components'
 import 'bootstrap/dist/css/bootstrap-grid.css';
 import PortalVue from 'portal-vue';
 
+const signupNoSlash = '/signup?';
+const signupWithSlash = '/signup/?';
+
+function workaroundSignupQueryParams(router) {
+  let routerMatch = router.match;
+  router.match = function (raw, current, redirectedFrom) {
+    if (typeof raw === 'string' &&
+        raw.startsWith(signupNoSlash))
+    {
+      raw = raw.replace(signupNoSlash, signupWithSlash);
+    }
+
+    return routerMatch.apply(router, [raw, current, redirectedFrom]);
+  }
+}
+
 export default ({
   Vue,
   options,
@@ -23,4 +39,5 @@ export default ({
     }
   });
 
+  workaroundSignupQueryParams(router);
 }


### PR DESCRIPTION
## Description:
In the current vue router implementation query parameters are dropped when the URL does not have a trailing slash. `/page?test` is redirected to `/page/` and `/page/?test` remains unchanged. This is critical for signup page because information passed along with singup ulr is lost.

Vue does not provide an interface to workaround this issue with redirect route or with some kind of setting. Router callbacks are also called after query parameters are dropped.

The last option is to intercept one of the router functions and patch input data to get correct output. `router.match` function takes in a raw location string and returns a corresponding route - that seems to be a good place for updating the input URL.

### Resolves:
* [OKTA-671204](https://oktainc.atlassian.net/browse/OKTA-671204)