### PR TITLE
Added note about getManagerAppUser() behavior

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
@@ -239,7 +239,7 @@ The following should be noted about these functions:
 
 * Be sure to pass the correct App name for the `managerSource`, `assistantSource`, and `attributeSource` parameters.
 * Currently, `active_directory` is the only supported value for `managerSource` and `assistantSource`.
-* Calling the `getManagerUser("active_directory")` function doesn't trigger a user profile update after the manager is changed.
+* Calling either of the `getManagerUser()` or `getManagerAppUser()` functions doesn't trigger a user profile update after the manager is changed.
 * The manager and assistant functions aren't supported for user profiles sourced from multiple Active Directory instances.
 * The manager and assistant functions aren't supported for user profile attributes from multiple app instances. That is, the expression `getManagerUser("active_directory", "google").firstName` returns null if your org has two or more instances of a `google` app.
 


### PR DESCRIPTION
## Description:
- **What's changed?** Noted that getManagerAppUser() doesn't trigger a user profile update when a manager changes.
- **Is this PR related to a Monolith release?** OKTA-670033

### Resolves:

* [OKTA-670033](https://oktainc.atlassian.net/browse/OKTA-670033)
