### PR TITLE
Note that the ne operator isn't supporter for Users

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/users/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/users/index.md
@@ -1199,6 +1199,7 @@ This operation:
   - `sortOrder` is optional and defaults to ascending
   - `sortOrder` is ignored if `sortBy` is not present
   - Users with the same value for the `sortBy` property will be ordered by `id`
+  - The `ne` (not equal) operator isn't supported, but you can obtain the same result by using `lt ... or ... gt`. For example, to see all users except those that have a status of "Active", use `(status lt "STAGED" or status gt "STAGED")`.
 
 | Search Term Example                             | Description                                     |
 | :---------------------------------------------- | :---------------------------------------------- |

--- a/packages/@okta/vuepress-site/docs/reference/api/users/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/users/index.md
@@ -1199,7 +1199,7 @@ This operation:
   - `sortOrder` is optional and defaults to ascending
   - `sortOrder` is ignored if `sortBy` is not present
   - Users with the same value for the `sortBy` property will be ordered by `id`
-  - The `ne` (not equal) operator isn't supported, but you can obtain the same result by using `lt ... or ... gt`. For example, to see all users except those that have a status of "Active", use `(status lt "STAGED" or status gt "STAGED")`.
+  - The `ne` (not equal) operator isn't supported, but you can obtain the same result by using `lt ... or ... gt`. For example, to see all users except those that have a status of "STAGED", use `(status lt "STAGED" or status gt "STAGED")`.
 
 | Search Term Example                             | Description                                     |
 | :---------------------------------------------- | :---------------------------------------------- |

--- a/packages/@okta/vuepress-site/docs/reference/user-query/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/user-query/index.md
@@ -29,7 +29,7 @@ The search query parameter (`search`) returns one or more users matched against 
 
 This query parameter provides the largest range of search options and optimal performance. The `search` parameter requires URL encoding for applicable search expressions, supports pagination, and accepts sorting parameters.
 
-The search query parameter uses standard Okta API filtering semantics to create search criteria that includes mathematical operators such as equal to (`eq`), greater than or equal to (`ge`), and so on. You can combine multiple expressions using logical operators and parentheses. See [Filtering](/docs/reference/core-okta-api/#filter).
+The search query parameter uses standard Okta API filtering semantics to create search criteria that includes mathematical operators such as equal to (`eq`), greater than or equal to (`ge`), and so on. You can combine multiple expressions using logical operators and parentheses. The `ne` (not equal) operator isn't supported, but you can obtain the same result by using `lt ... or ... gt`. For example, to see all users except those that have a status of "STAGED", use `http:s//${yourOktaDomain}/api/v1/users?search=status+lt+%22STAGED%22+or+status+gt+%22STAGED%22`. See [Filtering](/docs/reference/core-okta-api/#filter).
 
 ### URL encoding
 

--- a/packages/@okta/vuepress-site/docs/reference/user-query/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/user-query/index.md
@@ -29,7 +29,7 @@ The search query parameter (`search`) returns one or more users matched against 
 
 This query parameter provides the largest range of search options and optimal performance. The `search` parameter requires URL encoding for applicable search expressions, supports pagination, and accepts sorting parameters.
 
-The search query parameter uses standard Okta API filtering semantics to create search criteria that includes mathematical operators such as equal to (`eq`), greater than or equal to (`ge`), and so on. You can combine multiple expressions using logical operators and parentheses. The `ne` (not equal) operator isn't supported, but you can obtain the same result by using `lt ... or ... gt`. For example, to see all users except those that have a status of "STAGED", use `http:s//${yourOktaDomain}/api/v1/users?search=status+lt+%22STAGED%22+or+status+gt+%22STAGED%22`. See [Filtering](/docs/reference/core-okta-api/#filter).
+The search query parameter uses standard Okta API filtering semantics to create search criteria that includes mathematical operators such as equal to (`eq`), greater than or equal to (`ge`), and so on. You can combine multiple expressions using logical operators and parentheses. The `ne` (not equal) operator isn't supported, but you can obtain the same result by using `lt ... or ... gt`. For example, to see all users except those that have a status of "STAGED", use `https://${yourOktaDomain}/api/v1/users?search=status+lt+%22STAGED%22+or+status+gt+%22STAGED%22`. See [Filtering](/docs/reference/core-okta-api/#filter).
 
 ### URL encoding
 


### PR DESCRIPTION
## Description:
- **What's changed?** Add a note that the ne operator isn't supported for Users and explain how to get the same results using a combination of lt, gt, and or operators.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-674903](https://oktainc.atlassian.net/browse/OKTA-674903)
