### PR TITLE
Add section on securing service app with an admin role

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/terraform-enable-org-access/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/terraform-enable-org-access/main/index.md
@@ -91,6 +91,19 @@ If the key isn't in the right format, convert it to the correct format using the
 
 > **Note:** The file that contains the converted private key must begin with `-----BEGIN RSA PRIVATE KEY-----`. If not, try step two again.
 
+## Assign admin roles
+
+Limit the access of the service app to your org by assigning it one or more admin roles. This increases the security of your org by defining which resources are accessible.
+
+1. In the Admin Console, open the service app and select **Admin roles**.
+2. Click **Edit assignments**.
+3. In the **Complete the assignment** section, for **Role** select **Group Administrator**.
+4. Click **Save Changes**.
+
+> **Note:** The example Terraform configuration in this guide requires only the `Group Administrator` role. Create an appropriate custom role your own service app.
+
+For more information on admin roles, see [Assign admin roles to the OAuth 2.0 service app](/docs/guides/secure-oauth-between-orgs/main/#assign-admin-roles-to-the-oauth-2-0-service-app).
+
 ## Add credentials to Terraform
 
 Create a Terraform configuration that uses the credentials that you created earlier:


### PR DESCRIPTION
## Latest preview build
Jan 3, 2024 @ 3:00 EDT
https://6595bc18a5d8a20d8397ed9f--reverent-murdock-829d24.netlify.app/docs/guides/terraform-enable-org-access/main/#assign-admin-roles

## Description:

Added a section on adding admin roles to the service app used by Terraform.

### Resolves:

* [OKTA-654929](https://oktainc.atlassian.net/browse/OKTA-654929)