### PR TITLE
Add OPA Links to ToC

### DIFF
--- a/packages/@okta/vuepress-theme-prose/const/navbar.const.js
+++ b/packages/@okta/vuepress-theme-prose/const/navbar.const.js
@@ -1043,10 +1043,8 @@ export const reference = [
                { title: "Zones", path: "/docs/reference/api/zones/" }
             ]
          },
-         {
-            title: "Advanced Server Access API",
-            path: "/docs/reference/api/asa/introduction/"
-         },
+         { title: "Okta Privileged Access API", path: "/docs/api/openapi/opa/" },
+         { title: "Advanced Server Access API", path: "/docs/api/openapi/asa/" },
          {
             title: "SCIM Protocol",
             path: "/docs/reference/scim/",


### PR DESCRIPTION
## Description:
- **What's changed?** Updates the ToC to use relative links to Redocly. This uses relative links, so the URLs will not generate correctly on local or preview builds.
- **Is this PR related to a Monolith release?** No

[Preview](https://65a583aacaa093242c8d5fe8--reverent-murdock-829d24.netlify.app)

### Resolves:

* [OKTA-680608](https://oktainc.atlassian.net/browse/OKTA-680608)