### PR TITLE
OKTA-676273 Update SCIM - determine if User already exists section

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/scim/scim-11/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/scim/scim-11/index.md
@@ -60,9 +60,9 @@ After you complete this step, whenever a user is assigned to the integration in 
 
 **GET** /Users
 
-Okta checks that the User object exists on the SCIM server through a GET method request with the `filter=userName eq "${userName}"` path parameter. This check is performed using the `eq` (equal) operator against the unique identifier for all users. You can use any other attribute (instead of `${userName}`) that was configured as a unique identifier for the SCIM integration.
+Okta checks that the User object exists on the SCIM server through a GET method request with the `filter=userName eq "${userName}"` query parameter. Your SCIM server must support this query parameter to provision users with Okta successfully. This check is performed using the `eq` (equal) operator against the unique identifier configured for the SCIM integration.
 
-For example, if the email attribute is configured as a unique identifier, then the path parameter to determine if the user exists is `filter=userName eq "${email}"`.
+For example, if the email attribute is configured as a unique identifier, then the query parameter to determine if the user exists is `filter=userName eq "${email}"`.
 
 > **Note:** The filter must check an attribute that is _unique_ for all Users in the Service Provider profiles.
 

--- a/packages/@okta/vuepress-site/docs/reference/scim/scim-11/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/scim/scim-11/index.md
@@ -60,7 +60,9 @@ After you complete this step, whenever a user is assigned to the integration in 
 
 **GET** /Users
 
-Okta checks that the User object exists on the SCIM server through a GET method request with the `filter=userName` parameter (or any other filter parameter that was configured with the SCIM integration). This check is performed using the `eq` (equal) operator and is the only one necessary to successfully provision users with Okta.
+Okta checks that the User object exists on the SCIM server through a GET method request with the `filter=userName eq "${userName}"` path parameter. This check is performed using the `eq` (equal) operator against the unique identifier for all users. You can use any other attribute (instead of `${userName}`) that was configured as a unique identifier for the SCIM integration.
+
+For example, if the email attribute is configured as a unique identifier, then the path parameter to determine if the user exists is `filter=userName eq "${email}"`.
 
 > **Note:** The filter must check an attribute that is _unique_ for all Users in the Service Provider profiles.
 

--- a/packages/@okta/vuepress-site/docs/reference/scim/scim-20/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/scim/scim-20/index.md
@@ -52,9 +52,9 @@ After you complete this step, whenever a user is assigned to the integration in 
 
 **GET** /Users
 
-Okta checks that the User object exists on the SCIM server through a GET method request with the `filter=userName eq "${userName}"` path parameter. This check is performed using the `eq` (equal) operator against the unique identifier for all users. You can use any other attribute (instead of `${userName}`) that was configured as a unique identifier for the SCIM integration.
+Okta checks that the User object exists on the SCIM server through a GET method request with the `filter=userName eq "${userName}"` query parameter. Your SCIM server must support this query parameter to provision users with Okta successfully. This check is performed using the `eq` (equal) operator against the unique identifier configured for the SCIM integration.
 
-For example, if the email attribute is configured as a unique identifier, then the path parameter to determine if the user exist is `filter=userName eq "${email}"`.
+For example, if the email attribute is configured as a unique identifier, then the query parameter to determine if the user exists is `filter=userName eq "${email}"`.
 
 > **Note:** The filter must check an attribute that is _unique_ for all Users in the Service Provider profiles.
 

--- a/packages/@okta/vuepress-site/docs/reference/scim/scim-20/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/scim/scim-20/index.md
@@ -52,7 +52,9 @@ After you complete this step, whenever a user is assigned to the integration in 
 
 **GET** /Users
 
-Okta checks that the User object exists on the SCIM server through a GET method request with the `filter=userName` parameter (or any other filter parameter that was configured with the SCIM integration). This check is performed using the `eq` (equal) operator and is the only one necessary to successfully provision users with Okta.
+Okta checks that the User object exists on the SCIM server through a GET method request with the `filter=userName eq "${userName}"` path parameter. This check is performed using the `eq` (equal) operator against the unique identifier for all users. You can use any other attribute (instead of `${userName}`) that was configured as a unique identifier for the SCIM integration.
+
+For example, if the email attribute is configured as a unique identifier, then the path parameter to determine if the user exist is `filter=userName eq "${email}"`.
 
 > **Note:** The filter must check an attribute that is _unique_ for all Users in the Service Provider profiles.
 


### PR DESCRIPTION
## Description:
- **What's changed?** Update SCIM 2.0 and 1.1: Determine if User already exists section
- **Is this PR related to a Monolith release?** No

### Preview:
https://65aafac20c7751212b244e94--reverent-murdock-829d24.netlify.app/docs/reference/scim/scim-20/#determine-if-the-user-already-exists

### Resolves:

* [OKTA-676273](https://oktainc.atlassian.net/browse/OKTA-676273)
