### PR TITLE
Update hasDirectoryUser() description

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
@@ -247,7 +247,7 @@ The following should be noted about these functions:
 
 | Function              | Description                                                                                                                                 |
 | --------              | ---------                                                                                                                                   |
-| `hasDirectoryUser()`  | Checks whether the user has an Active Directory assignment and returns `true` if the user has a single AD assignment or `false`, otherwise  |
+| `hasDirectoryUser()`  | Checks whether the user has an Active Directory (AD) assignment and returns `true` if the user has a single AD assignment or `false` if the user has either zero or multiple AD assignments  |
 | `hasWorkdayUser()`    | Checks whether the user has a Workday assignment and returns a boolean                                                                      |
 | `findDirectoryUser()` | Finds the Active Directory App user object and returns that object or null if the user has more than one or no Active Directory assignments |
 | `findWorkdayUser()`   | Finds the Workday App user object and returns that object or null if the user has more than one or no Workday assignments                   |

--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language/index.md
@@ -247,7 +247,7 @@ The following should be noted about these functions:
 
 | Function              | Description                                                                                                                                 |
 | --------              | ---------                                                                                                                                   |
-| `hasDirectoryUser()`  | Checks whether the user has an Active Directory assignment and returns a boolean                                                            |
+| `hasDirectoryUser()`  | Checks whether the user has an Active Directory assignment and returns `true` if the user has a single AD assignment or `false`, otherwise  |
 | `hasWorkdayUser()`    | Checks whether the user has a Workday assignment and returns a boolean                                                                      |
 | `findDirectoryUser()` | Finds the Active Directory App user object and returns that object or null if the user has more than one or no Active Directory assignments |
 | `findWorkdayUser()`   | Finds the Workday App user object and returns that object or null if the user has more than one or no Workday assignments                   |


### PR DESCRIPTION
## Description:
- **What's changed?** Updated description of hasDirectoryUser() to state it returns true only when a single AD match is found; false, otherwise.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-633731](https://oktainc.atlassian.net/browse/OKTA-633731)
