### PR TITLE
Fixed: Sidenav left border should appear when expanding a left nav item

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_sidebar.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_sidebar.scss
@@ -60,11 +60,6 @@
   }
 }
 
-.tree-nav > .sections:before,
-.tree-nav > .sections > li > .sections:before {
-  display: none;
-}
-
 .tree-nav > .sections > li > .sections > li,
 .tree-nav > .sections > li > .sections > li > .sections > li,
 .tree-nav > .sections > li > .sections > li > .sections > li > .sections > li {

--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_sidebar.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_sidebar.scss
@@ -38,7 +38,8 @@
   margin-top: 0;
 }
 
-.tree-nav .sections.bordered:before {
+.tree-nav .sections.bordered:before,
+.tree-nav .sections.show-border:before {
   content: "";
 
   position: absolute;
@@ -53,7 +54,8 @@
 }
 
 @media (max-width: 1439px) {
-  .tree-nav .sections.bordered:before {
+  .tree-nav .sections.bordered:before,
+  .tree-nav .sections.show-border:before {
     left: -38px;
   }
 }

--- a/packages/@okta/vuepress-theme-prose/components/SidebarItem.vue
+++ b/packages/@okta/vuepress-theme-prose/components/SidebarItem.vue
@@ -89,7 +89,7 @@
       <ul
         v-if="entityType === types.parent"
         v-show="sublinksExpanded || isCurrentPage(link.path)"
-        class="sections"
+        :class="sublinksExpanded ? 'sections show-border' : 'sections'"
       >
         <SidebarItem
           v-for="sublink in link.subLinks"

--- a/packages/@okta/vuepress-theme-prose/components/SidebarItem.vue
+++ b/packages/@okta/vuepress-theme-prose/components/SidebarItem.vue
@@ -89,7 +89,7 @@
       <ul
         v-if="entityType === types.parent"
         v-show="sublinksExpanded || isCurrentPage(link.path)"
-        :class="sublinksExpanded ? 'sections show-border' : 'sections'"
+        :class="sublinksExpanded || isCurrentPage(link.path) ? 'sections show-border' : 'sections'"
       >
         <SidebarItem
           v-for="sublink in link.subLinks"


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Sidenav left border should appear when expanding a left nav item
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-681884](https://oktainc.atlassian.net/browse/OKTA-681884)

Preview - https://65b2267d1779274958baddca--reverent-murdock-829d24.netlify.app
