### PR TITLE
Add grant_type param for Postman OAuth instructions

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/postman-collections/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/postman-collections/index.md
@@ -7,7 +7,7 @@ meta:
 
 # Import a Postman Collection
 
-Learn how to [use Postman with the Okta REST APIs](/code/rest/).
+Learn how to [use Postman with the Okta REST APIs](/docs/reference/rest/).
 
 > **Note:** These buttons are also available at the top of each [API reference page](/docs/reference/api/apps/).
 

--- a/packages/@okta/vuepress-site/docs/reference/rest/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/rest/index.md
@@ -209,6 +209,8 @@ Include the following parameters in your `/token` request:
 
     In this example, only one access scope is requested (`scope=okta.users.read`). When you request an access token for multiple scopes, the format for the scope value looks like this: `scope=okta.users.read okta.apps.read`
 
+* `grant_type`: Use `client_credentials`.
+
 * `client_assertion_type`: Specifies the type of assertion, in this case a JWT token:  `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`
 
 * `client_assertion`: The signed JWT. Paste the JWT that you signed in the [Create and sign the JWT](#create-and-sign-the-jwt) section.


### PR DESCRIPTION
## Description:
- **What's changed?** Add grant_type param for Postman OAuth instructions. Fixed broken link in Postman Collection list.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
