### PR TITLE
OKTA-696671 Update CLIENT_AS_PRINCIPAL note for org2org and Postman instructions

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/secure-oauth-between-orgs/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/secure-oauth-between-orgs/main/index.md
@@ -200,21 +200,6 @@ For the hub-and-spoke OAuth 2.0 Org2Org provisioning connection, Okta recommends
 * `USER_ADMIN` (Group administrator)
 * `GROUP_MEMBERSHIP_ADMIN` (Group membership administrator)
 
-<!-- Consider adding this section when custom roles can be verified by the Integration Platform team at GA
-
-If you're using [custom roles](https://help.okta.com/okta_help.htm?type=oie&id=ext-about-creating-custom-admin-roles) for the OAuth 2.0 Org2Org provisioning connection, you require the following:
-
-* Permissions required:
-  * Manage users
-  * Manage groups
-
-* Resource sets recommended:
-  * All Users
-  * All Groups
-
-> **Note:** You can bind resource sets to many different types of resources, such as user groups, flows, authorization servers, and so on. You don't necessarily have to use the All Groups resource set in this use case. You can specify permissions for a specific subset of users in a custom role. See [Custom role assignment](/docs/concepts/role-assignment/#custom-role-assignment) and the [Custom Role assignment API operations](/docs/reference/api/roles/#custom-role-assignment-operations).
--->
-
 You can use the Admin Console to assign an admin role to your service app. See [Assign admin roles to apps](https://help.okta.com/okta_help.htm?type=oie&id=csh-work-with-admin-assign-admin-role-to-apps) and go to the **Admin roles** tab from your app integration details. Alternatively, you can assign the admin role to your service app with the Okta API.
 
 As an Okta super admin, make a `POST /oauth2/v1/clients/${yourServiceAppId}/roles` request to the hub org with the following required parameters to assign an admin role:

--- a/packages/@okta/vuepress-site/docs/guides/secure-oauth-between-orgs/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/secure-oauth-between-orgs/main/index.md
@@ -21,7 +21,7 @@ This guide explains how to securely configure Okta hub-and-spoke orgs to synchro
 
 Multiple Okta orgs for your multi-tenant solution
 
-> **Note:** The Org2Org app integration isn't available in Okta Developer-Edition orgs. If you need to test this feature in your Developer-Edition org, contact your Okta account team.
+> **Note:** The Org2Org app integration isn't available in Okta Developer Edition orgs. If you need to test this feature in your developer org, contact your Okta account team.
 
 ---
 
@@ -67,8 +67,7 @@ You can use OAuth 2.0 to push user and group information from a spoke org to a c
 
 You use the spoke org to push users and groups to the central hub org. In the spoke org, add an instance of the Org2Org app integration by using the [Okta Apps API](/docs/reference/api/apps/#add-okta-org2org-application). This generates an integration instance with the key certificates required to connect to the hub org.
 
-> **Note:** You can't use an Okta Developer-Edition org as a spoke org since the Org2Org app integration isn't available in developer orgs. If you need to test this feature in your Developer-Edition org, contact your Okta account team.
-
+> **Note:** You can't use an Okta Developer Edition org as a spoke org since the Org2Org app integration isn't available. If you need to test this feature in your developer org, contact your Okta account team.
 
 As an Okta admin, make a `POST /api/v1/apps` request to the spoke org with [Okta Org2Org parameters](/docs/reference/api/apps/#add-okta-org2org-application):
 
@@ -190,19 +189,11 @@ curl -X POST \
 
 ### Assign admin roles to the OAuth 2.0 service app
 
-> **Note:** Use these instructions for:
-> * Preview orgs <br>
->   To automatically assign the super admin role to all custom API service apps that you create, enable the **Public client app admins** org setting. See [Assign admin roles to apps](https://help.okta.com/okta_help.htm?type=oie&id=csh-work-with-admin-assign-admin-role-to-apps).
-> * Production orgs with the **Assign admin roles to public client apps** Early Access feature enabled
-
-<!--
-Before Okta provided the ability to assign admin roles to service apps, the Super Administrator (`SUPER_ADMIN`) role was automatically assigned to all service apps. You can now fine-tune the resources that a service app can access by assigning specific standard or custom admin roles. No role is automatically assigned, so you must assign a role before you use the service app.
-If you have a Production org and want to turn on the **Assign admin roles to public client apps** feature, see [Manage Early Access and Beta features](https://help.okta.com/okta_help.htm?id=ext_Manage_Early_Access_features).
- -->
-
 Assign admin roles for every OAuth 2.0 service app that you create in the hub org. Service apps with assigned admin roles are constrained to the permissions and resources that are included in the role. This improves security for an org since it ensures that service apps only have access to the resources that are needed to perform their tasks.
 
 You can assign a [standard admin role](https://help.okta.com/okta_help.htm?type=oie&id=ext-administrators-admin-comparison) or a [custom admin role](https://help.okta.com/okta_help.htm?type=oie&id=ext-about-creating-custom-admin-roles) with permissions to specific resource sets.
+
+> **Note:** To bypass the assign-admin-role task, enable the **Public client app admins** org setting. This enabled setting automatically assigns the super admin role to custom API service apps that you create after the scopes are granted. Go to **Settings** > **Account** > **Public client app admins** in the Admin Console to edit this setting. See [Assign admin roles to apps](https://help.okta.com/okta_help.htm?type=oie&id=csh-work-with-admin-assign-admin-role-to-apps).
 
 For the hub-and-spoke OAuth 2.0 Org2Org provisioning connection, Okta recommends that you assign the following [standard admin roles](/docs/concepts/role-assignment/#standard-role-types):
 
@@ -223,6 +214,8 @@ If you're using [custom roles](https://help.okta.com/okta_help.htm?type=oie&id=e
 
 > **Note:** You can bind resource sets to many different types of resources, such as user groups, flows, authorization servers, and so on. You don't necessarily have to use the All Groups resource set in this use case. You can specify permissions for a specific subset of users in a custom role. See [Custom role assignment](/docs/concepts/role-assignment/#custom-role-assignment) and the [Custom Role assignment API operations](/docs/reference/api/roles/#custom-role-assignment-operations).
 -->
+
+You can use the Admin Console to assign an admin role to your service app. See [Assign admin roles to apps](https://help.okta.com/okta_help.htm?type=oie&id=csh-work-with-admin-assign-admin-role-to-apps) and go to the **Admin roles** tab from your app integration details. Alternatively, you can assign the admin role to your service app with the Okta API.
 
 As an Okta super admin, make a `POST /oauth2/v1/clients/${yourServiceAppId}/roles` request to the hub org with the following required parameters to assign an admin role:
 

--- a/packages/@okta/vuepress-site/docs/guides/secure-oauth-between-orgs/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/secure-oauth-between-orgs/main/index.md
@@ -193,7 +193,7 @@ Assign admin roles for every OAuth 2.0 service app that you create in the hub or
 
 You can assign a [standard admin role](https://help.okta.com/okta_help.htm?type=oie&id=ext-administrators-admin-comparison) or a [custom admin role](https://help.okta.com/okta_help.htm?type=oie&id=ext-about-creating-custom-admin-roles) with permissions to specific resource sets.
 
-> **Note:** To bypass the assign-admin-role task, enable the **Public client app admins** org setting. This enabled setting automatically assigns the super admin role to custom API service apps that you create after the scopes are granted. Go to **Settings** > **Account** > **Public client app admins** in the Admin Console to edit this setting. See [Assign admin roles to apps](https://help.okta.com/okta_help.htm?type=oie&id=csh-work-with-admin-assign-admin-role-to-apps).
+> **Note:** To temporarily bypass the assign-admin-role task, enable the **Public client app admins** org setting. This enabled setting automatically assigns the super admin role to custom API service apps that you create after the scopes are granted. Go to **Settings** > **Account** > **Public client app admins** in the Admin Console to edit this setting. See [Assign admin roles to apps](https://help.okta.com/okta_help.htm?type=oie&id=csh-work-with-admin-assign-admin-role-to-apps). Disable this setting after you incorporate the assign-admin-role task to your workflow.
 
 For the hub-and-spoke OAuth 2.0 Org2Org provisioning connection, Okta recommends that you assign the following [standard admin roles](/docs/concepts/role-assignment/#standard-role-types):
 

--- a/packages/@okta/vuepress-site/docs/guides/secure-oauth-between-orgs/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/secure-oauth-between-orgs/main/index.md
@@ -193,7 +193,7 @@ Assign admin roles for every OAuth 2.0 service app that you create in the hub or
 
 You can assign a [standard admin role](https://help.okta.com/okta_help.htm?type=oie&id=ext-administrators-admin-comparison) or a [custom admin role](https://help.okta.com/okta_help.htm?type=oie&id=ext-about-creating-custom-admin-roles) with permissions to specific resource sets.
 
-> **Note:** To temporarily bypass the assign-admin-role task, enable the **Public client app admins** org setting. This enabled setting automatically assigns the super admin role to custom API service apps that you create after the scopes are granted. Go to **Settings** > **Account** > **Public client app admins** in the Admin Console to edit this setting. See [Assign admin roles to apps](https://help.okta.com/okta_help.htm?type=oie&id=csh-work-with-admin-assign-admin-role-to-apps). Disable this setting after you incorporate the assign-admin-role task to your workflow.
+> **Note:** To temporarily bypass assigning an admin role, enable the **Public client app admins** org setting. This automatically assigns the super admin role to custom API service apps that you create after the scopes are granted. Go to **Settings** > **Account** > **Public client app admins** in the Admin Console to edit this setting. See [Assign admin roles to apps](https://help.okta.com/okta_help.htm?type=oie&id=csh-work-with-admin-assign-admin-role-to-apps). Disable this setting after you incorporate admin role assignments in your workflow.
 
 For the hub-and-spoke OAuth 2.0 Org2Org provisioning connection, Okta recommends that you assign the following [standard admin roles](/docs/concepts/role-assignment/#standard-role-types):
 

--- a/packages/@okta/vuepress-site/docs/reference/rest/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/rest/index.md
@@ -140,7 +140,6 @@ First, create a service app integration where you can define your scope-based ac
 1. On the **Create a new app integration** page, select **API Services** as the **Sign-in method** and click **Next**.
 1. Enter a name for your app integration and click **Save**. The settings page for the app integration appears, showing the **General** tab. Make note of the **Client ID** listed in the **Client Credentials** section. You need this information for the [Create and sign the JWT](#create-and-sign-the-jwt) task.
 1. Click the **Admin roles** tab and assign an admin role with permissions to the resource sets that you require.
-   > **Note:** This step is only required for Preview orgs. For Production orgs, this step is required only if the **Assign admin roles to public client apps** Early Access feature is enabled.
 
    You can assign the [standard admin roles](https://help.okta.com/okta_help.htm?type=oie&id=ext-administrators-admin-comparison) or a [custom admin role](https://help.okta.com/okta_help.htm?type=oie&id=ext-about-creating-custom-admin-roles) with permissions to specific resource sets. See [Assign admin roles to apps](https://help.okta.com/okta_help.htm?type=oie&id=csh-work-with-admin-assign-admin-role-to-apps).
 
@@ -148,6 +147,8 @@ First, create a service app integration where you can define your scope-based ac
    1. Click **Edit assignments**.
    {style="list-style-type:lower-alpha"}
    1. Select **Super Administrator** under Roles and click **Save Changes**.
+
+   > **Note:** To bypass the assign-admin-role step, enable the **Public client app admins** org setting. This enabled setting automatically assigns the super admin role to custom API service apps that you create after the scopes are granted. Go to **Settings** > **Account** > **Public client app admins** in the Admin Console to edit this setting. See [Assign admin roles to apps](https://help.okta.com/okta_help.htm?type=oie&id=csh-work-with-admin-assign-admin-role-to-apps).
 
 1. Select the **Okta API Scopes** tab and then click **Grant** for each of the scopes that you want to add to the app grant collection. Ensure that you grant the scopes for the API access you require. See [Okta OAuth 2.0 scopes](https://developer.okta.com/docs/api/oauth2/). <br>For example, click **Grant** next to `okta.users.read`.
 

--- a/packages/@okta/vuepress-site/docs/reference/rest/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/rest/index.md
@@ -148,7 +148,7 @@ First, create a service app integration where you can define your scope-based ac
    {style="list-style-type:lower-alpha"}
    1. Select **Super Administrator** under Roles and click **Save Changes**.
 
-   > **Note:** To bypass the assign-admin-role step, enable the **Public client app admins** org setting. This enabled setting automatically assigns the super admin role to custom API service apps that you create after the scopes are granted. Go to **Settings** > **Account** > **Public client app admins** in the Admin Console to edit this setting. See [Assign admin roles to apps](https://help.okta.com/okta_help.htm?type=oie&id=csh-work-with-admin-assign-admin-role-to-apps).
+   > **Note:** See [Assign admin roles to apps](https://help.okta.com/okta_help.htm?type=oie&id=csh-work-with-admin-assign-admin-role-to-apps).
 
 1. Select the **Okta API Scopes** tab and then click **Grant** for each of the scopes that you want to add to the app grant collection. Ensure that you grant the scopes for the API access you require. See [Okta OAuth 2.0 scopes](https://developer.okta.com/docs/api/oauth2/). <br>For example, click **Grant** next to `okta.users.read`.
 


### PR DESCRIPTION
## Description:
- **What's changed?** Remove SS EA note for CLIENT_AS_PRINCIPAL and update org setting note in OAuth org2org and Postman instruction topics.
- **Is this PR related to a Monolith release?** 2024.02.0 (missed)

### Preview:
https://65cd38b8555a083099a577f8--reverent-murdock-829d24.netlify.app/docs/guides/secure-oauth-between-orgs/main/#assign-admin-roles-to-the-oauth-2-0-service-app
https://65cd38b8555a083099a577f8--reverent-murdock-829d24.netlify.app/docs/reference/rest/#create-a-service-app-in-okta

### Resolves:

* [OKTA-696671](https://oktainc.atlassian.net/browse/OKTA-696671)
