### PR TITLE
OKTA-694170 OAUTH2-use-external-key-for-org-as-access-token

### DIFF
--- a/packages/@okta/vuepress-site/docs/concepts/auth-servers/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/auth-servers/index.md
@@ -9,17 +9,17 @@ meta:
 
 <ApiAmProdWarning />
 
-Authentication and authorization are essential to application development. Whether you are developing an internal IT app for your employees, building a portal for your partners, or exposing a set of APIs for developers building apps around your resources, you need the right authentication and authorization support for your projects. With Okta, you can control access to your application using both [OAuth 2.0 and OpenID Connect](/docs/concepts/oauth-openid/). Use Okta as your authorization server to retain all of your user information and grant users tokens to control their authorization and authentication.
+Authentication and authorization are essential to application development. Whether you're developing an internal IT app for your employees, building a portal for your partners, or exposing a set of APIs for developers building apps around your resources, you need the right authentication and authorization support for your projects. With Okta, you can control access to your application using both [OAuth 2.0 and OpenID Connect](/docs/concepts/oauth-openid/). Use Okta as your authorization server to retain all of your user information and grant users tokens to control their authorization and authentication.
 
 ## What is an authorization server
 
-At its core, an authorization server is simply an engine for minting OpenID Connect or [OAuth 2.0](/docs/concepts/oauth-openid/#oauth-2-0) tokens. An authorization server is also used to apply access policies. Each authorization server has a unique issuer URI and its own signing key for tokens to keep a proper boundary between security domains.
+At its core, an authorization server is simply an engine for minting OpenID Connect (OIDC) or [OAuth 2.0](/docs/concepts/oauth-openid/#oauth-2-0) tokens. An authorization server is also used to apply access policies. Each authorization server has a unique issuer URI and its own signing key for tokens to keep a proper boundary between security domains.
 
 ## What you can use an authorization server for
 
-You can use an authorization server to perform Single Sign-On (SSO) with Okta for your OpenID Connect apps. You can also use an authorization server to secure your own APIs and provide user authorization to access your web services.
+You can use an authorization server to perform Single Sign-On (SSO) with Okta for your OIDC apps. You can also use an authorization server to secure your own APIs and provide user authorization to access your web services.
 
-OpenID Connect is used to authenticate users with a web app. The app uses the ID token that is returned from the authorization server to know if a user is authenticated and to obtain profile information about the user, such as their username or locale. OAuth 2.0 is used to authorize user access to an API. An access token is used by the resource server to validate a user's level of authorization/access. When using OpenID Connect or OAuth, the authorization server authenticates a user and issues an ID token and/or an access token.
+OIDC is used to authenticate users with a web app. The app uses the ID token that is returned from the authorization server to know if a user is authenticated and to obtain profile information about the user, such as their username or locale. OAuth 2.0 is used to authorize user access to an API. An access token is used by the resource server to validate a user's level of authorization/access. When using OIDC or OAuth, the authorization server authenticates a user and issues an ID token and/or an access token.
 
 > **Note:** You can't mix tokens between different authorization servers. By design, authorization servers don't have trust relationships with each other.
 
@@ -31,7 +31,9 @@ Okta has two types of authorization servers: the org authorization server and th
 
 Every Okta org comes with a built-in authorization server called the org authorization server. The base URL for the org authorization server is `https://${yourOktaOrg}`.
 
-You use the org authorization server to perform SSO with Okta for your OpenID Connect apps or to get an access token for the Okta APIs. You can't customize this authorization server with regards to audience, claims, policies, or scopes. Additionally, the resulting access token's issuer is `https://${yourOktaOrg}`, which indicates that only Okta can consume or validate it. The access token can't be used or validated by your own applications.
+You can use the org authorization server to perform SSO with Okta for your OpenID Connect apps or to get an access token for the Okta APIs. You can't customize audience, claims, policies, or scopes for this authorization server.
+
+The issuer for access tokens from an org authorization server is `https://${yourOktaOrg}`, which indicates that only Okta can consume or validate it. The access token can't be used or validated by your own applications. The contents of the access token are subject to change at any time without notice, therefore any attempts to validate the access token may not work in the future.
 
 #### Org authorization server discovery endpoints
 
@@ -43,7 +45,7 @@ The following discovery endpoints return OpenID Connect or OAuth 2.0 metadata re
 
 ### Custom authorization server
 
-You use a custom authorization server to create and apply authorization policies to secure your APIs. An access token that is minted by a custom authorization server is consumed by your APIs.
+You can use a custom authorization server to create and apply authorization policies to secure your APIs. An access token that is minted by a custom authorization server is consumed by your APIs.
 
 Okta allows you to [create multiple custom authorization servers](/docs/guides/customize-authz-server/main/#create-an-authorization-server) within a single Okta org that you can use to protect your own resource servers. Within each authorization server, you can define your own custom OAuth 2.0 [scopes](/docs/guides/customize-authz-server/main/#create-scopes), [claims](/docs/guides/customize-authz-server/main/#create-claims), and [access policies](/docs/guides/customize-authz-server/main/#create-access-policies) to support authorization for your APIs.
 
@@ -61,7 +63,7 @@ For custom authorization servers that you create yourself, the `${authorizationS
 
 #### Custom authorization server discovery endpoints
 
-The following endpoints return OpenID Connect or OAuth 2.0 metadata related to a custom authorization server. Clients can use this information to programmatically configure their interactions with Okta. Custom scopes and custom claims aren't returned.
+The following endpoints return OIDC or OAuth 2.0 metadata related to a custom authorization server. Clients can use this information to programmatically configure their interactions with Okta. Custom scopes and custom claims aren't returned.
 
 The OpenID and OAuth discovery endpoints for a custom authorization server are:
 
@@ -77,9 +79,9 @@ The OpenID and OAuth discovery endpoints for the default custom authorization se
 
 ## Which authorization server should you use
 
-If you are just looking to add SSO for your OpenID Connect-based applications, you can use your org authorization server. You should also use the org authorization server if you want to use [OAuth 2.0 bearer tokens with your Okta APIs](/docs/guides/implement-oauth-for-okta/). Only the org authorization server can mint access tokens that contain Okta API scopes.
+If you're looking to add SSO for your OIDC-based applications, you can use your org authorization server. Also, use the org authorization server if you want to use [OAuth 2.0 bearer tokens with your Okta APIs](/docs/guides/implement-oauth-for-okta/). Only the org authorization server can mint access tokens that contain Okta API scopes.
 
-If your application has requirements such as additional scopes, customizing rules for when to grant scopes, or you need additional authorization servers with different scopes and claims, then you need to [create a custom authorization server](/docs/guides/customize-authz-server/).
+If your application has requirements such as additional scopes, customizing rules for when to grant scopes, or you need more authorization servers with different scopes and claims, then you need to [create a custom authorization server](/docs/guides/customize-authz-server/).
 
 The following table describes which capabilities are supported by the custom authorization server (includes the default custom authorization server) and which are supported by the org authorization server.
 
@@ -87,9 +89,9 @@ The following table describes which capabilities are supported by the custom aut
 | :----------------------------------------- | :----------------------------------- | :-------------------------- |
 | SSO with OpenID Connect                    | Yes                                  | Yes                         |
 | Use Okta Developer SDKs & Widgets for SSO  | Yes                                  | Yes                         |
-| Retrieve user profile in ID Token          | Yes                                  | Yes                         |
+| Retrieve user profile in ID token          | Yes                                  | Yes                         |
 | Apply authorization policies to custom APIs| Yes                                  | No                          |
 | Add custom scopes or claims to tokens      | Yes                                  | No                          |
 | Integrate with an API Gateway              | Yes                                  | No                          |
-| Machine-to-Machine or Microservices        | Yes                                  | No                          |
-| Mint Access Tokens with Okta API Scopes    | No                                   | Yes                         |
+| Machine-to-machine or microservices        | Yes                                  | No                          |
+| Mint access tokens with Okta API scopes    | No                                   | Yes                         |

--- a/packages/@okta/vuepress-site/docs/guides/validate-access-tokens/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/validate-access-tokens/main/index.md
@@ -50,7 +50,7 @@ The JSON Web Keys (JWK) need to be retrieved from your [Okta authorization serve
 
 > For more information about retrieving this metadata, see [Retrieve Authorization Server Metadata](/docs/reference/api/oidc/#well-knownoauth-authorization-server).
 
-### Decoding and Validating the Access Token
+### Decode and Validate the Access Token
 
 You need to decode the access token, which is in JWT format.  This involves the following steps:
 - Verify the token signature.

--- a/packages/@okta/vuepress-site/docs/guides/validate-access-tokens/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/validate-access-tokens/main/index.md
@@ -19,7 +19,7 @@ Validate access tokens.
 
 ## About access token validation
 
-If you are building a modern app or API, you likely want to know if your end user is authenticated. This is important to give context or to protect APIs from unauthenticated users. You can use Okta to authenticate your end users and issue them signed access and ID tokens, which your application can then use. It is important that your application only uses the access token to grant access, and not the ID token. For more information about this, see the [Access Tokens vs ID Tokens](#access-tokens-vs-id-tokens) section below.
+If you're building a modern app or API, you likely want to know if your end user is authenticated. This is important to give context or to protect APIs from unauthenticated users. You can use Okta to authenticate your end users and issue them signed access and ID tokens, which your application can then use. It's important that your application only uses the access token to grant access, and not the ID token. For more information about this, see the [Access Tokens vs ID Tokens](#access-tokens-vs-id-tokens) section.
 
 After the signed tokens are issued to the end users, they can be passed to your application for validation. There are two ways to verify a token: locally or remotely with Okta. The token is signed with a JSON Web Key (JWK) using the RS256 algorithm. To validate the signature, Okta provides your application with a public key that can be used.
 
@@ -27,43 +27,45 @@ After the signed tokens are issued to the end users, they can be passed to your 
 - If you'd like to see how to validate a token directly with Okta: [Validating A Token Remotely With Okta](#validating-a-token-remotely-with-okta)
 - If you want to see specifically how to accomplish this in your language of choice: [Okta Libraries to Help You Verify Access Tokens](#okta-libraries-to-help-you-verify-access-tokens)
 
+> **Note:** Access tokens from the org authorization server, as signified by an issuer `https://${yourOktaOrg}`, shouldn't be consumed or validated by any application other than Okta. Consider these access tokens as opaque strings since their content is subject to change at any time without notice. Therefore, any attempts to validate the tokens may not work in the future.
+
 ## Access Tokens vs ID Tokens
 
-As mentioned above, it is important that the resource server (your server-side application) accepts only the access token from a client. This is because access tokens are intended for authorizing access to a resource.
+As mentioned earlier, it's important that the resource server (your server-side application) accepts only the access token from a client. This is because access tokens are intended for authorizing access to a resource.
 
-ID Tokens, on the other hand, are intended for authentication. They provide information about the resource owner, to allow you verify that they are who they say they are. Authentication is the concern of the clients. Because of this, when a client makes an authentication request, the ID Token that is returned contains the `client_id` in the ID Token's `aud` claim.
+ID tokens, on the other hand, are intended for authentication. They provide information about the resource owner so that you can verify that they're who they say they are. Authentication is the concern of the clients. Because of this, when a client makes an authentication request, the ID token that is returned contains the `client_id` in the ID token's `aud` claim.
 
 ## What to Check When Validating an Access Token
 
 The high-level overview of validating an access token looks like this:
 
 - Retrieve and parse your Okta JSON Web Keys (JWK), which should be checked periodically and cached by your application.
-- Decode the access token, which is in JSON Web Token (JWT) format
-- Verify the signature used to sign the access token
-- Verify the claims found inside the access token
+- Decode the access token, which is in JSON Web Token (JWT) format.
+- Verify the signature used to sign the access token.
+- Verify the claims found inside the access token.
 
 ### Retrieve The JSON Web Keys
 
-The JSON Web Keys (JWK) need to be retrieved from your [Okta authorization server](/docs/guides/customize-authz-server/), though your application should have them cached. See [Best practices](/docs/reference/api/oidc/#best-practices). Specifically, your authorization server's Metadata endpoint contains the `jwks_uri`, which you can use to get the JWK.  
+The JSON Web Keys (JWK) need to be retrieved from your [Okta authorization server](/docs/guides/customize-authz-server/), though your application should have them cached. See [Best practices](/docs/reference/api/oidc/#best-practices). Specifically, your authorization server's Metadata endpoint contains the `jwks_uri`, which you can use to get the JWK.
 
 > For more information about retrieving this metadata, see [Retrieve Authorization Server Metadata](/docs/reference/api/oidc/#well-knownoauth-authorization-server).
 
 ### Decoding and Validating the Access Token
 
-You will have to decode the access token, which is in JWT format.  This involves the following steps:
-- Verify the Token Signature
-- Verify the Claims
+You need to decode the access token, which is in JWT format.  This involves the following steps:
+- Verify the token signature.
+- Verify the claims.
 
 <StackSelector snippet="accesstoken" noSelector/>
 
-## Validating A Token Remotely With Okta
+## Validate A Token Remotely With Okta
 
-Alternatively, you can also validate an access or refresh Token using the Token Introspection endpoint: [Introspection Request](/docs/reference/api/oidc/#introspect). This endpoint takes your token as a URL query parameter and returns back a simple JSON response with a boolean `active` property.
+Alternatively, you can also validate an access or refresh token using the Token Introspection endpoint: [Introspection Request](/docs/reference/api/oidc/#introspect). This endpoint takes your token as a URL query parameter and returns back a simple JSON response with a boolean `active` property.
 
 This incurs a network request which is slower to do verification, but can be used when you want to guarantee that the access token hasn't been revoked.
 
-## See also 
+## See also
 
 - A high-level overview of OpenID Connect can be found [here](/docs/concepts/oauth-openid/#openid-connect).
-- The access tokens are in [JSON Web Token (JWT)](https://tools.ietf.org/html/rfc7519) format. They are signed using asymmetrical [JSON Web Keys (JWK)](https://tools.ietf.org/html/rfc7517).
-- More information about Okta's access tokens can be found in the [OIDC & OAuth 2.0 API Reference](/docs/reference/api/oidc/#id-token).
+- The access tokens are in [JSON Web Token (JWT)](https://tools.ietf.org/html/rfc7519) format. They're signed using asymmetrical [JSON Web Keys (JWK)](https://tools.ietf.org/html/rfc7517).
+- More information about Okta access tokens can be found in the [OIDC & OAuth 2.0 API Reference](/docs/reference/api/oidc/#id-token).


### PR DESCRIPTION
## Description:
- **What's changed?** OAUTH2_USE_EXTERNAL_KEY_FOR_ORG_AS_ACCESS_TOKEN updates in AS concept, and Validate token guide.
- **Is this PR related to a Monolith release?** Yes, 2024.03.0

### Resolves:

* [OKTA-694170](https://oktainc.atlassian.net/browse/OKTA-694170)
