### PR TITLE
[OKTA-699116] : One fixed header

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_headerNav.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_headerNav.scss
@@ -1,9 +1,4 @@
 .header-nav {
-  position: fixed;
-  top: 87px;
-  left: 0;
-  z-index: 4;
-
   display: flex;
   align-items: center;
   padding: 0 31px;

--- a/packages/@okta/vuepress-theme-prose/components/MobileOnThisPage.vue
+++ b/packages/@okta/vuepress-theme-prose/components/MobileOnThisPage.vue
@@ -27,6 +27,8 @@
 </template>
 
 <script>
+  import { LAYOUT_CONSTANTS } from "../layouts/Layout";
+
   export default {
     name: 'MobileOnThisPage',
     data: ()=>({ 
@@ -49,7 +51,7 @@
         this.selectedOption = value
         const target = document.querySelector('#'+value.code)
 
-        const scrollToPosition = target.offsetTop - 20;
+        const scrollToPosition = target.offsetTop - LAYOUT_CONSTANTS.ANCHOR_TOP_MARGIN;
 
         window.scrollTo({top: scrollToPosition, behavior: 'smooth'})
       }

--- a/packages/@okta/vuepress-theme-prose/components/OnThisPage.vue
+++ b/packages/@okta/vuepress-theme-prose/components/OnThisPage.vue
@@ -34,7 +34,6 @@
 </template>
 
 <script>
-import { LAYOUT_CONSTANTS } from "../layouts/Layout.vue";
 import AnchorHistory from "../mixins/AnchorHistory.vue";
 import _ from "lodash";
 export default {
@@ -100,19 +99,6 @@ export default {
     window.removeEventListener("resize", this.updateAnchors);
   },
   methods: {
-    setAlwaysOnViewPosition: _.debounce(function() {
-      let maxHeight =
-        document.querySelector(".on-this-page").clientHeight - window.scrollY;
-      if (maxHeight > window.innerHeight) {
-        maxHeight =
-          window.innerHeight -
-          document.querySelector(".fixed-header").clientHeight -
-          60;
-      }
-      document.querySelector(".on-this-page-navigation").style.height =
-        maxHeight + "px";
-    }, 200),
-
     setActiveAnchor: _.debounce(function() {
       const onThisPageActiveAnchor = this.getActiveAnchor();
       this.activeAnchor = onThisPageActiveAnchor

--- a/packages/@okta/vuepress-theme-prose/layouts/Layout.vue
+++ b/packages/@okta/vuepress-theme-prose/layouts/Layout.vue
@@ -86,7 +86,8 @@
 
 <script>
 export const LAYOUT_CONSTANTS = {
-  HEADER_TO_CONTENT_GAP: 45 //px
+  HEADER_TO_CONTENT_GAP: 45, //px
+  ANCHOR_TOP_MARGIN: 32
 };
 const TABLET_BREAKPOINT = 767;
 

--- a/packages/@okta/vuepress-theme-prose/layouts/Layout.vue
+++ b/packages/@okta/vuepress-theme-prose/layouts/Layout.vue
@@ -2,15 +2,13 @@
   <div class="layout">
     <div class="fixed-header">
       <Header />
+      <HeaderNav />
     </div>
     <div
       :class="{
         'page-body': true,
       }"
     >
-      <HeaderNav />
-
-
       <div
         v-if="$page.frontmatter.component"
         class="content"

--- a/packages/@okta/vuepress-theme-prose/mixins/AnchorHistory.vue
+++ b/packages/@okta/vuepress-theme-prose/mixins/AnchorHistory.vue
@@ -5,17 +5,11 @@ export default {
   inject: ['appContext'],
   data() {
     return {
-      paddedHeaderHeight: 0,
       anchorOffset: []
     };
   },
   mounted() {},
   methods: {
-    getPaddedHeaderHeight: function () {
-      return  document.querySelector(".fixed-header").clientHeight +
-              LAYOUT_CONSTANTS.HEADER_TO_CONTENT_GAP;
-    },
-
     setAnchors: function (anchors) {
         this.anchors = anchors;
         this.getAnchorsOffset();
@@ -25,8 +19,6 @@ export default {
         return;
       }
 
-      this.paddedHeaderHeight = this.getPaddedHeaderHeight()
-      
       const anchorOffsets = this.anchors.map(
         /* 
           In case of a few pages like error codes (/docs/reference/error-codes/), we are using our custom template
@@ -51,7 +43,7 @@ export default {
       if (!target) {
         return;
       }
-      const scrollToPosition = target.offsetTop - 20;
+      const scrollToPosition = target.offsetTop - LAYOUT_CONSTANTS.ANCHOR_TOP_MARGIN;
 
       window.scrollTo({top: scrollToPosition, behavior: 'smooth'});
     },
@@ -83,8 +75,8 @@ export default {
 
       const matchingPair = this.anchorsOffset.find(
         pair =>
-          scrollTop >= pair.start - 20 &&
-          (!pair.end || scrollTop < pair.end - 20),
+          scrollTop >= pair.start - LAYOUT_CONSTANTS.ANCHOR_TOP_MARGIN &&
+          (!pair.end || scrollTop < pair.end - LAYOUT_CONSTANTS.ANCHOR_TOP_MARGIN),
         this
       );
       const activeAnchor = matchingPair

--- a/packages/@okta/vuepress-theme-prose/mixins/AnchorHistory.vue
+++ b/packages/@okta/vuepress-theme-prose/mixins/AnchorHistory.vue
@@ -83,8 +83,8 @@ export default {
 
       const matchingPair = this.anchorsOffset.find(
         pair =>
-          scrollTop >= pair.start - this.paddedHeaderHeight &&
-          (!pair.end || scrollTop < pair.end - this.paddedHeaderHeight),
+          scrollTop >= pair.start - 20 &&
+          (!pair.end || scrollTop < pair.end - 20),
         this
       );
       const activeAnchor = matchingPair


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** 

1. Make one fixed header
2. "On this page" navigation should match anchors. When we scroll up on the page - active item on the right side should change to one that above the current one.

### Resolves:

* [OKTA-699116](https://oktainc.atlassian.net/browse/OKTA-699116)

### Preview:
https://65de070744b78100801e7bf1--reverent-murdock-829d24.netlify.app/

### Proof of work:

1. 

<img width="1726" alt="Screenshot 2024-02-27 at 8 05 33 PM" src="https://github.com/okta/okta-developer-docs/assets/158277016/955e8d89-0d53-43a4-aa33-cd6a7979803b">

2. 

https://github.com/okta/okta-developer-docs/assets/158277016/568d78db-ae75-4f2d-b478-ce8810b74afe


