### PR TITLE
chore(docs): Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<img src="https://aws1.discourse-cdn.com/standard14/uploads/oktadev/original/1X/0c6402653dfb70edc661d4976a43a46f33e5e919.png" align="right" width="256px"/>
-
 [![Support](https://img.shields.io/badge/support-developer%20forum-blue.svg)](https://devforum.okta.com/)
 
 # Overview of Okta Developer site

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <img src="https://aws1.discourse-cdn.com/standard14/uploads/oktadev/original/1X/0c6402653dfb70edc661d4976a43a46f33e5e919.png" align="right" width="256px"/>
 
 [![Support](https://img.shields.io/badge/support-developer%20forum-blue.svg)](https://devforum.okta.com/)
-[![Build Status](https://travis-ci.org/okta/okta-developer-docs.svg?branch=master)](https://travis-ci.org/okta/okta-developer-docs)
 
 # Overview of Okta Developer site
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:

Changes to the main repo README.

- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
  - Removes a now-outdated TravisCI build status shield which was deprecated via https://github.com/okta/okta-developer-docs/pull/3816.  TravisCI hasn't been run in 2 years. Repo seems to have both CircleCI and Github Actions, so either build shields could be added back for those w/ write access to the repo and pipelines.
  - Removes the bad image which is coming from a CDN; not sure what to replace it with, but easy for anyone to add back if they know its source. (maybe company logo?)
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->
  - No.

Note: As an open source contributor, I've not signed the [Okta CLA ](https://developer.okta.com/cla/) but this should fall in the "obvious fix" category meaning that's not necessary.

### Screenshots

| Before | After |
| --- | --- |
|  <img width="924" alt="image" src="https://github.com/okta/okta-developer-docs/assets/33203301/35042c1a-1e57-4bcd-b2a8-109e713eafdb">  |  <img width="924" alt="image" src="https://github.com/okta/okta-developer-docs/assets/33203301/ca246622-63e0-4fdd-8e9e-709757bf7520"> |

