### PR TITLE
fix(docs): Typos and vendor proper capitalization

### DIFF
--- a/packages/@okta/vuepress-site/books/api-security/sanitizing/attack-vectors/index.md
+++ b/packages/@okta/vuepress-site/books/api-security/sanitizing/attack-vectors/index.md
@@ -32,7 +32,7 @@ Cache-Control: no-cache
 foo=bar&key=value
 ```
 
-You can see right away: request headers are user input too.  Imagine for a moment that an HTTP client maliciously changes the User-Agent header. The logged User-Agent may falsely identify a request as coming from a different client application than the one in which it really originated.originated from. While that's unlikely to affect the current request, it might cause confusion in the application's logging and reporting system.
+You can see right away: request headers are user input too.  Imagine for a moment that an HTTP client maliciously changes the User-Agent header. The logged User-Agent may falsely identify a request as coming from a different client application than the one in which it really originated from. While that's unlikely to affect the current request, it might cause confusion in the application's logging and reporting system.
 
 Further, the User-Agent could be visible from an internal web application that doesn't sanitize the User-Agent values before displaying them. In this case, an HTTP client could maliciously modify their User-Agent to any JavaScript code they want which would then be executed in an internal user's browser via XSS.
 

--- a/packages/@okta/vuepress-site/books/api-security/sanitizing/attack-vectors/index.md
+++ b/packages/@okta/vuepress-site/books/api-security/sanitizing/attack-vectors/index.md
@@ -9,11 +9,13 @@ title: Look For Other Attack Vectors - Sanitizing Data
 Inputs are everywhere, often only evident in hindsight. User input and file uploads are just the tip of the iceberg, but what if we consider more than input and instead the code itself? Here are a couple of examples to illustrate this point.
 
 ### Your Dependencies
-Do you trust all of your dependencies? How about all of the transitive dependencies of your application? It is not uncommon to for an application to have a page that lists its dependencies versions and licenses (the later might even be required depending on the license). The popular Node package manager (npm) has had a few projects which have contained [maliciously formed license fields](https://blog.npmjs.org/post/80277229932/newly-paranoid-maintainers). In another npm incident, [packages ran malicious scripts](https://iamakulov.com/notes/npm-malicious-packages/) upon installation automatically that uploaded the user's environment variables to a third party.
+
+Do you trust all of your dependencies? How about all of the transitive dependencies of your application? It is not uncommon to for an application to have a page that lists its dependencies versions and licenses (the latter might even be required depending on the license). The popular Node package manager (npm) has had a few projects which have contained [maliciously formed license fields](https://blog.npmjs.org/post/80277229932/newly-paranoid-maintainers). In another npm incident, [packages ran malicious scripts](https://iamakulov.com/notes/npm-malicious-packages/) upon installation automatically that uploaded the user's environment variables to a third party.
 
 Every dependency is code you include from other systems across your trust boundary. Properly inspecting and validating your dependencies is a critical first step of any input sanitation plan. GitHub recently introduced [automated security alerting](https://blog.github.com/2017-11-16-introducing-security-alerts-on-github/) to let you know when your dependencies might have security issues. Pay attention to these and you can prevent a lot of headaches.
 
 ### Inbound HTML Requests
+
 Almost all values from an HTTP request can be changed by the sender and need to be handled accordingly. To help illustrate this, here is a simple HTTP POST including numerous headers to `http://example.com/submit-me`:
 
 ```http
@@ -32,8 +34,8 @@ Cache-Control: no-cache
 foo=bar&key=value
 ```
 
-You can see right away: request headers are user input too.  Imagine for a moment that an HTTP client maliciously changes the User-Agent header. The logged User-Agent may falsely identify a request as coming from a different client application than the one in which it really originated from. While that's unlikely to affect the current request, it might cause confusion in the application's logging and reporting system.
+You can see right away: request headers are user input too.  Imagine for a moment that an HTTP client maliciously changes the `User-Agent` header. The logged `User-Agent` may falsely identify a request as coming from a different client application than the one in which it really originated from. While that's unlikely to affect the current request, it might cause confusion in the application's logging and reporting system.
 
-Further, the User-Agent could be visible from an internal web application that doesn't sanitize the User-Agent values before displaying them. In this case, an HTTP client could maliciously modify their User-Agent to any JavaScript code they want which would then be executed in an internal user's browser via XSS.
+Further, the `User-Agent` could be visible from an internal web application that doesn't sanitize the `User-Agent` values before displaying them. In this case, an HTTP client could maliciously modify their `User-Agent` to any JavaScript code they want which would then be executed in an internal user's browser via XSS.
 
 As these examples illustrate, even sanitizing relatively innocuous inputs is an important part of an overall security strategy.

--- a/packages/@okta/vuepress-site/code/dotnet/aspnet/index.md
+++ b/packages/@okta/vuepress-site/code/dotnet/aspnet/index.md
@@ -31,16 +31,6 @@ meta:
 These resources walk you through adding user authentication to your ASP.NET app in minutes.
 
 <ul class='language-ctas'>
-  <!-- <li>
-    <a href='/docs/guides/sign-into-web-app-redirect/aspnet/main/' class='Button--blueDarkOutline' data-proofer-ignore>
-      <span>Sign users in quickstart</span>
-    </a>
-  </li>
-  <li>
-    <a href='/docs/guides/protect-your-api/aspnet/main/' class='Button--blueDarkOutline' data-proofer-ignore>
-      <span>Protect your API quickstart</span>
-    </a>
-  </li>-->
   <li>
     <DropdownButton caption="Sample app">
       <DropdownButtonOption href='https://github.com/okta/samples-aspnet'>MVC & Web API</DropdownButtonOption>

--- a/packages/@okta/vuepress-site/code/dotnet/aspnet/index.md
+++ b/packages/@okta/vuepress-site/code/dotnet/aspnet/index.md
@@ -79,13 +79,8 @@ Okta Classic Engine:
 
 ## Recommended guides
 
-Okta-hosted Sign-In Widget guide:
-
-Sign into your web app with redirect auth  (coming soon)
-
-Embedded SDK and Sign-In Widget sign-in guide:
-
-[Get set up with Identity Engine sample apps and embedded use cases](/docs/guides/oie-embedded-common-org-setup/aspnet/main/)
+* Okta-hosted Sign-In Widget guide: Sign into your web app with redirect auth  (coming soon)
+*  Embedded SDK and Sign-In Widget sign-in guide: [Get set up with Identity Engine sample apps and embedded use cases](/docs/guides/oie-embedded-common-org-setup/aspnet/main/)
 
 Other guides:
 

--- a/packages/@okta/vuepress-site/code/dotnet/aspnet/index.md
+++ b/packages/@okta/vuepress-site/code/dotnet/aspnet/index.md
@@ -68,7 +68,7 @@ Okta Identity Engine:
 
 Okta Classic Engine:
 
-* The [Okta .NET Authentication SDK](https://github.com/okta/okta-auth-dotnet) is useful if you cann't use OIDC and need your server-side code to interact with the Authentication API for handling the sign-in flow.
+* The [Okta .NET Authentication SDK](https://github.com/okta/okta-auth-dotnet) is useful if you can't use OIDC and need your server-side code to interact with the Authentication API for handling the sign-in flow.
 * Okta's [Okta ASP.NET OIDC middleware Integration](https://github.com/okta/okta-aspnet) makes it easy to add sign-in to your ASP.NET Core applications and protect your Web APIs.
 * [Okta ASP.NET OIDC integration on NuGet](https://www.nuget.org/packages/Okta.AspNet)
 

--- a/packages/@okta/vuepress-site/code/ios/quickstart-appauth-swift/index.md
+++ b/packages/@okta/vuepress-site/code/ios/quickstart-appauth-swift/index.md
@@ -109,7 +109,7 @@ In native applications, it is common for users to have a long-lived session. It'
 
 ### Store the User's Tokens
 
-Tokens are securly stored in the keychain. They are easily set and retrieved with the helper methods `set` and `get`.
+Tokens are securely stored in the keychain. They are easily set and retrieved with the helper methods `set` and `get`.
 
 ```swift
 OktaAuth

--- a/packages/@okta/vuepress-site/code/ios/quickstart-appauth-swift/index.md
+++ b/packages/@okta/vuepress-site/code/ios/quickstart-appauth-swift/index.md
@@ -11,24 +11,24 @@ This guide walks you through integrating authentication and authorization into a
 
 ## Prerequisites
 
-If you don't already have a **Developer Edition Account**, you can create one at [https://developer.okta.com/signup/](https://developer.okta.com/signup/).
+If you don't already have a **Developer Edition Account**, you can create one [by signing up](https://developer.okta.com/signup/).
 
 ### Add an OpenID Connect Client
 
 * Sign in to the Okta Developer Dashboard, and **Create New App**.
 * Choose **Native app** as the platform, then populate your new OpenID Connect application with values similar to:
 
-| Setting              | Value                                               |
-| -------------------  | --------------------------------------------------- |
-| Application Name     | OpenId Connect App (must be unique)               |
-| Login redirect URIs  | `com.okta.example:/callback`                         |
-| Logout redirect URIs | `com.okta.example:/logout`                            |
+    | Setting              | Value                                |
+    | -------------------  | ------------------------------------ |
+    | Application Name     | OpenId Connect App (must be unique)  |
+    | Login redirect URIs  | `com.okta.example:/callback`         |
+    | Logout redirect URIs | `com.okta.example:/logout`           |
 
 > **Note:** As with any Okta application, make sure that you assign Users or Groups to the OpenID Connect Client. Otherwise, no one can use it.
 
 ## Installation
 
-The simplest way to add authentication into an iOS app is using the library [Okta AppAuth](http://cocoapods.org/pods/OktaAuth), available through [CocoaPods](http://cocoapods.org). To install it, simply add the following line to your Podfile:
+The simplest way to add authentication into an iOS app is using the library [Okta AppAuth](http://cocoapods.org/pods/OktaAuth), available through [CocoaPods](http://cocoapods.org). To install it, simply add the following line to your `Podfile`:
 
 ```ruby
 pod 'OktaAuth', '~> 0.1'
@@ -59,7 +59,7 @@ Create a new `Okta.plist` file in your application's bundle with the following f
 </plist>
 ```
 
-**Note**: To receive a `refresh_token`, you must include the `offline_access` scope.
+> **Note**: To receive a `refresh_token`, you must include the `offline_access` scope.
 
 > **Important:** Most native applications send access tokens to access APIs. If you're building an API that needs to accept access tokens, [create an authorization server](/docs/guides/customize-authz-server/).
 

--- a/packages/@okta/vuepress-site/code/java/spring_security_saml/index.md
+++ b/packages/@okta/vuepress-site/code/java/spring_security_saml/index.md
@@ -334,7 +334,7 @@ When you sign in, the resulting page shows that you have a `ROLE_USER` authority
 
 ## Deploy with Heroku
 
-After you have Okta working with the generated Spring Security SAML application, the next step is to take the example code and move it to your production enviroment. The specifics of how this works are different depending on how your application is set up.
+After you have Okta working with the generated Spring Security SAML application, the next step is to take the example code and move it to your production environment. The specifics of how this works are different depending on how your application is set up.
 
 One quick way to see this app working in a production environment is to deploy it to Heroku. [Install the Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli) and create an account to begin. Then, follow the steps below to prepare and deploy your app.
 

--- a/packages/@okta/vuepress-site/code/javascript/okta_auth_sdk/index.md
+++ b/packages/@okta/vuepress-site/code/javascript/okta_auth_sdk/index.md
@@ -196,7 +196,7 @@ else {
 }
 ```
 
-> **Note:** This example, like everything else on this page, is for illustrative purposess only. The `prompt()` method isn't considered a secure way of asking for user authentication credentials.
+> **Note:** This example, like everything else on this page, is for illustrative purposes only. The `prompt()` method isn't considered a secure way of asking for user authentication credentials.
 
 #### Complete Okta Session and OIDC token example
 

--- a/packages/@okta/vuepress-site/code/python/pysaml2/index.md
+++ b/packages/@okta/vuepress-site/code/python/pysaml2/index.md
@@ -16,7 +16,7 @@ This guide describes how to install and configure an example application that de
 
 > **Note:** The library isn't Okta's and isn't supported by Okta.
 
-This guide assumes that you are familiar with the basics of Python software development: using the command line, editing text files, using [virtualenv](https://virtualenv.pypa.io/en/latest/), and using [pip](https://en.wikipedia.org/wiki/Pip_%28package_manager%29).
+This guide assumes that you are familiar with the basics of Python software development: using the command line, editing text files, using [`virtualenv`](https://virtualenv.pypa.io/en/latest/), and using [`pip`](https://en.wikipedia.org/wiki/Pip_%28package_manager%29).
 
 If you're already familiar with Okta, you can skip to the section titled "Configuring PySAML2 to work with Okta."
 
@@ -125,8 +125,8 @@ Use both methods to test your application. In each case, you know if the test wo
 
     	```bash
     	$ source venv/bin/activate
-	$ python app.py
-	```
+	    $ python app.py
+	    ```
 
     -   Open the example application in your browser:
         `http://localhost:5000/`
@@ -138,16 +138,16 @@ Use both methods to test your application. In each case, you know if the test wo
 
     -  Start the example application from the command line:
 
-    ```bash
-    	$ source venv/bin/activate
-	$ python app.py
-	```
+        ```bash
+        $ source venv/bin/activate
+        $ python app.py
+	    ```
 
     -  Sign in to your Okta organization.
 
     -  Click the button for the application that you created earlier in the "Configuring Okta to work with PySAML2" section above: ![PySAML2 Example](/img/pysaml2-example-okta-chiclet.png "PySAML2 Example")
 
-If you can to get to the "Logged in" page using both of the methods above, the test are successful.
+If you can to get to the "Logged in" page using both of the methods above, the tests are successful.
 
 Congratulations on getting Okta working with PySAML2!
 

--- a/packages/@okta/vuepress-site/code/python/pysaml2/index.md
+++ b/packages/@okta/vuepress-site/code/python/pysaml2/index.md
@@ -155,6 +155,6 @@ Congratulations on getting Okta working with PySAML2!
 
 At this point, you should be familiar with setting up a SAML enabled application to work with an Okta organization and how to configure PySAML2 to work with Okta.
 
-After you have your Okta organization working with the example Python application, the next step is to take the example code and move it to your production application. The specifics of how this works is different depending on how your application is set up. Pay special attention to the notes in the `app.py` file. For example, on a production system, you can't hard code the contents of the `metadata_url_for` dictionary. They shoulc come from a dynamic datastore.
+After you have your Okta organization working with the example Python application, the next step is to take the example code and move it to your production application. The specifics of how this works is different depending on how your application is set up. Pay special attention to the notes in the `app.py` file. For example, on a production system, you can't hard code the contents of the `metadata_url_for` dictionary. They should come from a dynamic datastore.
 
 If you want to learn more about SAML and what to consider when writing a SAML implementation, Okta's in-depth [SAML guidance](https://www.okta.com/integrate/documentation/saml/) is a great place to learn more.

--- a/packages/@okta/vuepress-site/code/python/pysaml2/index.md
+++ b/packages/@okta/vuepress-site/code/python/pysaml2/index.md
@@ -42,7 +42,6 @@ guide. As noted in the [Create your integration](/docs/guides/build-sso-integrat
 
   **Note:** `5000` is the port that Flask uses by default. If you're using a different port number, change `5000` to appropriate one.
 
-
 ## Configure PySAML2 to work with Okta
 
 Now that you have configured the PySAML2 Example application icon in your Okta organization, you are ready to configure PySAML2 to work with your Okta organization. In this section we use the **Identity Provider metadata** link from the section above to configure PySAML2. After you complete the following steps, you have a working example of connecting Okta to a sample Python application using PySAML2.
@@ -81,7 +80,7 @@ Now that you have configured the PySAML2 Example application icon in your Okta o
     $ $EDITOR app.py
     ```
 
-5. After opening the `app.py` file, modify the contents of the `metadata_url_for` dictionary as shown below.
+5. In `app.py` file, modify the contents of the `metadata_url_for` dictionary as shown below.
 
     ``` python
     metadata_url_for = {
@@ -89,7 +88,7 @@ Now that you have configured the PySAML2 Example application icon in your Okta o
     }
     ```
 
-6. Be sure to replace the contents of `${metadataUrl}` with the link that you copied in step \#10 of the [Setting up a SAML application in Okta](/docs/guides/customize-authz-server/) instructions that you followed above.
+    Replace the contents of `${metadataUrl}` with the link that you copied in step \#10 of the [Setting up a SAML application in Okta](/docs/guides/customize-authz-server/) instructions that you followed above.
 
     > **Note:** The contents of `${metadataUrl}` should look similar to: `https://${yourOktaDomain}/app/a0b1c2deFGHIJKLMNOPQ/sso/saml/metadata`
 

--- a/packages/@okta/vuepress-site/docs/guides/saml-inline-hook/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/saml-inline-hook/main/index.md
@@ -54,7 +54,7 @@ At a high-level, the following workflow occurs:
 
 The Spring Boot, SAML, and Okta application is designed to implement Single Sign-On (SSO) with Spring Security's SAML and Okta.
 
-Access the Spring Boot, SAML, and Okta code from the following Github repository:
+Access the Spring Boot, SAML, and Okta code from the following GitHub repository:
 
 [https://github.com/oktadev/okta-spring-boot-saml-example](https://github.com/oktadev/okta-spring-boot-saml-example)
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/angular/download-sample.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/angular/download-sample.md
@@ -1,4 +1,4 @@
-1. In your project folder, download the sample application from the gitHub repository and navigate to the custom-login folder.
+1. In your project folder, download the sample application from the GitHub repository and navigate to the custom-login folder.
 
     ```bash
     git clone https://github.com/okta/samples-js-angular.git

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/vue/useaccesstoken.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/vue/useaccesstoken.md
@@ -1,6 +1,6 @@
 Let's say that you have an API that provides messages for a user. You could create a component that gets the access token and uses it to make an authenticated request to your server.
 
-Here is what the Vue component could look like for this hypothetical example using [axios](https://github.com/axios/axios):
+Here is what the Vue component could look like for this hypothetical example using [Axios](https://github.com/axios/axios):
 
 ```js
 <template>

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/vue/useaccesstoken.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/vue/useaccesstoken.md
@@ -1,6 +1,6 @@
 Let's say that you have an API that provides messages for a user. You could create a component that gets the access token and uses it to make an authenticated request to your server.
 
-Here is what the Vue component could look like for this hypothentical example using [axios](https://github.com/axios/axios):
+Here is what the Vue component could look like for this hypothetical example using [axios](https://github.com/axios/axios):
 
 ```js
 <template>

--- a/packages/@okta/vuepress-site/docs/guides/submit-oin-app/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/submit-oin-app/main/index.md
@@ -54,7 +54,7 @@ This guide covers submissions that use the following protocols:
 
     > **Notes:**
     > * SAML integrations must use SHA256 encryption for security. If you're using SHA-1 for encryption, see our guide on how to [Upgrade SAML Apps to SHA256](/docs/guides/updating-saml-cert/).
-    > * The OIN Wizard places certain limits on SAMl integration submissions. See [OIN limitations](/docs/guides/submit-app-prereq/main/#oin-limitations).
+    > * The OIN Wizard places certain limits on SAML integration submissions. See [OIN limitations](/docs/guides/submit-app-prereq/main/#oin-limitations).
 
 > **Note:** SWA app integrations are no longer accepted for publication in the OIN catalog. However, the OIN team still maintains existing SWA apps.
 

--- a/packages/@okta/vuepress-site/docs/guides/terraform-design-access-security/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/terraform-design-access-security/main/index.md
@@ -43,7 +43,7 @@ With this flow, Terraform uses credentials to request access to your org. The se
 The credentials used for this flow are a public/private key pair. Okta stores the public key in the service app, and Terraform uses the private key in the configuration. You can [generate the key pair](/docs/guides/implement-oauth-for-okta-serviceapp) in the Okta service app or with your own secure internal methods. See [Create access credentials](/docs/guides/terraform-enable-org-access/main/#create-access-credentials).
 
 > **Note:** The Okta Terraform Provider requires the private key to use PKCS#1 encoding.
-Okta recommends storing the private key in a separate and secure location and using a secrets and encryption management system, such as Hashicorp Vault. You can use input variables and environment variables to provide credentials to Terraform.
+Okta recommends storing the private key in a separate and secure location and using a secrets and encryption management system, such as HashiCorp Vault. You can use input variables and environment variables to provide credentials to Terraform.
 
 > **Note:** Don't store credentials as plain text in your Terraform configuration.
 

--- a/packages/@okta/vuepress-site/docs/guides/terraform-enable-org-access/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/terraform-enable-org-access/main/index.md
@@ -138,7 +138,7 @@ Create a Terraform configuration that uses the credentials that you created earl
    * `org_name`: Your Okta org name. For example, `exampleOrgName` from the full domain `https://exampleOrgName.okta.com`.
    * `base_url`: Your Okta org domain
    * `client_id`: The client ID of the service app that you created in an earlier step.
-   * `private_key`: Either the path to the private key file or the private key itself. Okta recommends storing the key in a separate location and using a secrets and encryption management system, such as Hashicorp Vault.
+   * `private_key`: Either the path to the private key file or the private key itself. Okta recommends storing the key in a separate location and using a secrets and encryption management system, such as HashiCorp Vault.
    * `scopes`: A list of scopes required by the Terraform configuration. This example uses the `okta.groups.manage` scope.
 
 For more information on declaring the Okta Provider in your Terraform configuration, see the [Okta Provider documentation](https://registry.terraform.io/providers/okta/okta/latest/docs).

--- a/packages/@okta/vuepress-site/docs/guides/terraform-overview/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/terraform-overview/main/index.md
@@ -22,7 +22,7 @@ For example, you can include an `okta_groups` resource in your Terraform code to
 
 The Okta Provider interacts with your org by making API calls using the Okta Go SDK. Each resource and data source makes calls to different APIs to read and manage the objects in your org. Some resources and data sources make more than one API call when you run your Terraform code. See [Minimize Terraform rate limit errors](/docs/guides/terraform-design-rate-limits) for tips on managing the number of API calls that Terraform makes.
 
-For a closer look at how resources and data sources call the API, see the [terraform-provider-okta](https://github.com/okta/terraform-provider-okta) Github repository.
+For a closer look at how resources and data sources call the API, see the [terraform-provider-okta](https://github.com/okta/terraform-provider-okta) GitHub repository.
 
 > **Note:** To use Terraform to automate your Customer Identity Cloud (CIC), use the Auth0 Provider.
 

--- a/packages/@okta/vuepress-site/docs/guides/token-inline-hook/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/token-inline-hook/main/index.md
@@ -49,7 +49,7 @@ At a high-level, the following workflow occurs:
 
 ## Set up the sample Express application
 
-The sample Node.js Express application is designed to demonstrate the [Authorization Code flow](/docs/guides/implement-grant-type/authcode/main/), and includes an Okta-hosted Login sample used in this token inline hook guide. Access the code from the following github repository and use the following instructions to set up your sample application.
+The sample Node.js Express application is designed to demonstrate the [Authorization Code flow](/docs/guides/implement-grant-type/authcode/main/), and includes an Okta-hosted Login sample used in this token inline hook guide. Access the code from the following GitHub repository and use the following instructions to set up your sample application.
 
 * [Express Sample Applications for Okta](https://github.com/okta/samples-nodejs-express-4)
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
  - Fixes a few minor typos in the doc caught with `mdspell`.
  - Also properly cases GitHub and HashiCorp to align to how those vendors/products are marketed. (Trivial, but drives consistency)
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->
  - No.

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

Note: I've not signed the Okta CLA, but believe this falls into the "obvious fix" category.