### PR TITLE
OKTA-701961 | When we enter anchor tag in address bar it redirects to wrong location

### DIFF
--- a/packages/@okta/vuepress-theme-prose/global-components/ErrorCodes.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/ErrorCodes.vue
@@ -299,7 +299,7 @@ export default {
 
   .error-codes .error-code h4 {
     clear: left;
-    margin: 25px 0 0;
+    margin: 32px 0 0;
     padding: 6px 10px;
     overflow: hidden;
 
@@ -308,6 +308,7 @@ export default {
     text-overflow: ellipsis;
     white-space: nowrap;
     color: $link_color;
+    scroll-padding-top: 160px;
   }
 
   .error-codes .error-code h4 .title-error-code {

--- a/packages/@okta/vuepress-theme-prose/global-components/Oauth2ErrorCodes.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/Oauth2ErrorCodes.vue
@@ -259,7 +259,7 @@
 
   .error-codes .error-code h4 {
     clear: left;
-    margin: 25px 0 0;
+    margin: 32px 0 0;
     padding: 6px 10px;
     overflow: hidden;
 
@@ -268,6 +268,7 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     color: $link_color;
+    scroll-padding-top: 160px;
   }
 
   .error-codes .error-code h4 .title-error-code {


### PR DESCRIPTION
…

<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Implementing CSS property `scroll-padding-top` to ensure users navigate to a specific section via a hash URL, such that targed element is not hidden behind the fixed-header.
- **Is this PR related to a Monolith release?** No
- 
### Resolves:

* [OKTA-701961](https://oktainc.atlassian.net/browse/OKTA-701961)


https://github.com/okta/okta-developer-docs/assets/158277016/2fea6300-5c07-4ebe-a94c-6f3a0d669b0f

