### PR TITLE
OKTA-703301 - Apps API update: add note for PUT /apps

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -2598,7 +2598,9 @@ Updates an application in your organization
 | app           | Updated app              | Body       | [Application](#application-object) | FALSE    |         |
 | applicationId | `id` of an app to update | URL        | String                            | TRUE     |         |
 
-> **Note:** All properties must be specified when updating an app. **Delta updates are not supported.**
+> **Notes:**
+> * All properties must be specified when updating an app. **Delta updates are not supported.**
+> * You can't modify system-assigned properties, such as `id`, `name`, `status`, `lastUpdated`, and `created`.
 
 ##### Response parameters
 

--- a/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/apps/index.md
@@ -2600,7 +2600,7 @@ Updates an application in your organization
 
 > **Notes:**
 > * All properties must be specified when updating an app. **Delta updates are not supported.**
-> * You can't modify system-assigned properties, such as `id`, `name`, `status`, `lastUpdated`, and `created`.
+> * You can't modify system-assigned properties, such as `id`, `name`, `status`, `lastUpdated`, and `created`. The values for these properties in the PUT request body are ignored.
 
 ##### Response parameters
 


### PR DESCRIPTION
## Description:
- **What's changed?**  Apps API: PUT /apps operation. Some of the fields are immutable in the request body, and any new value passed to that field will be ignored while updating the AppInstance. API doc should mention that these fields are immutable and any changes will be ignored. 
- **Is this PR related to a Monolith release?** No

### Preview:
https://65ef58af4c20d302e83de2c9--reverent-murdock-829d24.netlify.app/docs/reference/api/apps/#update-application

### Resolves:

* [OKTA-703301](https://oktainc.atlassian.net/browse/OKTA-703301)
