### PR TITLE
[OKTA-629246] Users and Groups APIs supports the contains operator (redo)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ node_modules
 tests/cypress/videos
 tests/cypress/screenshots
 $null
+
+# yarn lockfile
+yarn.lock

--- a/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/groups/index.md
@@ -729,9 +729,11 @@ curl -v -X GET \
 
 Searches for groups based on the properties specified in the search parameter
 
-Property names in the search parameter are case sensitive, whereas operators (`eq`, `sw`, and so on) and string values are case insensitive.
+Property names in the search parameter are case sensitive, whereas [operators](/docs/reference/core-okta-api/#operators) (`eq`, `sw`, and so on) and string values are case insensitive.
 
 This operation:
+
+- Supports the `co` operator with the `profile.name` and `profile.description` attributes.
 
 - Supports [pagination](/docs/reference/core-okta-api/#pagination).
 
@@ -755,6 +757,7 @@ This operation:
 | `id eq "00gak46y5hydV6NdM0g4"`                            | Groups with a specified `id`                                              |
 | `profile.name eq "West Coast Users"`                      | Groups that have a `name` of `West Coast Users`                           |
 | `profile.samAccountName sw "West Coast" `                 | Groups whose `samAccountName` starts with `West Coast`                    |
+| `profile.name co "EMEA"`                                  | Groups that have a `name` that contains `EMEA`                            |
 | `source.id eq "0oa2v0el0gP90aqjJ0g7"`                     | Groups that have the source application with a specified `source.id`      |
 
 ##### Search Examples

--- a/packages/@okta/vuepress-site/docs/reference/api/users/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/users/index.md
@@ -1153,7 +1153,7 @@ The first three parameters in the table below correspond to different ways to li
 
 | Parameter   | Description                                                                                                                                    | Param Type   | DataType   | Required |
 | :---------- | :--------------------------------------------------------------------------------------------------------------------------------------------- | :----------- | :--------- | :------- |
-| search      | Searches for users with a supported [filtering](/docs/reference/core-okta-api/#filter) expression for most properties. Okta recommends this option for optimal performance.          | Query        | String     | FALSE    |
+| search      | Searches for users with a supported [filtering](/docs/reference/core-okta-api/#filter) expression for most properties. Use this option for optimal performance.          | Query        | String     | FALSE    |
 | filter      | [Filters](/docs/reference/core-okta-api/#filter) users with a supported expression for a subset of properties. However, Okta recommends using the search parameter.                  | Query        | String     | FALSE    |
 | q           | Finds a user that matches `firstName`, `lastName`, and `email` properties. However, Okta recommends the search parameter.                       | Query        | String     | FALSE    |
 | limit       | Specifies the number of results returned (maximum 200).                           | Query        | Number     | FALSE    |
@@ -1181,10 +1181,11 @@ Searches for users based on the properties specified in the search parameter. Th
 
 > **Note:** Results from the Search API are computed from asynchronously indexed and eventually consistent data. The indexing delay is typically less than one second.
 
-Property names in the search parameter are case sensitive, whereas operators (`eq`, `sw`, and so on) and string values are case insensitive. Unlike with [user logins](#okta-login), diacritical marks are significant in search string values: a search for `isaac.brock` finds `Isaac.Brock`, but doesn't find a property whose value is `isáàc.bröck`.
+Property names in the search parameter are case sensitive, whereas [operators](/docs/reference/core-okta-api/#operators) (`eq`, `sw`, and so on) and string values are case insensitive. Unlike with [user logins](#okta-login), diacritical marks are significant in search string values: a search for `isaac.brock` finds `Isaac.Brock`, but doesn't find a property whose value is `isáàc.bröck`.
 
 This operation:
 
+- Supports using the `co` operator in the search parameter with the `profile.firstName`, `profile.lastNameExpressions`, `profile.email`, and `profile.login` attributes.
 - Supports [pagination](/docs/reference/core-okta-api/#pagination).
 - Requires [URL encoding](http://en.wikipedia.org/wiki/Percent-encoding).
   For example, `search=profile.department eq "Engineering"` is encoded as `search=profile.department%20eq%20%22Engineering%22`.
@@ -1210,6 +1211,7 @@ This operation:
 | `profile.department eq "Engineering"`           | Users that have a `department` of `Engineering` |
 | `profile.occupation eq "Leader"`                | Users that have an `occupation` of `Leader`     |
 | `profile.lastName sw "Smi" `                    | Users whose `lastName` starts with `Smi`        |
+| `profile.email co "support" `                   | Users whose `email` contains `support`          |
 
 ##### Search examples
 

--- a/packages/@okta/vuepress-site/docs/reference/core-okta-api/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/core-okta-api/index.md
@@ -265,25 +265,25 @@ The filter and search parameters must contain at least one valid Boolean express
 
 ### Operators
 
-Most of the operators listed in the [SCIM Protocol Specification](https://www.rfc-editor.org/rfc/rfc7644#section-3.4.2.2) are supported:
+The following operators from the [SCIM Protocol Specification](https://www.rfc-editor.org/rfc/rfc7644#section-3.4.2.2) are supported:
 
 | Operator | Description           | Behavior                                                                                                                                                                                                                                                                      |
 | -------- | -----------           | --------                                                                                                                                                                                                                                                                      |
-| `eq`       | equal                 | Matches if the attribute and operand values are identical |
+| `eq`       | equal                 | Matches if the attribute and operand values are identical. |
 | `ge`       | greater than or equal | Matches if the attribute value is greater than or equal to the operand value. The actual comparison depends on the attribute type. `String` attribute types are a lexicographical comparison and `Date` types are a chronological comparison. |
 | `gt`       | greater than          | Matches if the attribute value is greater than the operand value. The actual comparison depends on the attribute type. `String` attribute types are a lexicographical comparison and `Date` types are a chronological comparison.                 |
 | `le`       | less than or equal    | Matches if the attribute value is less than or equal to the operand value. The actual comparison depends on the attribute type. `String` attribute types are a lexicographical comparison and `Date` types are a chronological comparison.   |
 | `lt`       | less than             | Matches if the attribute value is less than the operand value. The actual comparison depends on the attribute type. `String` attribute types are a lexicographical comparison and `Date` types are a chronological comparison.                    |
-| `ne`       | not equal             | Matches if the attribute value doesn't match the operand value |
+| `ne`       | not equal             | Matches if the attribute value doesn't match the operand value. |
 | `pr`       | present (has value)   | Matches if the attribute has a non-empty value or if it contains a non-empty node for complex attributes.  |
 | `sw`       | starts with           | The entire operand value must be a substring of the attribute value that starts at the beginning of the attribute value. This criterion is satisfied if the two strings are identical.                                                                                         |
-| `ew`       | ends with             | The entire operand value must be a substring of the attribute value that starts at the end of the attribute value. This criterion is satisfied if the two strings are identical. This operator is only usable with the System Log API.                          |
+| `ew`       | ends with             | The entire operand value must be a substring of the attribute value that starts at the end of the attribute value. This criterion is satisfied if the two strings are identical. This operator is only usable with the [System Log API](/docs/reference/api/system-log/#filtering-results).                          |
+| `co`       | contains              | Matches if the operand value exists as a substring in the attribute value. This includes the case where the attribute and operand values are identical. You can only use this operator with the [Groups](/docs/reference/api/groups/#list-groups-with-search), [System Log](/docs/reference/api/system-log/#filtering-results), and [Users](/docs/reference/api/users/#list-users-with-search) APIs.                      |
 
 > **Notes:**
 > * Some objects don't support all the listed operators.
 > * The `ne` (not equal) operator isn't supported for some objects, but you can obtain the same result by using `lt ... or ... gt`. For example, to see all user agents except for "iOS", use `(client.userAgent.os lt "iOS" or client.userAgent.os gt "iOS")`.
 > * All `Date` values use the ISO 8601 format `YYYY-MM-DDTHH:mm:ss.SSSZ`.
-> * The [System Log API](/docs/reference/api/system-log/#filtering-results) supports the contains (`co`) and ends with (`ew`) operators.
 
 #### Attribute operators
 

--- a/packages/@okta/vuepress-site/docs/reference/user-query/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/user-query/index.md
@@ -31,6 +31,8 @@ This query parameter provides the largest range of search options and optimal pe
 
 The search query parameter uses standard Okta API filtering semantics to create search criteria that includes mathematical operators such as equal to (`eq`), greater than or equal to (`ge`), and so on. You can combine multiple expressions using logical operators and parentheses. The `ne` (not equal) operator isn't supported, but you can obtain the same result by using `lt ... or ... gt`. For example, to see all users except those that have a status of "STAGED", use `https://${yourOktaDomain}/api/v1/users?search=status+lt+%22STAGED%22+or+status+gt+%22STAGED%22`. See [Filtering](/docs/reference/core-okta-api/#filter).
 
+This query parameter supports using the `co` operator with the `profile.firstName`, `profile.lastNameExpressions`, `profile.email`, and `profile.login` attributes.
+
 ### URL encoding
 
 The search parameter requires URL encoding for expressions that include characters such as spaces and double quotes used for strings. See [URL encoding](http://en.wikipedia.org/wiki/Percent-encoding). For example:


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. --> Changes from Tim's original PR #4416 
- **Is this PR related to a Monolith release?** <!-- If so, which one? --> TBD. Potentially 2024.07.0

**Note:** This PR might not be merged. It depends on when the Redocly version of these APIs are migrated.

### Resolves:

* [OKTA-629246](https://oktainc.atlassian.net/browse/OKTA-629246)
