### PR TITLE
SIW Gen3 - Document afterRender revert

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -77,6 +77,31 @@ See [Customization examples](#customization-examples) for snippets that you can 
 
    > **Note:** To discard your changes without publishing them, click **Revert changes** or click the **Code editor** toggle again. Turning off the code editor restores the default JavaScript code.
 
+### Use afterRender with the third generation
+
+Triggered when the widget transitions to a new page.
+
+https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender
+
+Use cases:
+
+* Change label text
+* Change input labels on page
+
+Gen 3 built on React, which interprets `afterRender` in a way that's incompatible with Gen 3.
+
+CSS can't be used b/c Odyssey and design tokens (see link) don't need them.
+
+Sample DOM manipulations:
+
+#### DOM manipulation 1
+
+
+#### DOM manipulation 2
+
+
+
+
 ## Use design tokens
 
 Design tokens make the Sign-In Widget's visual style consistent and easier to update. Tokens replace static values to customize the following:

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -86,7 +86,7 @@ The third generation of the Sign-In Widget is built on [Preact](https://preactjs
 
 To keep the third generation of the Sign-In Widget from reverting your `afterRender` customizations, use the DOM `MutationObserver()` function. See [MutationObserver](https://dom.spec.whatwg.org/#ref-for-dom-mutationobserver-mutationobserver).
 
-> **Note:** Use the `MutationObserver` with caution. The following solutions are only for developers with experience using this function.
+> **Note:** Use `MutationObserver` with caution. The following solutions are only for developers with experience using this function.
 
 To update UI elements, consider the following example:
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -81,7 +81,7 @@ See [Customization examples](#customization-examples) for snippets that you can 
 
 The third generation of the Sign-In Widget is built on [Preact](https://preactjs.com/) -- a lightweight React alternative. This means the `afterRender` function incompatible with customizations that make DOM manipulations and other render-related side-effects (see [Components and Hooks must be pure](https://react.dev/reference/rules/components-and-hooks-must-be-pure)).
 
-Typically, with the second generation of Sign-In Widget, you can use `afterRender` to change label text or input labels on a page. The Sign-In Widget triggers `afterRender` when transitioning to a new page and animations have finished. See [afterRender](https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender).
+With the second generation of Sign-In Widget, you can use `afterRender` to change label text or input labels on a page. The Sign-In Widget triggers `afterRender` when transitioning to a new page and animations have finished. See [afterRender](https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender). This will not work in the third generation of Sign-in Widget.
 
 #### Resolve the afterRender revert
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -158,7 +158,7 @@ To update UI elements, consider the following example:
        console.log(error.message, error);
     });
 
-    oktaSignIn.on('afterRender', (context) => {
+    oktaSignIn.on('afterRender', function (context) {
        if (context.formName === 'identify') {
           // Sends a log to your external logging service indicating a customer landed on this view
           someExternalLoggingService.log('Rendered Primary auth form'); 

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -105,7 +105,7 @@ To update UI elements, consider the following example:
       }
       // For the reset-authenticator view, updates the button label
       if (contextObj.formName === 'reset-authenticator') {
-        const el = document.querySelector('[data-type="save"]');
+        var el = document.querySelector('[data-type="save"]');
         if (el) { el.textContent = 'A different label'; }
       }
     }

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -80,16 +80,14 @@ See [Customization examples](#customization-examples) for snippets that you can 
 
 ### About the afterRender function
 
-The third generation of the Sign-In Widget is built on [Preact](https://preactjs.com/), a lightweight React alternative. This means that the [`afterRender`] (https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender) function doesn't work when used to make DOM manipulations and other render-related side effects. The Okta Sign-In Widget reverts your customizations to default settings. See [Components and Hooks must be pure](https://react.dev/reference/rules/components-and-hooks-must-be-pure).
+The third generation of the Sign-In Widget is built on [Preact](https://preactjs.com/), a lightweight React alternative. This means that the [`afterRender`] (https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender) function doesn't work when used to make DOM manipulations and other render-related side effects. If you use `afterRender` for DOM manipulations, the Okta Sign-In Widget reverts any customizations to default settings. See [Components and Hooks must be pure](https://react.dev/reference/rules/components-and-hooks-must-be-pure).
 
-* To use `afterRender` for DOM manipulations, include the `MutationObserver` function.
+* To use `afterRender` for DOM manipulations, consider using the `MutationObserver` function.
 * To use `afterRender` for non-DOM manipulations, you don't need the `MutationObserver` function.
 
 #### Use MutationObserver for DOM manipulations
 
 To keep the third generation of the Sign-In Widget from reverting your `afterRender` customizations, use the DOM `MutationObserver` function. See [MutationObserver](https://dom.spec.whatwg.org/#ref-for-dom-mutationobserver-mutationobserver).
-
-> **Note:** Use `MutationObserver` with caution. The following solutions are only for developers with experience using this function.
 
 To update UI elements, consider the following example:
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -85,7 +85,7 @@ Typically, with the second generation of Sign-In Widget, you can use `afterRende
 
 #### Resolve the afterRender revert
 
-To keep the third generation of the Sign-In Widget from reverting your customizations, use the DOM `MutationObserver()` function. See [MutationObserver](https://dom.spec.whatwg.org/#ref-for-dom-mutationobserver-mutationobserver).
+To keep the third generation of the Sign-In Widget from reverting your `afterRender` customizations, use the DOM `MutationObserver()` function. See [MutationObserver](https://dom.spec.whatwg.org/#ref-for-dom-mutationobserver-mutationobserver).
 
 > **Note:** Use the `MutationObserver` with caution. The following solutions are only for developers with experience using this function.
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -79,13 +79,13 @@ See [Customization examples](#customization-examples) for snippets that you can 
 
 ### Use afterRender with the third generation
 
-The third generation of the Sign-In Widget is built on React.js. It inteprets the `afterRender` function in a way that's incompatible with customizations. The widget reverts your customizations to Okta default settings.
+The third generation of the Sign-In Widget is built on React.js. It interprets the `afterRender` function in a way that's incompatible with customizations. Sign-In Widget reverts your customizations to Okta default settings.
 
-Typically, with the second generation of the widget, you can use `afterRender` to change label text or input labels on a page. The widget triggers `afterRender` when transitioning to a new page and animations have finished. See [afterRender](https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender).
+Typically, with the second generation of Sign-In Widget, you can use `afterRender` to change label text or input labels on a page. The Sign-In Widget triggers `afterRender` when transitioning to a new page and animations have finished. See [afterRender](https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender).
 
 #### Resolve the afterRender revert
 
-To keep the third generation of the widget from reverting your customizations, use the DOM `MutationObserver()` function. See [MutationObserver](https://dom.spec.whatwg.org/#ref-for-dom-mutationobserver-mutationobserver).
+To keep the third generation of the Sign-In Widget from reverting your customizations, use the DOM `MutationObserver()` function. See [MutationObserver](https://dom.spec.whatwg.org/#ref-for-dom-mutationobserver-mutationobserver).
 
 > **Note:** Use the `MutationObserver` with caution. The following solutions are only for developers with experience using this function.
 
@@ -96,43 +96,43 @@ To update UI elements, consider the following example:
     var config = OktaUtil.getSignInWidgetConfig();
 
     var oktaSiwRoot = document.querySelector('#okta-login-container');
-    // this will allow us to reference the context from each render 
+    // The following allows you to reference the context from each render
     let contextObj = {};
     function cb(mutations, observer) {
-      // for the primary auth form, update the button label
+      // For the primary auth form, updates the button label
       if (contextObj.formName === 'identify') {
         const el = document.querySelector('[data-type="save"]');
         if (el) { el.textContent = 'Some new label'; }
       }
-      // for the reset-authenticator view, update button label
+      // For the reset-authenticator view, updates the button label
       if (contextObj.formName === 'reset-authenticator') {
         const el = document.querySelector('[data-type="save"]');
         if (el) { el.textContent = 'A different label'; }
       }
     }
-    // initializes the mutation observer object
+    // Initializes the mutation observer object
     var observer = new MutationObserver(cb);
 
-    // Render the Okta Sign-In Widget
+    // Renders the Okta Sign-In Widget
     var oktaSignIn = new OktaSignIn(config);
 
-    // The below will vary based on your own configuration
+    // The following varies based on your configuration
     oktaSignIn.renderEl({ el: '#okta-login-container' }, OktaUtil.completeLogin, function (error) {
        console.log(error.message, error);
     });
 
-    oktaSignIn.on('afterRender', function (ctx) { // ← restore the context
-      // reset the global context object for reference by the callback function
+    oktaSignIn.on('afterRender', function (ctx) { // ← Restores the context
+      // Resets the global context object for reference using the callback function
       contextObj = context;
-      // this condition is to only execute this observer for specific views/forms
+      // The following condition only executes the observer for specific views/forms
       if (context.formName === 'identify' || context.formName === 'reset-authenticator') {
-        // pause
+        // Pauses
         observer.disconnect();
 
-        // call once after initial render
+        // Calls once after initial render
         cb();
 
-        // observe for re-renders
+        // Observes for re-renders
         observer.observe(oktaSiwRoot, {
           subtree: true,
           childList: true,
@@ -151,17 +151,17 @@ To update UI elements, consider the following example:
  <script type="text/javascript" nonce="{{nonceValue}}">
     var config = OktaUtil.getSignInWidgetConfig();
 
-    // Render the Okta Sign-In Widget
+    // Renders the Okta Sign-In Widget
     var oktaSignIn = new OktaSignIn(config);
 
-    // The below will vary based on your own configuration
+    // The following varies based on your own configuration
     oktaSignIn.renderEl({ el: '#okta-login-container' }, OktaUtil.completeLogin, function (error) {
        console.log(error.message, error);
     });
 
     oktaSignIn.on('afterRender', (context) => {
        if (context.formName === 'identify') {
-          // send a log to your external logging service indicating a customer landed on this view
+          // Sends a log to your external logging service indicating a customer landed on this view
           someExternalLoggingService.log('Rendered Primary auth form'); 
        }
     });

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -79,9 +79,11 @@ See [Customization examples](#customization-examples) for snippets that you can 
 
 ### Use afterRender with the third generation
 
-The third generation of the Sign-In Widget is built on [Preact](https://preactjs.com/) -- a lightweight React alternative. This means the `afterRender` function incompatible with customizations that make DOM manipulations and other render-related side-effects (see [Components and Hooks must be pure](https://react.dev/reference/rules/components-and-hooks-must-be-pure)).
+The third generation of the Sign-In Widget is built on [Preact](https://preactjs.com/), a lightweight React alternative. This means that the `afterRender` function doesn't work with the third generation.
 
-With the second generation of Sign-In Widget, you can use `afterRender` to change label text or input labels on a page. The Sign-In Widget triggers `afterRender` when transitioning to a new page and animations have finished. See [afterRender](https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender). This will not work in the third generation of Sign-in Widget.
+With the second generation of the Sign-In Widget, you can use [`afterRender`] (https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender)to change label text or input labels on a page.
+
+With the third generation, `afterRender` is incompatible with customizations that make DOM manipulations and other render-related side-effects (see [Components and Hooks must be pure](https://react.dev/reference/rules/components-and-hooks-must-be-pure)).
 
 #### Resolve the afterRender revert
 
@@ -145,7 +147,7 @@ To update UI elements, consider the following example:
  </script>
  ```
 
- The following example doesn't update the UI, but instead sends a log to your external logging service:
+ The third generation can use the `afterRender` function for non-DOM manipulations without additional logic. The following example doesn't update the UI, but instead sends a log to your external logging service:
 
  ```javascript
  <script type="text/javascript" nonce="{{nonceValue}}">

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -79,8 +79,6 @@ See [Customization examples](#customization-examples) for snippets that you can 
 
 ### Use afterRender with the third generation
 
-### afterRender and the third generation
-
 The third generation of the Sign-In Widget is built on React.js. It inteprets the `afterRender` function in a way that's incompatible with customizations. The widget reverts your customizations to Okta default settings.
 
 Typically, with the second generation of the widget, you can use `afterRender` to change label text or input labels on a page. The widget triggers `afterRender` when transitioning to a new page and animations have finished. See [afterRender](https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender).

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -82,7 +82,10 @@ See [Customization examples](#customization-examples) for snippets that you can 
 
 The third generation of the Sign-In Widget is built on [Preact](https://preactjs.com/), a lightweight React alternative. This means that the [`afterRender`] (https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender) function doesn't work when used to make DOM manipulations and other render-related side-effects. The Okta Sign-In Widget reverts your customizations to default settings. See [Components and Hooks must be pure](https://react.dev/reference/rules/components-and-hooks-must-be-pure).
 
-#### Resolve the afterRender revert
+* To use `afterRender` for DOM manipulations, include the `MutationObserver()` function.
+* To use `afterRender` for non-DOM manipulations, you don't need the `MutationObserver()` function.
+
+#### Use MutationObserver for DOM manipulations
 
 To keep the third generation of the Sign-In Widget from reverting your `afterRender` customizations, use the DOM `MutationObserver()` function. See [MutationObserver](https://dom.spec.whatwg.org/#ref-for-dom-mutationobserver-mutationobserver).
 
@@ -144,7 +147,9 @@ To update UI elements, consider the following example:
  </script>
  ```
 
- The third generation can use the `afterRender` function for non-DOM manipulations without extra logic. The following example doesn't update the UI, but instead sends a log to your external logging service:
+#### User afterRender for non-Dom manipulations
+
+ The third generation can use the `afterRender` function for non-DOM manipulations without extra logic. The following example doesn't update the UI, so it doesn't need the `MutationObserver`. Instead, it sends a log to your external logging service:
 
  ```javascript
  <script type="text/javascript" nonce="{{nonceValue}}">

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -96,7 +96,7 @@ To update UI elements, consider the following example:
 
     var oktaSiwRoot = document.querySelector('#okta-login-container');
     // The following allows you to reference the context from each render
-    let contextObj = {};
+    var contextObj = {};
     function cb(mutations, observer) {
       // For the primary auth form, updates the button label
       if (contextObj.formName === 'identify') {

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -78,13 +78,9 @@ See [Customization examples](#customization-examples) for snippets that you can 
 
    > **Note:** To discard your changes without publishing them, click **Revert changes** or click the **Code editor** toggle again. Turning off the code editor restores the default JavaScript code.
 
-### Use afterRender with the third generation
+### About the afterRender function
 
-The third generation of the Sign-In Widget is built on [Preact](https://preactjs.com/), a lightweight React alternative. This means that the `afterRender` function doesn't work when used to make DOM manipulations in the third generation.
-
-With the second generation of the Sign-In Widget, you can use [`afterRender`] (https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender)to change label text or input labels on a page.
-
-With the third generation, `afterRender` is incompatible with customizations that make DOM manipulations and other render-related side-effects (see [Components and Hooks must be pure](https://react.dev/reference/rules/components-and-hooks-must-be-pure)).
+The third generation of the Sign-In Widget is built on [Preact](https://preactjs.com/), a lightweight React alternative. This means that the [`afterRender`] (https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender) function doesn't work when used to make DOM manipulations and other render-related side-effects. See [Components and Hooks must be pure](https://react.dev/reference/rules/components-and-hooks-must-be-pure).
 
 #### Resolve the afterRender revert
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -79,7 +79,7 @@ See [Customization examples](#customization-examples) for snippets that you can 
 
 ### Use afterRender with the third generation
 
-The third generation of the Sign-In Widget is built on [Preact](https://preactjs.com/), a lightweight React alternative. This means that the `afterRender` function doesn't work with the third generation.
+The third generation of the Sign-In Widget is built on [Preact](https://preactjs.com/), a lightweight React alternative. This means that the `afterRender` function doesn't work when used to make DOM manipulations in the third generation.
 
 With the second generation of the Sign-In Widget, you can use [`afterRender`] (https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender)to change label text or input labels on a page.
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -80,7 +80,7 @@ See [Customization examples](#customization-examples) for snippets that you can 
 
 ### About the afterRender function
 
-The third generation of the Sign-In Widget is built on [Preact](https://preactjs.com/), a lightweight React alternative. This means that the [`afterRender`] (https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender) function doesn't work when used to make DOM manipulations and other render-related side-effects. See [Components and Hooks must be pure](https://react.dev/reference/rules/components-and-hooks-must-be-pure).
+The third generation of the Sign-In Widget is built on [Preact](https://preactjs.com/), a lightweight React alternative. This means that the [`afterRender`] (https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender) function doesn't work when used to make DOM manipulations and other render-related side-effects. The Okta Sign-In Widget reverts your customizations to default settings. See [Components and Hooks must be pure](https://react.dev/reference/rules/components-and-hooks-must-be-pure).
 
 #### Resolve the afterRender revert
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -100,7 +100,7 @@ To update UI elements, consider the following example:
     function cb(mutations, observer) {
       // For the primary auth form, updates the button label
       if (contextObj.formName === 'identify') {
-        const el = document.querySelector('[data-type="save"]');
+        var el = document.querySelector('[data-type="save"]');
         if (el) { el.textContent = 'Some new label'; }
       }
       // For the reset-authenticator view, updates the button label

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -80,7 +80,7 @@ See [Customization examples](#customization-examples) for snippets that you can 
 
 ### About the afterRender function
 
-The third generation of the Sign-In Widget is built on [Preact](https://preactjs.com/), a lightweight React alternative. This means that the [`afterRender`] (https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender) function doesn't work when used to make DOM manipulations and other render-related side-effects. The Okta Sign-In Widget reverts your customizations to default settings. See [Components and Hooks must be pure](https://react.dev/reference/rules/components-and-hooks-must-be-pure).
+The third generation of the Sign-In Widget is built on [Preact](https://preactjs.com/), a lightweight React alternative. This means that the [`afterRender`] (https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender) function doesn't work when used to make DOM manipulations and other render-related side effects. The Okta Sign-In Widget reverts your customizations to default settings. See [Components and Hooks must be pure](https://react.dev/reference/rules/components-and-hooks-must-be-pure).
 
 * To use `afterRender` for DOM manipulations, include the `MutationObserver()` function.
 * To use `afterRender` for non-DOM manipulations, you don't need the `MutationObserver()` function.

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -3,6 +3,7 @@ title: Style the Sign-In Widget (third generation)
 excerpt: Learn how to customize the Sign-In Widget (third generation)
 layout: Guides
 ---
+<ApiLifecycle access="ie" />
 
 This guide explains how to customize the Sign-In Widget (third generation) for redirect authentication.
 
@@ -147,7 +148,7 @@ To update UI elements, consider the following example:
  </script>
  ```
 
- The third generation can use the `afterRender` function for non-DOM manipulations without additional logic. The following example doesn't update the UI, but instead sends a log to your external logging service:
+ The third generation can use the `afterRender` function for non-DOM manipulations without extra logic. The following example doesn't update the UI, but instead sends a log to your external logging service:
 
  ```javascript
  <script type="text/javascript" nonce="{{nonceValue}}">

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -82,12 +82,12 @@ See [Customization examples](#customization-examples) for snippets that you can 
 
 The third generation of the Sign-In Widget is built on [Preact](https://preactjs.com/), a lightweight React alternative. This means that the [`afterRender`] (https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender) function doesn't work when used to make DOM manipulations and other render-related side effects. The Okta Sign-In Widget reverts your customizations to default settings. See [Components and Hooks must be pure](https://react.dev/reference/rules/components-and-hooks-must-be-pure).
 
-* To use `afterRender` for DOM manipulations, include the `MutationObserver()` function.
-* To use `afterRender` for non-DOM manipulations, you don't need the `MutationObserver()` function.
+* To use `afterRender` for DOM manipulations, include the `MutationObserver` function.
+* To use `afterRender` for non-DOM manipulations, you don't need the `MutationObserver` function.
 
 #### Use MutationObserver for DOM manipulations
 
-To keep the third generation of the Sign-In Widget from reverting your `afterRender` customizations, use the DOM `MutationObserver()` function. See [MutationObserver](https://dom.spec.whatwg.org/#ref-for-dom-mutationobserver-mutationobserver).
+To keep the third generation of the Sign-In Widget from reverting your `afterRender` customizations, use the DOM `MutationObserver` function. See [MutationObserver](https://dom.spec.whatwg.org/#ref-for-dom-mutationobserver-mutationobserver).
 
 > **Note:** Use `MutationObserver` with caution. The following solutions are only for developers with experience using this function.
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -87,7 +87,7 @@ The third generation of the Sign-In Widget is built on [Preact](https://preactjs
 
 #### Use MutationObserver for DOM manipulations
 
-To keep the third generation of the Sign-In Widget from reverting your `afterRender` customizations, use the DOM `MutationObserver` function. See [MutationObserver](https://dom.spec.whatwg.org/#ref-for-dom-mutationobserver-mutationobserver).
+To prevent the third generation of the Sign-In Widget from reverting your `afterRender` customizations, use the DOM `MutationObserver` function. See [MutationObserver](https://dom.spec.whatwg.org/#ref-for-dom-mutationobserver-mutationobserver).
 
 To update UI elements, consider the following example:
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -79,7 +79,7 @@ See [Customization examples](#customization-examples) for snippets that you can 
 
 ### Use afterRender with the third generation
 
-The third generation of the Sign-In Widget is built on React.js. It interprets the `afterRender` function in a way that's incompatible with customizations. Sign-In Widget reverts your customizations to Okta default settings.
+The third generation of the Sign-In Widget is built on React.js. It interprets the `afterRender` function in a way that's incompatible with customizations. The Sign-In Widget reverts your customizations to Okta default settings.
 
 Typically, with the second generation of Sign-In Widget, you can use `afterRender` to change label text or input labels on a page. The Sign-In Widget triggers `afterRender` when transitioning to a new page and animations have finished. See [afterRender](https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender).
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -79,7 +79,7 @@ See [Customization examples](#customization-examples) for snippets that you can 
 
 ### Use afterRender with the third generation
 
-The third generation of the Sign-In Widget is built on React.js. It interprets the `afterRender` function in a way that's incompatible with customizations. The Sign-In Widget reverts your customizations to Okta default settings.
+The third generation of the Sign-In Widget is built on [Preact](https://preactjs.com/) -- a lightweight React alternative. This means the `afterRender` function incompatible with customizations that make DOM manipulations and other render-related side-effects (see [Components and Hooks must be pure](https://react.dev/reference/rules/components-and-hooks-must-be-pure)).
 
 Typically, with the second generation of Sign-In Widget, you can use `afterRender` to change label text or input labels on a page. The Sign-In Widget triggers `afterRender` when transitioning to a new page and animations have finished. See [afterRender](https://github.com/okta/okta-signin-widget?tab=readme-ov-file#afterrender).
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Documents the workaround for the `afterRender` revert when used with SIW Gen3.
- **Is this PR related to a Monolith release?** No.

### Resolves:

* [OKTA-686866](https://oktainc.atlassian.net/browse/OKTA-686866)
