### PR TITLE
OKTA-716079 - Add new target property to System Log API

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
@@ -137,6 +137,12 @@ Each LogEvent object describes a single logged action or "event" that is perform
                "detailEntry" = {
                     String -> String/Resource Map
                }
+              "changeDetails" = {
+                  "from:": {String -> String/Resource Map
+                  }
+                  "to:": {String -> String/Resource Map
+                  }
+              }
      }
 ],
 "transaction": { Object, Optional
@@ -242,10 +248,11 @@ The entity that an actor performs an action on. Targets can be anything, such as
 | Property    | Description                                                  | DataType            | Nullable |
 | ----------- | ------------------------------------------------------------ | ---------------     | -------- |
 | id          | ID of a target                                               | String              | FALSE    |
-| type        | Type of a target                                             | String              | FALSE    |
+| type        | Type of target                                               | String              | FALSE    |
 | alternateId | Alternative ID of a target                                   | String              | TRUE     |
 | displayName | Display name of a target                                     | String              | TRUE     |
-| detailEntry | Details on a target                                         | Map[String->Object] | TRUE     |
+| detailEntry | Details on a target                                          | Map[String->Object] | TRUE     |
+| changeDetails | Details on what's changed on a target                      | Map[String->Object] | TRUE     |
 
 ```json
 {
@@ -256,6 +263,43 @@ The entity that an actor performs an action on. Targets can be anything, such as
     "type": "User"
 }
 ```
+
+#### changeDetails property
+
+The `changeDetails` property of the `target` object defines the change of state of an entity within Okta. Each `changeDetails` property contains a `to` and `from` object that defines the state change. Not all event types support the `changeDetails` property, and not all `target` objects contain the `changeDetails` property.
+
+```json
+"target": [
+  {
+    "id": "0oaabcd1234",
+    "type": "AppInstance",
+    "alternateId": "Workday",
+    "displayName": "Workday",
+    "detailEntry": null,
+    "changeDetails": {
+      "from": {
+        "vpnLocationOptions": "DISABLED",
+        "vpnSettingsZones": {
+          "include": [],
+          "exclude": []
+        }
+      },
+      "to": {
+        "message": "You must a use VPN to connect to this application",
+        "vpnLocationOptions": "ZONE",
+        "vpnSettingsZones": {
+          "include": [
+            "ALL_ZONES"
+          ],
+          "exclude": []
+        }
+      }
+    }
+  }
+]
+```
+
+>**Note**: When querying the `changeDetails` property, you can't search on the `to` or `from` objects. You must include a property within the object.
 
 ### Client object
 

--- a/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
@@ -266,7 +266,7 @@ The entity that an actor performs an action on. Targets can be anything, such as
 
 #### changeDetails property
 
-The `changeDetails` property of the `target` object defines the change of state of an entity within Okta. Each `changeDetails` property contains a `to` and `from` object that defines the state change. Not all event types support the `changeDetails` property, and not all `target` objects contain the `changeDetails` property.
+The `changeDetails` property of the `target` object defines the change of state of an entity within Okta. Each `changeDetails` property contains a `to` and `from` object that defines the change. Not all event types support the `changeDetails` property, and not all `target` objects contain the `changeDetails` property.
 
 ```json
 "target": [

--- a/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
@@ -135,9 +135,9 @@ Each LogEvent object describes a single logged action or "event" that is perform
                "alternateId": String, Optional
                "displayName": String, Optional
                "detailEntry" = {
-                    String -> String/Resource Map
+                  String -> String/Resource Map
                }
-              "changeDetails" = {
+               "changeDetails" = {
                   "from:": {String -> String/Resource Map
                   }
                   "to:": {String -> String/Resource Map

--- a/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/system-log/index.md
@@ -252,7 +252,7 @@ The entity that an actor performs an action on. Targets can be anything, such as
 | alternateId | Alternative ID of a target                                   | String              | TRUE     |
 | displayName | Display name of a target                                     | String              | TRUE     |
 | detailEntry | Details on a target                                          | Map[String->Object] | TRUE     |
-| changeDetails | Details on what's changed on a target                      | Map[String->Object] | TRUE     |
+| changeDetails | Details on the target's changes                   | Map[String->Object] | TRUE     |
 
 ```json
 {
@@ -299,7 +299,7 @@ The `changeDetails` property of the `target` object defines the change of state 
 ]
 ```
 
->**Note**: When querying the `changeDetails` property, you can't search on the `to` or `from` objects. You must include a property within the object.
+>**Note**: When querying the `changeDetails` property, you can't search on the `to` or `from` objects alone. You must include a property within the object.
 
 ### Client object
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Adding the `changeDetails` property to the [System Log API](https://developer.okta.com/docs/reference/api/system-log/#target-object) reference.
- **Is this PR related to a Monolith release?** Yes, 2025.05.0

### Resolves:

* [OKTA-716079](https://oktainc.atlassian.net/browse/OKTA-716079)
