### PR TITLE
[DO NOT MERGE] chore: Edit of Basic sign-in flow with the password factor

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/auth-js/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/auth-js/main/index.md
@@ -316,6 +316,6 @@ var config = {
 
 ## See also
 
-* [Basic sign-in flow example with the password factor](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main)
+* [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main)
 * [Okta Auth JS and React](/docs/guides/sign-in-to-spa-authjs/react/main)
 * [Okta Auth JS and Vue](/docs/guides/sign-in-to-spa-authjs/vue/main)

--- a/packages/@okta/vuepress-site/docs/guides/auth-js/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/auth-js/main/index.md
@@ -316,6 +316,6 @@ var config = {
 
 ## See also
 
-* [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main)
+* [Sign-in flow: password-only](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main)
 * [Okta Auth JS and React](/docs/guides/sign-in-to-spa-authjs/react/main)
 * [Okta Auth JS and Vue](/docs/guides/sign-in-to-spa-authjs/vue/main)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-google-authenticator/main/aspnet/relatedusecases.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-google-authenticator/main/aspnet/relatedusecases.md
@@ -1,2 +1,2 @@
-* [Sign in with password and email factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/aspnet/main/)
+* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/aspnet/main/)
 * [Self-service registration](/docs/guides/oie-embedded-sdk-use-case-self-reg/aspnet/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-google-authenticator/main/aspnet/relatedusecases.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-google-authenticator/main/aspnet/relatedusecases.md
@@ -1,2 +1,2 @@
-* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/aspnet/main/)
+* [Sign-in flow: password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/aspnet/main/)
 * [Self-service registration](/docs/guides/oie-embedded-sdk-use-case-self-reg/aspnet/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-google-authenticator/main/java/relatedusecases.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-google-authenticator/main/java/relatedusecases.md
@@ -1,2 +1,2 @@
-* [Sign in with password and email factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/java/main/)
+* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/java/main/)
 * [Self-service registration](/docs/guides/oie-embedded-sdk-use-case-self-reg/java/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-google-authenticator/main/java/relatedusecases.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-google-authenticator/main/java/relatedusecases.md
@@ -1,2 +1,2 @@
-* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/java/main/)
+* [Sign-in flow: password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/java/main/)
 * [Self-service registration](/docs/guides/oie-embedded-sdk-use-case-self-reg/java/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-okta-email/main/aspnet/seealso.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-okta-email/main/aspnet/seealso.md
@@ -1,2 +1,2 @@
-* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/aspnet/main/)
+* [Sign-in flow: password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/aspnet/main/)
 * [User password recovery with email factor](/docs/guides/oie-embedded-sdk-use-case-pwd-recovery-mfa/aspnet/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-okta-email/main/aspnet/seealso.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-okta-email/main/aspnet/seealso.md
@@ -1,2 +1,2 @@
-* [Sign in with password and email factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/aspnet/main/)
+* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/aspnet/main/)
 * [User password recovery with email factor](/docs/guides/oie-embedded-sdk-use-case-pwd-recovery-mfa/aspnet/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-okta-email/main/java/seealso.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-okta-email/main/java/seealso.md
@@ -1,2 +1,2 @@
-* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/java/main/)
+* [Sign-in flow: password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/java/main/)
 * [User password recovery with email factor](/docs/guides/oie-embedded-sdk-use-case-pwd-recovery-mfa/java/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-okta-email/main/java/seealso.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-okta-email/main/java/seealso.md
@@ -1,2 +1,2 @@
-* [Sign in with password and email factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/java/main/)
+* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/java/main/)
 * [User password recovery with email factor](/docs/guides/oie-embedded-sdk-use-case-pwd-recovery-mfa/java/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-okta-email/main/nodeexpress/seealso.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-okta-email/main/nodeexpress/seealso.md
@@ -1,2 +1,2 @@
-* [Sign in with password and email factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/nodejs/main/)
+* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/nodejs/main/)
 * [User password recovery with email factor](/docs/guides/oie-embedded-sdk-use-case-pwd-recovery-mfa/nodejs/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-okta-email/main/nodeexpress/seealso.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-okta-email/main/nodeexpress/seealso.md
@@ -1,2 +1,2 @@
-* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/nodejs/main/)
+* [Sign-in flow: password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/nodejs/main/)
 * [User password recovery with email factor](/docs/guides/oie-embedded-sdk-use-case-pwd-recovery-mfa/nodejs/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-okta-verify/main/aspnet/relatedusecases.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-okta-verify/main/aspnet/relatedusecases.md
@@ -1,2 +1,2 @@
-* [Sign in with password and email factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/aspnet/main/)
+* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/aspnet/main/)
 * [Google Authenticator enrollment and challenge flows](/docs/guides/authenticators-google-authenticator/aspnet/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-okta-verify/main/aspnet/relatedusecases.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-okta-verify/main/aspnet/relatedusecases.md
@@ -1,2 +1,2 @@
-* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/aspnet/main/)
+* [Sign-in flow: password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/aspnet/main/)
 * [Google Authenticator enrollment and challenge flows](/docs/guides/authenticators-google-authenticator/aspnet/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-okta-verify/main/java/relatedusecases.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-okta-verify/main/java/relatedusecases.md
@@ -1,2 +1,2 @@
-* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/java/main/)
+* [Sign-in flow: password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/java/main/)
 * [Google Authenticator enrollment and challenge flows](/docs/guides/authenticators-google-authenticator/java/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-okta-verify/main/java/relatedusecases.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-okta-verify/main/java/relatedusecases.md
@@ -1,2 +1,2 @@
-* [Sign in with password and email factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/java/main/)
+* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/java/main/)
 * [Google Authenticator enrollment and challenge flows](/docs/guides/authenticators-google-authenticator/java/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-okta-verify/main/nodeexpress/relatedusecases.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-okta-verify/main/nodeexpress/relatedusecases.md
@@ -1,2 +1,2 @@
-* [Sign in with password and email factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/nodejs/main/)
+* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/nodejs/main/)
 * [Google Authenticator enrollment and challange flows](/docs/guides/authenticators-google-authenticator/nodeexpress/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-okta-verify/main/nodeexpress/relatedusecases.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-okta-verify/main/nodeexpress/relatedusecases.md
@@ -1,2 +1,2 @@
-* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/nodejs/main/)
+* [Sign-in flow: password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/nodejs/main/)
 * [Google Authenticator enrollment and challange flows](/docs/guides/authenticators-google-authenticator/nodeexpress/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-web-authn/main/aspnet/relatedusecases.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-web-authn/main/aspnet/relatedusecases.md
@@ -1,2 +1,2 @@
-* [Sign in with password and email factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/aspnet/main/)
+* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/aspnet/main/)
 * [Self-service registration](/docs/guides/oie-embedded-sdk-use-case-self-reg/aspnet/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-web-authn/main/aspnet/relatedusecases.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-web-authn/main/aspnet/relatedusecases.md
@@ -1,2 +1,2 @@
-* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/aspnet/main/)
+* [Sign-in flow: password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/aspnet/main/)
 * [Self-service registration](/docs/guides/oie-embedded-sdk-use-case-self-reg/aspnet/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-web-authn/main/java/relatedusecases.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-web-authn/main/java/relatedusecases.md
@@ -1,2 +1,2 @@
-* [Sign in with password and email factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/java/main/)
+* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/java/main/)
 * [Self-service registration](/docs/guides/oie-embedded-sdk-use-case-self-reg/java/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-web-authn/main/java/relatedusecases.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-web-authn/main/java/relatedusecases.md
@@ -1,2 +1,2 @@
-* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/java/main/)
+* [Sign-in flow: password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/java/main/)
 * [Self-service registration](/docs/guides/oie-embedded-sdk-use-case-self-reg/java/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-web-authn/main/nodeexpress/relatedusecases.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-web-authn/main/nodeexpress/relatedusecases.md
@@ -1,2 +1,2 @@
-* [Sign in with password and email factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/nodejs/main/)
+* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/nodejs/main/)
 * [Self-service registration](/docs/guides/oie-embedded-sdk-use-case-self-reg/nodejs/main/)

--- a/packages/@okta/vuepress-site/docs/guides/authenticators-web-authn/main/nodeexpress/relatedusecases.md
+++ b/packages/@okta/vuepress-site/docs/guides/authenticators-web-authn/main/nodeexpress/relatedusecases.md
@@ -1,2 +1,2 @@
-* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/nodejs/main/)
+* [Sign-in flow: password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/nodejs/main/)
 * [Self-service registration](/docs/guides/oie-embedded-sdk-use-case-self-reg/nodejs/main/)

--- a/packages/@okta/vuepress-site/docs/guides/device-context/main/aspnet/relatedusecases.md
+++ b/packages/@okta/vuepress-site/docs/guides/device-context/main/aspnet/relatedusecases.md
@@ -1,5 +1,5 @@
-* [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/aspnet/main/)
-* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/aspnet/main/)
+* [Sign-in flow: password-only](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/aspnet/main/)
+* [Sign-in flow: password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/aspnet/main/)
 * [Device Context](https://help.okta.com/okta_help.htm?type=oie&id=ext-devcontext-main)
 * [Behavior Detection](https://help.okta.com/okta_help.htm?type=oie&id=ext-about-behavior-detection)
 * [Okta Expression Reference Guide](/docs/reference/okta-expression-language-in-identity-engine/#security-context)

--- a/packages/@okta/vuepress-site/docs/guides/device-context/main/aspnet/relatedusecases.md
+++ b/packages/@okta/vuepress-site/docs/guides/device-context/main/aspnet/relatedusecases.md
@@ -1,5 +1,5 @@
-* [Basic sign-in flow example with the password factor](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/aspnet/main/)
-* [Sign in with password and email factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/aspnet/main/)
+* [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/aspnet/main/)
+* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/aspnet/main/)
 * [Device Context](https://help.okta.com/okta_help.htm?type=oie&id=ext-devcontext-main)
 * [Behavior Detection](https://help.okta.com/okta_help.htm?type=oie&id=ext-about-behavior-detection)
 * [Okta Expression Reference Guide](/docs/reference/okta-expression-language-in-identity-engine/#security-context)

--- a/packages/@okta/vuepress-site/docs/guides/device-context/main/nodeexpress/relatedusecases.md
+++ b/packages/@okta/vuepress-site/docs/guides/device-context/main/nodeexpress/relatedusecases.md
@@ -1,5 +1,5 @@
-* [Basic sign-in flow example with the password factor](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main/)
-* [Sign in with password and email factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/nodejs/main/)
+* [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main/)
+* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/nodejs/main/)
 * [Device Context](https://help.okta.com/okta_help.htm?type=oie&id=ext-devcontext-main)
 * [Behavior Detection](https://help.okta.com/okta_help.htm?type=oie&id=ext-about-behavior-detection)
 * [Okta Expression Reference Guide](/docs/reference/okta-expression-language-in-identity-engine/#security-context)

--- a/packages/@okta/vuepress-site/docs/guides/device-context/main/nodeexpress/relatedusecases.md
+++ b/packages/@okta/vuepress-site/docs/guides/device-context/main/nodeexpress/relatedusecases.md
@@ -1,5 +1,5 @@
-* [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main/)
-* [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/nodejs/main/)
+* [Sign-in flow: password-only](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main/)
+* [Sign-in flow: password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/nodejs/main/)
 * [Device Context](https://help.okta.com/okta_help.htm?type=oie&id=ext-devcontext-main)
 * [Behavior Detection](https://help.okta.com/okta_help.htm?type=oie&id=ext-about-behavior-detection)
 * [Okta Expression Reference Guide](/docs/reference/okta-expression-language-in-identity-engine/#security-context)

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-run-samples/main/android/runsdkapp.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-run-samples/main/android/runsdkapp.md
@@ -11,4 +11,4 @@
 
 ### Work with the use cases
 
-After you successfully run the sample app, you can build your own integration by using the sample app as your guide. Explore use cases that are available with the SDK, starting with the [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/android/main/) use case.
+After you successfully run the sample app, you can build your own integration by using the sample app as your guide. Explore use cases that are available with the SDK, starting with the [Sign-in flow: password-only](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/android/main/) use case.

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-run-samples/main/android/runsdkapp.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-run-samples/main/android/runsdkapp.md
@@ -11,4 +11,4 @@
 
 ### Work with the use cases
 
-After you successfully run the sample app, you can build your own integration by using the sample app as your guide. Explore use cases that are available with the SDK, starting with the [Basic sign-in flow example with the password factor](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/android/main/) use case.
+After you successfully run the sample app, you can build your own integration by using the sample app as your guide. Explore use cases that are available with the SDK, starting with the [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/android/main/) use case.

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-run-samples/main/aspnet/runsdkapp.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-run-samples/main/aspnet/runsdkapp.md
@@ -10,4 +10,4 @@
 
 ### Work with the use cases
 
-After you successfully run the sample app, you can build your own integration by using the sample app as your guide. Explore use cases that are available with the SDK, starting with the [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/aspnet/main/) use case.
+After you successfully run the sample app, you can build your own integration by using the sample app as your guide. Explore use cases that are available with the SDK, starting with the [Sign-in flow: password-only](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/aspnet/main/) use case.

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-run-samples/main/aspnet/runsdkapp.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-run-samples/main/aspnet/runsdkapp.md
@@ -10,4 +10,4 @@
 
 ### Work with the use cases
 
-After you successfully run the sample app, you can build your own integration by using the sample app as your guide. Explore use cases that are available with the SDK, starting with the [Basic sign-in flow example with the password factor](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/aspnet/main/) use case.
+After you successfully run the sample app, you can build your own integration by using the sample app as your guide. Explore use cases that are available with the SDK, starting with the [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/aspnet/main/) use case.

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-run-samples/main/ios/runsdkapp.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-run-samples/main/ios/runsdkapp.md
@@ -9,4 +9,4 @@
 
 ### Work with the use cases
 
-After you run the sample app, you can build your own integration using the sample app. Explore available use cases for the SDK. See the [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/ios/main/).
+After you run the sample app, you can build your own integration using the sample app. Explore available use cases for the SDK. See the [Sign-in flow: password-only](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/ios/main/).

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-run-samples/main/ios/runsdkapp.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-run-samples/main/ios/runsdkapp.md
@@ -9,4 +9,4 @@
 
 ### Work with the use cases
 
-After you run the sample app, you can build your own integration using the sample app. Explore available use cases for the SDK. See the [Basic sign-in flow example with the password factor](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/ios/main/).
+After you run the sample app, you can build your own integration using the sample app. Explore available use cases for the SDK. See the [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/ios/main/).

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-run-samples/main/java/runsdkapp.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-run-samples/main/java/runsdkapp.md
@@ -26,4 +26,4 @@
 
 ### Work with the use cases
 
-After you run the sample app, build an integration using the sample app. Explore use cases that are available with the SDK. Start with the [Basic sign-in flow example with the password factor](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/java/main/).
+After you run the sample app, build an integration using the sample app. Explore use cases that are available with the SDK. Start with the [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/java/main/).

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-run-samples/main/java/runsdkapp.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-common-run-samples/main/java/runsdkapp.md
@@ -26,4 +26,4 @@
 
 ### Work with the use cases
 
-After you run the sample app, build an integration using the sample app. Explore use cases that are available with the SDK. Start with the [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/java/main/).
+After you run the sample app, build an integration using the sample app. Explore use cases that are available with the SDK. Start with the [Sign-in flow: password-only](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/java/main/).

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/android/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/android/integrationsteps.md
@@ -42,7 +42,7 @@ fun signIn() {
 }
 ```
 
-### Your app handles an authentication success response
+### Your app handles an authentication response
 
 `IDXAuthenticationWrapper.authenticate()` returns an [`AuthenticationResponse`](https://github.com/okta/okta-idx-java/blob/master/api/src/main/java/com/okta/idx/sdk/api/response/AuthenticationResponse.java) object with an [`AuthenticationStatus`](https://github.com/okta/okta-idx-java/blob/master/api/src/main/java/com/okta/idx/sdk/api/model/AuthenticationStatus.java) property indicating the current state of the sign-in flow. Handle the returned `AuthenticationStatus` value accordingly:
 
@@ -111,7 +111,7 @@ fun handleKnownTransitions(
 
 #### Failed authentication
 
-There's no explicit failed status from `AuthenticationStatus`. Check the response handler for an error in `AuthenticationResponse` for failed authentication and handle the flow accordingly. For example:
+There is no explicit failed status from `AuthenticationStatus`. Check the response handler for an error in `AuthenticationResponse` for failed authentication and handle the flow accordingly. For example:
 
 ```kotlin
 if (response.errors.isNotEmpty()) {

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/android/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/android/integrationsteps.md
@@ -1,6 +1,6 @@
 ### The user launches the sign-in page
 
-Build a sign-in page where users can input their username and password.
+Build a sign-in page where users input their username and password.
 
 <div class="half wireframe-border">
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/android/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/android/integrationsteps.md
@@ -1,6 +1,6 @@
 ### The user launches the sign-in page
 
-Build a sign-in page that captures both the user's name and their password.
+Build a sign-in page where users can input their username and password.
 
 <div class="half wireframe-border">
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/android/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/android/integrationsteps.md
@@ -1,6 +1,6 @@
 ### The user launches the sign-in page
 
-Build a sign-in page where users input their username and password.
+Display a sign-in page where users input their username and password.
 
 <div class="half wireframe-border">
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/android/summaryofsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/android/summaryofsteps.md
@@ -1,4 +1,4 @@
-The following diagram summarizes the steps involved in a sign-in flow using only a password:
+The following diagram summarizes the steps involved in a sign-in flow that only uses a password:
 
 <div class="full">
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/aspnet/getuserprofile.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/aspnet/getuserprofile.md
@@ -1,4 +1,4 @@
-## Get the user profile information
+## Get the user profile information (optional)
 
 After the user signs in successfully, request basic user information from the authorization server using the tokens that were returned in the previous step.
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/aspnet/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/aspnet/integrationsteps.md
@@ -1,6 +1,6 @@
 ### Your app displays the sign-in page
 
-Build a sign-in page that captures both the user's name and their password.
+Build a sign-in page where users can input their username and password.
 
 <div class="half wireframe-border">
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/aspnet/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/aspnet/integrationsteps.md
@@ -1,6 +1,6 @@
 ### Your app displays the sign-in page
 
-Build a sign-in page where users can input their username and password.
+Build a sign-in page where users input their username and password.
 
 <div class="half wireframe-border">
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/aspnet/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/aspnet/integrationsteps.md
@@ -1,6 +1,6 @@
 ### Your app displays the sign-in page
 
-Build a sign-in page where users input their username and password.
+Display a sign-in page where users input their username and password.
 
 <div class="half wireframe-border">
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/aspnet/pwdoptionalusecase.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/aspnet/pwdoptionalusecase.md
@@ -1,2 +1,1 @@
->
-> To learn about a sign-in use case where the password is optional, see the [Sign in with email only](/docs/guides/pwd-optional-sign-in-email/aspnet/main/) guide.
+To learn about a sign-in use case where the password is optional, see [Sign in with email only](/docs/guides/pwd-optional-sign-in-email/aspnet/main/).

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/aspnet/summaryofsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/aspnet/summaryofsteps.md
@@ -1,4 +1,4 @@
-The following diagram summarizes the steps involved in a sign-in flow using only a password:
+The following diagram summarizes the steps involved in a sign-in flow that only uses a password:
 
 <div class="full">
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/go/getuserprofile.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/go/getuserprofile.md
@@ -1,4 +1,4 @@
-## Get the user profile information
+## Get the user profile information (optional)
 
 After the user signs in successfully, request basic user information from the authorization server using the tokens that were returned in the previous step.
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/go/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/go/integrationsteps.md
@@ -14,7 +14,7 @@ if err != nil {
 }
 ```
 
-Display a sign-in page that captures the user's name and password.
+Display a sign-in page where users input their username and password.
 
 <div class="half wireframe-border">
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/index.md
@@ -1,5 +1,5 @@
 ---
-title: Basic sign-in flow with the password factor
+title: Sign-in flow with password (single factor)
 ---
 
 <ApiLifecycle access="ie" />
@@ -7,20 +7,20 @@ title: Basic sign-in flow with the password factor
 Enable a password-only sign-in flow in your web app using the embedded SDK.
 
 > **Note**: Passwords are a security vulnerability because they can be easily stolen and are prone to phishing attacks. Give your users the ability to use other authenticators by replacing password-only sign-in experiences with either a [password-optional](https://developer.okta.com/docs/guides/pwd-optional-overview) or a multifactor experience.
+
 <StackSnippet snippet="pwdoptionalusecase" />
 
 ---
 
-#### Learning outcomes
+## Learning outcomes
 
-Add a sign-in flow to a server-side web app that requires only a password.
+Add a sign-in flow to a server-side web app where the only authentication requirement is a user password.
 
-#### What you need
+## What you need
 
 <StackSnippet snippet="whatyouneed" />
-<br />
 
-#### Sample code
+## Sample code
 
 <StackSnippet snippet="samplecode" />
 
@@ -28,7 +28,7 @@ Add a sign-in flow to a server-side web app that requires only a password.
 
 ## Configuration updates
 
-To configure your app so it requires only a password, see <StackSnippet snippet="configureyourapp" inline />.
+Your app must be configured to support password factor-only use cases. For more information, see <StackSnippet snippet="configureyourapp" inline />.
 
 ## Summary of steps
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/index.md
@@ -1,5 +1,5 @@
 ---
-title: Sign-in flow with password (single factor)
+title: Sign-in flow with password
 ---
 
 <ApiLifecycle access="ie" />
@@ -28,7 +28,7 @@ Add a sign-in flow to a server-side web app where the only authentication requir
 
 ## Configuration updates
 
-Your app must be configured to support password factor-only use cases. For more information, see <StackSnippet snippet="configureyourapp" inline />.
+Your app must be configured to support password as single factor authentication. For more information, see <StackSnippet snippet="configureyourapp" inline />.
 
 ## Summary of steps
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/index.md
@@ -1,14 +1,16 @@
 ---
-title: Sign-in flow with password
+title: "Sign-in flow: password-only"
 ---
 
 <ApiLifecycle access="ie" />
 
 Enable a password-only sign-in flow in your web app using the embedded SDK.
 
-> **Note**: Passwords are a security vulnerability because they can be easily stolen and are prone to phishing attacks. Give your users the ability to use other authenticators by replacing password-only sign-in experiences with either a [password-optional](https://developer.okta.com/docs/guides/pwd-optional-overview) or a multifactor experience.
-
-<StackSnippet snippet="pwdoptionalusecase" />
+> **Note**: Passwords are a security vulnerability because they can be easily stolen and are prone to phishing attacks. Give users robust options by replacing password-only authentication with either:
+> * a multifactor experience, such as: [Sign-in flow: password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/) or [Sign-in flow: password and phone](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone) 
+> * a [password-optional experience](https://developer.okta.com/docs/guides/pwd-optional-overview) 
+>
+><StackSnippet snippet="pwdoptionalusecase" />
 
 ---
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/ios/getuserprofile.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/ios/getuserprofile.md
@@ -1,6 +1,6 @@
-## Get the user profile information
+## Get the user profile information (optional)
 
-Depending on your requirements and what information you want to retrieve after the user successfully signs in, you can obtain basic user information by making a request to the authorization server.
+After the user signs in successfully, you can choose to obtain basic user information by making a request to the authorization server.
 
 The following code shows a call to the [`/userinfo`](/docs/reference/api/oidc/#userinfo) endpoint where the access token is passed in to the authorization header. Basic JSON parsing is executed during the response.
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/ios/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/ios/integrationsteps.md
@@ -1,10 +1,10 @@
 ### Sample application and SDK integration
 
-Similar to the Okta APIs, the SDK uses a generic interface to handle each step of the user sign-in flow. This interface enables apps to use a dynamic model when responding to policy changes within Okta. Specifically, it enables a pure policy-driven design that accepts new functionality, such as adding other sign-in factors, without the need to update your app's code. This feature is important for mobile devices due to the challenges in updating apps. See how the [sample application](/docs/guides/oie-embedded-common-run-samples/ios/main/) uses the SDK to implement this dynamic policy-driven behavior.
+Similar to the Okta APIs, the SDK uses a generic interface to handle each step of the user sign-in flow. This interface enables apps to use a dynamic model when responding to policy changes within Okta. Specifically, it enables a pure policy-driven design that accepts new functionality, such as adding other sign-in factors, without the need to update your app's code. This feature is important for mobile devices due to the challenges in updating apps. To learn how the sample app uses the SDK, see [The embedded SDK flow](/docs/guides/oie-embedded-common-run-samples/ios/main/#the-embedded-sdk-flow).
 
 ### Integrate the SDK with the sample code
 
-In contrast to the sample app, the [sample code](https://github.com/okta/okta-idx-swift/tree/master/Samples/Signin%20Samples) provided in this step-by-step guide wraps the SDK with a more prescriptive and explicit interface that is purposely built to help facilitate understanding of how to use the SDK. It's meant to be a learning tool and although you can implement similar code in your app, you're advised to use the same best practice dynamic approach implemented in the sample app.
+In contrast to the iOS Identity Engine sample app, the [sample code](https://github.com/okta/okta-idx-swift/tree/master/Samples/Signin%20Samples) provided in this guide wraps the SDK with a more prescriptive and explicit interface. This interface was built to help people learn how to use the SDK. Although you can choose to implement similar code in your app, we recommend that you use the same best practice dynamic approach implemented in the sample app instead.
 
 The following steps document how to integrate the sample code into your app. The sample code converts the SDK's generic remediation interface into explicit authentication steps and automatically executes steps, such as the code-to-token exchange. The following diagram illustrates this call flow from your app's UI to the sample code, SDK, and API.
 
@@ -18,7 +18,7 @@ The following steps document how to integrate the sample code into your app. The
 
 ### Launch the app and initialize the SDK
 
-The first step is to initialize the SDK when the user opens your app. This is done by creating an instance of `BasicLogin` and passing into its initializer a `configuration` object.
+The SDK initializes when the user opens your app. Create an instance of `BasicLogin` and pass into its initializer a `configuration` object.
 
  ```swift
 self.authHandler = BasicLogin(configuration: configuration)
@@ -46,8 +46,6 @@ When the user enters their credentials and initiates the sign-in flow, call the 
 ### Send the user to the home page after a successful sign-in flow
 
 The final integration step is to send the user to the default home page after a successful sign-in flow. Optionally, you can obtain basic user information after the user successfully signs in by making a request to the Okta OpenID Connect authorization server. See [Get the user profile information](#get-the-user-profile-information).
-
-#### Sample code
 
 The following sample code is also located in the [okta-idx-swift repository](https://github.com/okta/okta-idx-swift/blob/master/Samples/Signin%20Samples/BasicLogin.swift).
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/ios/summaryofsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/ios/summaryofsteps.md
@@ -1,4 +1,4 @@
-The following sequence diagram details each step in the authentication flow for this use case.
+The following diagram summarizes the steps involved in a sign-in flow that only uses a password:
 
 <div class="full">
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/java/getuserprofile.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/java/getuserprofile.md
@@ -1,4 +1,4 @@
-## Get the user profile information
+## Get the user profile information (optional)
 
 After the user signs in successfully, request basic user information from the authorization server using the tokens that were returned in the previous step.
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/java/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/java/integrationsteps.md
@@ -1,6 +1,6 @@
 ### The user launches the sign-in page
 
-Build a sign-in page where users can input their username and password.
+Build a sign-in page where users input their username and password.
 
 <div class="half wireframe-border">
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/java/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/java/integrationsteps.md
@@ -32,7 +32,7 @@ AuthenticationResponse authenticationResponse =
    );
 ```
 
-### Your app handles an authentication success response
+### Your app handles an authentication response
 
 `IDXAuthenticationWrapper.authenticate()` returns an [`AuthenticationResponse`](https://github.com/okta/okta-idx-java/blob/master/api/src/main/java/com/okta/idx/sdk/api/response/AuthenticationResponse.java) object with an [`AuthenticationStatus`](https://github.com/okta/okta-idx-java/blob/master/api/src/main/java/com/okta/idx/sdk/api/model/AuthenticationStatus.java) property indicating the current state of the sign-in flow. Handle the returned `AuthenticationStatus` value accordingly:
 
@@ -88,7 +88,7 @@ Handle other returned [AuthenticationStatus](https://github.com/okta/okta-idx-ja
 
 #### Failed authentication
 
-There's no explicit failed status from `AuthenticationStatus`. Check the response handler for an error in `AuthenticationResponse` for failed authentication, and handle the flow accordingly. For example:
+There is no explicit failed status from `AuthenticationStatus`. Check the response handler for an error in `AuthenticationResponse` for failed authentication, and handle the flow accordingly. For example:
 
 ```java
 if (responseHandler.needsToShowErrors(authenticationResponse)) {

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/java/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/java/integrationsteps.md
@@ -1,6 +1,6 @@
 ### The user launches the sign-in page
 
-Build a sign-in page that captures both the user's name and their password.
+Build a sign-in page where users can input their username and password.
 
 <div class="half wireframe-border">
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/java/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/java/integrationsteps.md
@@ -1,6 +1,6 @@
 ### The user launches the sign-in page
 
-Build a sign-in page where users input their username and password.
+Display a sign-in page where users input their username and password.
 
 <div class="half wireframe-border">
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/java/pwdoptionalusecase.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/java/pwdoptionalusecase.md
@@ -1,2 +1,1 @@
->
-> To learn about a sign-in use case where the password is optional, see the [Sign in with email only](/docs/guides/pwd-optional-sign-in-email/java/main/) guide.
+To learn about a sign-in use case where the password is optional, see [Sign in with email only](/docs/guides/pwd-optional-sign-in-email/java/main/).

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/java/summaryofsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/java/summaryofsteps.md
@@ -1,4 +1,4 @@
-The following diagram summarizes the steps involved in a sign-in flow using only a password:
+The following diagram summarizes the steps involved in a sign-in flow that only uses a password:
 
 <div class="full">
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/nodejs/getuserprofile.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/nodejs/getuserprofile.md
@@ -1,4 +1,4 @@
-## Get the user profile information
+## Get the user profile information (optional)
 
 After the user signs in successfully, request basic user information from the authorization server using the tokens that were returned in the previous step.
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/nodejs/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/nodejs/integrationsteps.md
@@ -1,6 +1,6 @@
 ### Your app displays the sign-in page
 
-Build a sign-in page that captures both the user's name and their password.
+Build a sign-in page where users can input their username and password.
 
 <div class="half wireframe-border">
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/nodejs/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/nodejs/integrationsteps.md
@@ -1,6 +1,6 @@
 ### Your app displays the sign-in page
 
-Build a sign-in page where users can input their username and password.
+Build a sign-in page where users input their username and password.
 
 <div class="half wireframe-border">
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/nodejs/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/nodejs/integrationsteps.md
@@ -22,7 +22,7 @@ const authClient = getAuthClient(req);
 const transaction = await authClient.idx.authenticate({ username, password });
 ```
 
-### Your app handles an authentication success response
+### Your app handles an authentication response
 
 `authenticate()` returns a `transaction` object with a `status` property indicating the current state of the sign-in flow. Handle the returned `IdxStatus` value accordingly:
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/nodejs/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/nodejs/integrationsteps.md
@@ -1,6 +1,6 @@
 ### Your app displays the sign-in page
 
-Build a sign-in page where users input their username and password.
+Display a sign-in page where users input their username and password.
 
 <div class="half wireframe-border">
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/nodejs/pwdoptionalusecase.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/nodejs/pwdoptionalusecase.md
@@ -1,2 +1,1 @@
->
-> To learn about a sign-in use case where the password is optional, see the [Sign in with email only](/docs/guides/pwd-optional-sign-in-email/nodeexpress/main/) guide.
+To learn about a sign-in use case where the password is optional, see [Sign in with email only](/docs/guides/pwd-optional-sign-in-email/nodeexpress/main/).

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/nodejs/summaryofsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/main/nodejs/summaryofsteps.md
@@ -1,4 +1,4 @@
-The following diagram summarizes the steps involved in a sign-in flow using only a password:
+The following diagram summarizes the steps involved in a sign-in flow that only uses a password:
 
 <div class="full">
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-self-reg/main/aspnet/pwdoptionalusecase.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-self-reg/main/aspnet/pwdoptionalusecase.md
@@ -1,1 +1,1 @@
-> **Note:** To learn about a sign-up use case where the password is optional, see the [Sign up for a new account with email only](/docs/guides/pwd-optional-new-sign-up-email/aspnet/main/) guide.
+To learn about a sign-up use case where the password is optional, see [Sign up for a new account with email only](/docs/guides/pwd-optional-new-sign-up-email/aspnet/main/).

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-self-reg/main/go/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-self-reg/main/go/integrationsteps.md
@@ -286,7 +286,7 @@ func (s *Server) transitionToProfile(er *idx.EnrollmentResponse, w http.Response
   ...
 ```
 
-For more details about enrolling the phone factor, see the sample application. For details on how to verify a sign-in flow with the phone factor, see [Sign in with password and phone factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/go/main/).
+For more details about enrolling the phone factor, see the sample application. For details on how to verify a sign-in flow with the phone factor, see [Sign-in flow with password and phone](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/go/main/).
 
 ### Complete registration
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-self-reg/main/go/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-self-reg/main/go/integrationsteps.md
@@ -286,7 +286,7 @@ func (s *Server) transitionToProfile(er *idx.EnrollmentResponse, w http.Response
   ...
 ```
 
-For more details about enrolling the phone factor, see the sample application. For details on how to verify a sign-in flow with the phone factor, see [Sign-in flow with password and phone](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/go/main/).
+For more details about enrolling the phone factor, see the sample application. For details on how to verify a sign-in flow with the phone factor, see [Sign-in flow: password and phone](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/go/main/).
 
 ### Complete registration
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-self-reg/main/ios/summaryofsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-self-reg/main/ios/summaryofsteps.md
@@ -22,4 +22,4 @@ Source image: https://www.figma.com/file/YH5Zhzp66kGCglrXQUag2E/%F0%9F%93%8A-Upd
 
 </div>
 
-The above sequence diagram follows a path where the user skips the optional phone authenticator. To understand the authentication flow when the user selects the phone authenticator, see the [Sign in with password and phone factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/ios/main/).
+The above sequence diagram follows a path where the user skips the optional phone authenticator. To understand the authentication flow when the user selects the phone authenticator, see the [Sign-in flow with password and phone](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/ios/main/).

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-self-reg/main/ios/summaryofsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-self-reg/main/ios/summaryofsteps.md
@@ -22,4 +22,4 @@ Source image: https://www.figma.com/file/YH5Zhzp66kGCglrXQUag2E/%F0%9F%93%8A-Upd
 
 </div>
 
-The above sequence diagram follows a path where the user skips the optional phone authenticator. To understand the authentication flow when the user selects the phone authenticator, see the [Sign-in flow with password and phone](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/ios/main/).
+The above sequence diagram follows a path where the user skips the optional phone authenticator. To understand the authentication flow when the user selects the phone authenticator, see the [Sign-in flow: password and phone](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/ios/main/).

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/main/index.md
@@ -1,5 +1,5 @@
 ---
-title: Sign in with password and email factors
+title: Sign-in flow with password and email
 ---
 
 <ApiLifecycle access="ie" />

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/main/index.md
@@ -1,5 +1,5 @@
 ---
-title: Sign-in flow with password and email
+title: "Sign-in flow: password and email"
 ---
 
 <ApiLifecycle access="ie" />

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/main/go/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/main/go/integrationsteps.md
@@ -33,7 +33,7 @@ Source image: https://www.figma.com/file/YH5Zhzp66kGCglrXQUag2E/%F0%9F%93%8A-Upd
 During page load, call the `Client` object's `InitLogin` method. This method returns an object of type
 `LoginResponse` that is used to initate the sign-in process with Okta.  The object
 also contains a list of available social Identity Providers (IdPs) that is discussed in more detail in the
-[Sign-in flow with Facebook](/docs/guides/oie-embedded-sdk-use-case-sign-in-soc-idp/go/main)
+[Sign-in flow: Facebook](/docs/guides/oie-embedded-sdk-use-case-sign-in-soc-idp/go/main)
 use case.
 
 ```go

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/main/go/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/main/go/integrationsteps.md
@@ -33,7 +33,7 @@ Source image: https://www.figma.com/file/YH5Zhzp66kGCglrXQUag2E/%F0%9F%93%8A-Upd
 During page load, call the `Client` object's `InitLogin` method. This method returns an object of type
 `LoginResponse` that is used to initate the sign-in process with Okta.  The object
 also contains a list of available social Identity Providers (IdPs) that is discussed in more detail in the
-[Sign in with Facebook](/docs/guides/oie-embedded-sdk-use-case-sign-in-soc-idp/go/main)
+[Sign-in flow with Facebook](/docs/guides/oie-embedded-sdk-use-case-sign-in-soc-idp/go/main)
 use case.
 
 ```go

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/main/index.md
@@ -1,5 +1,5 @@
 ---
-title: Sign in with password and phone factors
+title: Sign-in flow with password and phone
 ---
 
 <ApiLifecycle access="ie" />

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/main/index.md
@@ -1,5 +1,5 @@
 ---
-title: Sign-in flow with password and phone
+title: "Sign-in flow: password and phone"
 ---
 
 <ApiLifecycle access="ie" />

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-soc-idp/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-soc-idp/main/index.md
@@ -1,5 +1,5 @@
 ---
-title: Sign-in flow with Facebook
+title: "Sign-in flow: Facebook"
 ---
 
 <ApiLifecycle access="ie" />

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-soc-idp/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-sdk-use-case-sign-in-soc-idp/main/index.md
@@ -1,5 +1,5 @@
 ---
-title: Sign in with Facebook
+title: Sign-in flow with Facebook
 ---
 
 <ApiLifecycle access="ie" />

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-widget-use-case-basic-sign-in/main/aspnet/integrationsteps.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-widget-use-case-basic-sign-in/main/aspnet/integrationsteps.md
@@ -49,7 +49,7 @@ public async Task<ActionResult> Callback(
 }
 ```
 
-### Get the user profile information
+### Get the user profile information (optional)
 
 After the user signs in successfully, request basic user information from the authorization server using the tokens that were returned in the previous step.
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-widget-use-case-basic-sign-in/main/aspnet/pwdoptionalusecase.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-widget-use-case-basic-sign-in/main/aspnet/pwdoptionalusecase.md
@@ -1,2 +1,1 @@
->
-> To learn about a sign-in use case where the password is optional, see [Sign in with email only](/docs/guides/pwd-optional-sign-in-email/aspnet/main/).
+To learn about a sign-in use case where the password is optional, see [Sign in with email only](/docs/guides/pwd-optional-sign-in-email/aspnet/main/).

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-widget-use-case-basic-sign-in/main/java/pwdoptionalusecase.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-widget-use-case-basic-sign-in/main/java/pwdoptionalusecase.md
@@ -1,2 +1,1 @@
->
-> To learn about a sign-in use case where the password is optional, see [Sign in with email only](/docs/guides/pwd-optional-sign-in-email/java/main/).
+To learn about a sign-in use case where a password is optional, see [Sign in with email only](/docs/guides/pwd-optional-sign-in-email/nodeexpress/main/).

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-widget-use-case-basic-sign-in/main/nodejs/pwdoptionalusecase.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-widget-use-case-basic-sign-in/main/nodejs/pwdoptionalusecase.md
@@ -1,1 +1,1 @@
-To learn about a sign-in use case where the password is optional, see [Sign in with email only](/docs/guides/pwd-optional-sign-in-email/nodeexpress/main/).
+To learn about a sign-in use case where a password is optional, see [Sign in with email only](/docs/guides/pwd-optional-sign-in-email/nodeexpress/main/).

--- a/packages/@okta/vuepress-site/docs/guides/oie-embedded-widget-use-case-basic-sign-in/main/nodejs/pwdoptionalusecase.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-embedded-widget-use-case-basic-sign-in/main/nodejs/pwdoptionalusecase.md
@@ -1,2 +1,1 @@
->
-> To learn about a sign-in use case where the password is optional, see [Sign in with email only](/docs/guides/pwd-optional-sign-in-email/nodeexpress/main/).
+To learn about a sign-in use case where the password is optional, see [Sign in with email only](/docs/guides/pwd-optional-sign-in-email/nodeexpress/main/).

--- a/packages/@okta/vuepress-site/docs/guides/oie-upgrade-api-sdk-to-oie-sdk/main/android/auth.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-upgrade-api-sdk-to-oie-sdk/main/android/auth.md
@@ -52,6 +52,6 @@ AuthenticationResponse authenticationResponse =
      idxAuthenticationWrapper.authenticate(new AuthenticationOptions(username, password.toCharArray()), proceedContext);
 ```
 
-See [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/android/main/) for further details on the Identity Engine password authentication flow.
+See [Sign-in flow: password-only](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/android/main/) for further details on the Identity Engine password authentication flow.
 
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-upgrade-api-sdk-to-oie-sdk/main/android/auth.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-upgrade-api-sdk-to-oie-sdk/main/android/auth.md
@@ -52,6 +52,6 @@ AuthenticationResponse authenticationResponse =
      idxAuthenticationWrapper.authenticate(new AuthenticationOptions(username, password.toCharArray()), proceedContext);
 ```
 
-See [Basic sign-in flow example with the password factor](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/android/main/) for further details on the Identity Engine password authentication flow.
+See [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/android/main/) for further details on the Identity Engine password authentication flow.
 
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-upgrade-api-sdk-to-oie-sdk/main/android/mfaauth.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-upgrade-api-sdk-to-oie-sdk/main/android/mfaauth.md
@@ -77,4 +77,4 @@ AuthenticationResponse authenticationResponse =
 
 The number of required/optional authenticators for MFA are configured in the Admin Console and in the authentication policies. The Identity Engine-enabled app is structured in a way that enables the MFA challenges to differ based on user, group, context, and available factors since the MFA process is driven by policies set in Okta and not hard-coded into the app.
 
-For further details on how this use case is implemented with the Java Identity Engine SDK, see [Sign in with password and email factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/android/main/).
+For further details on how this use case is implemented with the Java Identity Engine SDK, see [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/android/main/).

--- a/packages/@okta/vuepress-site/docs/guides/oie-upgrade-api-sdk-to-oie-sdk/main/android/mfaauth.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-upgrade-api-sdk-to-oie-sdk/main/android/mfaauth.md
@@ -77,4 +77,4 @@ AuthenticationResponse authenticationResponse =
 
 The number of required/optional authenticators for MFA are configured in the Admin Console and in the authentication policies. The Identity Engine-enabled app is structured in a way that enables the MFA challenges to differ based on user, group, context, and available factors since the MFA process is driven by policies set in Okta and not hard-coded into the app.
 
-For further details on how this use case is implemented with the Java Identity Engine SDK, see [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/android/main/).
+For further details on how this use case is implemented with the Java Identity Engine SDK, see [Sign-in flow: password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/android/main/).

--- a/packages/@okta/vuepress-site/docs/guides/oie-upgrade-api-sdk-to-oie-sdk/main/java/auth.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-upgrade-api-sdk-to-oie-sdk/main/java/auth.md
@@ -43,4 +43,4 @@ AuthenticationResponse authenticationResponse =
     idxAuthenticationWrapper.authenticate(new AuthenticationOptions(username, password.toCharArray()), proceedContext);
 ```
 
-See [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/java/main/) for further details on the Identity Engine password authentication flow.
+See [Sign-in flow: password-only](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/java/main/) for further details on the Identity Engine password authentication flow.

--- a/packages/@okta/vuepress-site/docs/guides/oie-upgrade-api-sdk-to-oie-sdk/main/java/auth.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-upgrade-api-sdk-to-oie-sdk/main/java/auth.md
@@ -43,4 +43,4 @@ AuthenticationResponse authenticationResponse =
     idxAuthenticationWrapper.authenticate(new AuthenticationOptions(username, password.toCharArray()), proceedContext);
 ```
 
-See [Basic sign-in flow example with the password factor](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/java/main/) for further details on the Identity Engine password authentication flow.
+See [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/java/main/) for further details on the Identity Engine password authentication flow.

--- a/packages/@okta/vuepress-site/docs/guides/oie-upgrade-api-sdk-to-oie-sdk/main/java/mfaauth.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-upgrade-api-sdk-to-oie-sdk/main/java/mfaauth.md
@@ -58,4 +58,4 @@ If additional factors are required, then `AuthenticationStatus=AWAITING_AUTHENTI
 
 The number of required/optional authenticators for MFA are configured in the Admin Console and in the authentication policies. The Identity Engine-enabled app is structured in a way that enables the MFA challenges to differ based on user, group, context, and available factors, since the MFA process is driven by policies set in Okta, and not hard-coded into the app.
 
-For further details on how this use case is implemented with the Java Identity Engine SDK, see [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/java/main/).
+For further details on how this use case is implemented with the Java Identity Engine SDK, see [Sign-in flow: password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/java/main/).

--- a/packages/@okta/vuepress-site/docs/guides/oie-upgrade-api-sdk-to-oie-sdk/main/java/mfaauth.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-upgrade-api-sdk-to-oie-sdk/main/java/mfaauth.md
@@ -58,4 +58,4 @@ If additional factors are required, then `AuthenticationStatus=AWAITING_AUTHENTI
 
 The number of required/optional authenticators for MFA are configured in the Admin Console and in the authentication policies. The Identity Engine-enabled app is structured in a way that enables the MFA challenges to differ based on user, group, context, and available factors, since the MFA process is driven by policies set in Okta, and not hard-coded into the app.
 
-For further details on how this use case is implemented with the Java Identity Engine SDK, see [Sign in with password and email factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/java/main/).
+For further details on how this use case is implemented with the Java Identity Engine SDK, see [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/java/main/).

--- a/packages/@okta/vuepress-site/docs/guides/pwd-optional-best-practices/main/aspnet/signinwithpwdandphone.md
+++ b/packages/@okta/vuepress-site/docs/guides/pwd-optional-best-practices/main/aspnet/signinwithpwdandphone.md
@@ -1,1 +1,1 @@
-[Sign in with password and phone factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/aspnet/main/)
+[Sign-in flow with password and phone](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/aspnet/main/)

--- a/packages/@okta/vuepress-site/docs/guides/pwd-optional-best-practices/main/aspnet/signinwithpwdandphone.md
+++ b/packages/@okta/vuepress-site/docs/guides/pwd-optional-best-practices/main/aspnet/signinwithpwdandphone.md
@@ -1,1 +1,1 @@
-[Sign-in flow with password and phone](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/aspnet/main/)
+[Sign-in flow: password and phone](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/aspnet/main/)

--- a/packages/@okta/vuepress-site/docs/guides/pwd-optional-best-practices/main/java/signinwithpwdandphone.md
+++ b/packages/@okta/vuepress-site/docs/guides/pwd-optional-best-practices/main/java/signinwithpwdandphone.md
@@ -1,1 +1,1 @@
-[Sign in with password and phone factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/java/main/)
+[Sign-in flow with password and phone](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/java/main/)

--- a/packages/@okta/vuepress-site/docs/guides/pwd-optional-best-practices/main/java/signinwithpwdandphone.md
+++ b/packages/@okta/vuepress-site/docs/guides/pwd-optional-best-practices/main/java/signinwithpwdandphone.md
@@ -1,1 +1,1 @@
-[Sign-in flow with password and phone](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/java/main/)
+[Sign-in flow: password and phone](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/java/main/)

--- a/packages/@okta/vuepress-site/docs/guides/pwd-optional-best-practices/main/nodeexpress/signinwithpwdandphone.md
+++ b/packages/@okta/vuepress-site/docs/guides/pwd-optional-best-practices/main/nodeexpress/signinwithpwdandphone.md
@@ -1,1 +1,1 @@
-[Sign-in flow with password and phone](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/nodejs/main/)
+[Sign-in flow: password and phone](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/nodejs/main/)

--- a/packages/@okta/vuepress-site/docs/guides/pwd-optional-best-practices/main/nodeexpress/signinwithpwdandphone.md
+++ b/packages/@okta/vuepress-site/docs/guides/pwd-optional-best-practices/main/nodeexpress/signinwithpwdandphone.md
@@ -1,1 +1,1 @@
-[Sign in with password and phone factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/nodejs/main/)
+[Sign-in flow with password and phone](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/nodejs/main/)

--- a/packages/@okta/vuepress-site/docs/guides/pwd-optional-best-practices/main/react/signinwithpwdandphone.md
+++ b/packages/@okta/vuepress-site/docs/guides/pwd-optional-best-practices/main/react/signinwithpwdandphone.md
@@ -1,2 +1,2 @@
-[Sign in with password and phone factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/nodejs/main/)
+[Sign-in flow with password and phone](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/nodejs/main/)
 

--- a/packages/@okta/vuepress-site/docs/guides/pwd-optional-best-practices/main/react/signinwithpwdandphone.md
+++ b/packages/@okta/vuepress-site/docs/guides/pwd-optional-best-practices/main/react/signinwithpwdandphone.md
@@ -1,2 +1,2 @@
-[Sign-in flow with password and phone](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/nodejs/main/)
+[Sign-in flow: password and phone](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-phone/nodejs/main/)
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/angular/see-also.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/angular/see-also.md
@@ -1,2 +1,2 @@
-* [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main)
+* [Sign-in flow: password-only](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main)
 * [Okta Auth JS SDK Interaction Code reference](https://github.com/okta/okta-auth-js/blob/master/docs/idx.md#introduction)

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/angular/see-also.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/angular/see-also.md
@@ -1,2 +1,2 @@
-* [Basic sign-in flow example with the password factor](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main)
+* [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main)
 * [Okta Auth JS SDK Interaction Code reference](https://github.com/okta/okta-auth-js/blob/master/docs/idx.md#introduction)

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/see-also.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/see-also.md
@@ -1,2 +1,2 @@
-* [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main)
+* [Sign-in flow: password-only](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main)
 * [Okta Auth JS SDK Interaction Code reference](https://github.com/okta/okta-auth-js/blob/master/docs/idx.md#introduction)

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/see-also.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/see-also.md
@@ -1,2 +1,2 @@
-* [Basic sign-in flow example with the password factor](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main)
+* [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main)
 * [Okta Auth JS SDK Interaction Code reference](https://github.com/okta/okta-auth-js/blob/master/docs/idx.md#introduction)

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/vue/see-also.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/vue/see-also.md
@@ -1,4 +1,4 @@
 * [Sign in to your SPA with the embedded Okta Sign-In Widget](/docs/guides/sign-in-to-spa-embedded-widget/vue/main/) for an embedded authentication Vue.js app that uses the Sign-In Widget
-* [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main/) for a web application that uses the embedded authentication deployment model
+* [Sign-in flow: password-only](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main/) for a web application that uses the embedded authentication deployment model
 * [Sign users in to your SPA using the redirect model](/docs/guides/sign-into-spa-redirect/vue/main/) for the redirect authentication deployment model
 * [Use redirect auth with the sample apps](/docs/guides/sampleapp-oie-redirectauth/) for multiple use case sample apps that use the redirect authentication deployment model

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/vue/see-also.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/vue/see-also.md
@@ -1,4 +1,4 @@
 * [Sign in to your SPA with the embedded Okta Sign-In Widget](/docs/guides/sign-in-to-spa-embedded-widget/vue/main/) for an embedded authentication Vue.js app that uses the Sign-In Widget
-* [Basic sign-in flow example with the password factor](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main/) for a web application that uses the embedded authentication deployment model
+* [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main/) for a web application that uses the embedded authentication deployment model
 * [Sign users in to your SPA using the redirect model](/docs/guides/sign-into-spa-redirect/vue/main/) for the redirect authentication deployment model
 * [Use redirect auth with the sample apps](/docs/guides/sampleapp-oie-redirectauth/) for multiple use case sample apps that use the redirect authentication deployment model

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/react/see-also.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/react/see-also.md
@@ -2,5 +2,5 @@
 * [Sign users in to your SPA using the redirect model](/docs/guides/sign-into-spa-redirect/react/main/) for the redirect authentication deployment model
 * [Use redirect auth with the sample apps](/docs/guides/sampleapp-oie-redirectauth/) for multiple use case sample apps that use the redirect authentication deployment model
 * [Load the widget](/docs/guides/oie-embedded-widget-use-case-load/) for web apps that use the embedded authentication deployment model
-* [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main/) for a web app that uses the embedded authentication deployment model
+* [Sign-in flow: password-only](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main/) for a web app that uses the embedded authentication deployment model
 * [Blog: A Quick Guide to React Login Options](https://developer.okta.com/blog/2020/12/16/react-login) for React app authentication options with the Okta Classic Engine

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/react/see-also.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/react/see-also.md
@@ -2,5 +2,5 @@
 * [Sign users in to your SPA using the redirect model](/docs/guides/sign-into-spa-redirect/react/main/) for the redirect authentication deployment model
 * [Use redirect auth with the sample apps](/docs/guides/sampleapp-oie-redirectauth/) for multiple use case sample apps that use the redirect authentication deployment model
 * [Load the widget](/docs/guides/oie-embedded-widget-use-case-load/) for web apps that use the embedded authentication deployment model
-* [Basic sign-in flow example with the password factor](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main/) for a web app that uses the embedded authentication deployment model
+* [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main/) for a web app that uses the embedded authentication deployment model
 * [Blog: A Quick Guide to React Login Options](https://developer.okta.com/blog/2020/12/16/react-login) for React app authentication options with the Okta Classic Engine

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/vue/see-also.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/vue/see-also.md
@@ -2,4 +2,4 @@
 * [Sign users in to your SPA using the redirect model](/docs/guides/sign-into-spa-redirect/vue/main/) for the redirect authentication deployment model
 * [Use redirect auth with the sample apps](/docs/guides/sampleapp-oie-redirectauth/) for multiple use case sample apps that use the redirect authentication deployment model
 * [Load the widget](/docs/guides/oie-embedded-widget-use-case-load/) for web apps that use the embedded authentication deployment model
-* [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main/) for a web app that uses the embedded authentication deployment model
+* [Sign-in flow: password-only](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main/) for a web app that uses the embedded authentication deployment model

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/vue/see-also.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-embedded-widget/main/vue/see-also.md
@@ -2,4 +2,4 @@
 * [Sign users in to your SPA using the redirect model](/docs/guides/sign-into-spa-redirect/vue/main/) for the redirect authentication deployment model
 * [Use redirect auth with the sample apps](/docs/guides/sampleapp-oie-redirectauth/) for multiple use case sample apps that use the redirect authentication deployment model
 * [Load the widget](/docs/guides/oie-embedded-widget-use-case-load/) for web apps that use the embedded authentication deployment model
-* [Basic sign-in flow example with the password factor](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main/) for a web app that uses the embedded authentication deployment model
+* [Sign-in flow with password](/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/nodejs/main/) for a web app that uses the embedded authentication deployment model

--- a/packages/@okta/vuepress-site/docs/release-notes/2022/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2022/index.md
@@ -784,7 +784,7 @@ When you use the [AuthN APIs](/docs/reference/api/authn/#request-parameters-for-
 
 #### Improved email magic link authentication experience is EA in Preview
 
-Email magic links are enhanced to allow end users to authenticate in two different contexts. They can authenticate using the same location where they click the link and quickly return to the application context. Or, if the end user clicks the link in a different browser, they can enter a one-time passcode to proceed with authentication. See [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/) and [Use redirect auth with the Identity Engine sample apps](/docs/guides/sampleapp-oie-redirectauth/).
+Email magic links are enhanced to allow end users to authenticate in two different contexts. They can authenticate using the same location where they click the link and quickly return to the application context. Or, if the end user clicks the link in a different browser, they can enter a one-time passcode to proceed with authentication. See [Sign-in flow: password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/) and [Use redirect auth with the Identity Engine sample apps](/docs/guides/sampleapp-oie-redirectauth/).
 
 #### Splunk available for Log Streaming is EA in Preview
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2022/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2022/index.md
@@ -784,7 +784,7 @@ When you use the [AuthN APIs](/docs/reference/api/authn/#request-parameters-for-
 
 #### Improved email magic link authentication experience is EA in Preview
 
-Email magic links are enhanced to allow end users to authenticate in two different contexts. They can authenticate using the same location where they click the link and quickly return to the application context. Or, if the end user clicks the link in a different browser, they can enter a one-time passcode to proceed with authentication. See [Sign in with password and email factors](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/) and [Use redirect auth with the Identity Engine sample apps](/docs/guides/sampleapp-oie-redirectauth/).
+Email magic links are enhanced to allow end users to authenticate in two different contexts. They can authenticate using the same location where they click the link and quickly return to the application context. Or, if the end user clicks the link in a different browser, they can enter a one-time passcode to proceed with authentication. See [Sign-in flow with password and email](/docs/guides/oie-embedded-sdk-use-case-sign-in-pwd-email/) and [Use redirect auth with the Identity Engine sample apps](/docs/guides/sampleapp-oie-redirectauth/).
 
 #### Splunk available for Log Streaming is EA in Preview
 

--- a/packages/@okta/vuepress-theme-prose/const/navbar.const.js
+++ b/packages/@okta/vuepress-theme-prose/const/navbar.const.js
@@ -244,11 +244,11 @@ export const guides = [
                 title: "Embedded SDK use cases",
                 subLinks: [
                   {
-                    title: "Basic sign-in flow with password",
+                    title: "Sign-in flow with password",
                     guideName: "oie-embedded-sdk-use-case-basic-sign-in",
                   },
                   {
-                    title: "Sign in with Facebook",
+                    title: "Sign-in flow with Facebook",
                     guideName: "oie-embedded-sdk-use-case-sign-in-soc-idp",
                   },
                   {
@@ -264,11 +264,11 @@ export const guides = [
                     guideName: "oie-embedded-sdk-use-case-new-user-activation",
                   },
                   {
-                    title: "Sign in: password + email",
+                    title: "Sign-in flow with password and email",
                     guideName: "oie-embedded-sdk-use-case-sign-in-pwd-email",
                   },
                   {
-                    title: "Sign in: pwd and phone",
+                    title: "Sign-in flow with password and phone",
                     guideName: "oie-embedded-sdk-use-case-sign-in-pwd-phone",
                   },
                   {

--- a/packages/@okta/vuepress-theme-prose/const/navbar.const.js
+++ b/packages/@okta/vuepress-theme-prose/const/navbar.const.js
@@ -244,11 +244,11 @@ export const guides = [
                 title: "Embedded SDK use cases",
                 subLinks: [
                   {
-                    title: "Sign-in flow with password",
+                    title: "Sign-in flow: password-only",
                     guideName: "oie-embedded-sdk-use-case-basic-sign-in",
                   },
                   {
-                    title: "Sign-in flow with Facebook",
+                    title: "Sign-in flow: Facebook",
                     guideName: "oie-embedded-sdk-use-case-sign-in-soc-idp",
                   },
                   {
@@ -264,11 +264,11 @@ export const guides = [
                     guideName: "oie-embedded-sdk-use-case-new-user-activation",
                   },
                   {
-                    title: "Sign-in flow with password and email",
+                    title: "Sign-in flow: password and email",
                     guideName: "oie-embedded-sdk-use-case-sign-in-pwd-email",
                   },
                   {
-                    title: "Sign-in flow with password and phone",
+                    title: "Sign-in flow: password and phone",
                     guideName: "oie-embedded-sdk-use-case-sign-in-pwd-phone",
                   },
                   {


### PR DESCRIPTION
## Description:
**What's changed?**: Edits to Basic sign-in flow with the password factor (https://developer.okta.com/docs/guides/oie-embedded-sdk-use-case-basic-sign-in/android/main/)

- Update page title to be more clear. Made sure title in TOC and title on page match. 
- Updated titles of 3 other pages in same TOC sub-section that had related content. Before the title styling was inconsistent.
![image](https://github.com/okta/okta-developer-docs/assets/33457271/7af0b829-cd72-46c3-822e-ea557dab8dbc)
-Updated link text for all 4 pages that were renamed

- Node.js and Java pages had a Note nested within a Note. Second note converted to be plain text within main note. 
    -Before: 
![image](https://github.com/okta/okta-developer-docs/assets/33457271/b35d878e-c82c-44c8-8ebb-dc6ff1022c94)
     -After: 
![image](https://github.com/okta/okta-developer-docs/assets/33457271/4c16d766-c105-4128-8b22-4f8b69ac4f9f)

- Copy-editing: Split up long sentences into shorter ones, added clarity to some sentences. Standardized intro sentences: some pages had slightly different wording in sentences after headings. 

- Removed contractions in some cases: While contractions are allowed as per Microsoft Style Guide, there were some instances where they made instructions unclear. Those were removed. 

- Learning Outcomes section: I can see in the git history that this section used to have bolded text instead of headings. Recently, they were all updated to be H4s. I assume H4s were chosen to maintain a small font size, similar to when normal text is bolded. However, it does not make sense for the hierarchy on all pages to be Title > H4 > H2. So I updated the Learning Outcomes section to all be H4s. This means they also show up in the mini TOC on the right. I think this is positive: it's nice for people scanning the page to see there are code samples, etc. However, if the docs team does not want this section to appear in the mini TOC, another solution will need to be found. 

**Is this PR related to a Monolith release?**: No, this is not related to a monolith release.

### Resolves:

Julia Beingessner's Technical Writer Interview Assignment
