### PR TITLE
[OKTA-726318] Send failure email when nightly job fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,18 @@ jobs:
             name: Send failure email if broken URLs found
             when: on_success
             command: |
-              chmod +x ./scripts/send-nightly-email.sh
-              ./scripts/send-nightly-email.sh
+              broken_urls=$(comm -23 <(sort urls.txt | uniq) <(sort falsepos.txt | uniq))
+              broken_urls=$(echo "$broken_urls" | sed 's/ /\n/g')
+              formatted_broken_urls=$(echo "$broken_urls" | awk '{printf "<a href=\"%s\">%s</a><br/>\n", $0, $0}')
+              
+              if [ -n "$formatted_broken_urls" ]; then
+                  curl --location --request POST 'https://www.cinotify.cc/api/notify' \
+                          -d "to=${NOTIFY_EMAIL}&subject=FAILED: Dev Docs Nightly Job&type=text/html&body=<p style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center; background-color: #ffcccc; padding: 10px;'>
+                          <span style='font-weight: bold;'>Nightly link checker job failed. See the list of broken URLs below.</span><br><br>
+                          <a href='https://app.circleci.com/pipelines/github/okta/okta-developer-docs/<< pipeline.number >>' style='display: inline-block; padding: 5px 10px; background-color: #4caf50; color: white; text-decoration: none;'>Click here</a>
+                          to see job details.<br>
+                      </p><h2 style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center;'>List of broken URLs:</h2>$formatted_broken_urls"
+              fi
 
   nightly_link_checker:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,49 @@ jobs:
         - run:
             name: Install dependencies
             command: yarn install --frozen-lockfile
+        # - run:
+        #     name: Build 
+        #     command: yarn build
+        # - run:
+        #     name: Run checks
+        #     command: ./scripts/yarn-checks-ci.sh
         - run:
-            name: Build 
+            name: Run script and capture logs
             command: yarn build
         - run:
-            name: Run checks
-            command: ./scripts/yarn-checks-ci.sh
+            name: Run link checker
+            command: yarn broken-link-checker:external > output.txt 2>&1 || true
+        - run:
+            name: Extract URLs from log
+            command: |
+              grep -o 'Link: https\?://[^[:space:]]*' output.txt | sed 's/Link: //' > urls.txt
+            when: always
+        - run:
+            name: Remove False Positives
+            command: |
+              comm -23 <(sort urls.txt | uniq) <(sort falsepos.txt | uniq) > broken_external_urls.txt
+        - run:
+            name: Print urls to log
+            command: |
+              cat broken_external_urls.txt
+        - run:
+            name: Send failure email if broken URLs found
+            when: on_success
+            command: |
+              broken_urls=($(comm -23 <(sort urls.txt | uniq) <(sort falsepos.txt | uniq)))
+              urls=$(echo "$broken_urls" | tr ' ' '\n')
+              hyperlinks=""
+              while IFS= read -r url; do               
+                  hyperlinks+="<a href=\"$url\">$url</a><br/>"
+              done <<< "$urls"
+              if [ -n "$broken_urls" ]; then
+                curl --location --request POST 'https://www.cinotify.cc/api/notify' \
+                          -d "to=${NOTIFY_EMAIL}&subject=FAILED: Dev Docs Nightly Job&type=text/html&body=<p style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center; background-color: #ffcccc; padding: 10px;'>
+                          <span style='font-weight: bold;'>Nightly link checker job failed. See the list of broken URLs below.</span><br><br>
+                          <a href='https://app.circleci.com/pipelines/github/okta/okta-developer-docs/<< pipeline.number >>' style='display: inline-block; padding: 5px 10px; background-color: #4caf50; color: white; text-decoration: none;'>Click here</a>
+                          to see job details.<br>
+                      </p><h2 style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center;'>List of broken URLs:</h2>$hyperlinks"
+              fi
 
   nightly_link_checker:
     docker:
@@ -59,14 +96,18 @@ jobs:
           when: on_success
           command: |
             broken_urls=($(comm -23 <(sort urls.txt | uniq) <(sort falsepos.txt | uniq)))
-            broken_urls=("${broken_urls[@]/%/<br/>}")
+            urls=$(echo "$broken_urls" | tr ' ' '\n')
+            hyperlinks=""
+            while IFS= read -r url; do               
+                hyperlinks+="<a href=\"$url\">$url</a><br/>"
+            done <<< "$urls"
             if [ -n "$broken_urls" ]; then
               curl --location --request POST 'https://www.cinotify.cc/api/notify' \
-                        -d "to=test-circleci-notif-aaaam4adaseamnmgdfiwsb4h3i@okta.org.slack.com&subject=FAILED: Dev Docs Nightly Job&type=text/html&body=<p style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center; background-color: #ffcccc; padding: 10px;'>
+                        -d "to=${NOTIFY_EMAIL}&subject=FAILED: Dev Docs Nightly Job&type=text/html&body=<p style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center; background-color: #ffcccc; padding: 10px;'>
                         <span style='font-weight: bold;'>Nightly link checker job failed. See the list of broken URLs below.</span><br><br>
                         <a href='https://app.circleci.com/pipelines/github/okta/okta-developer-docs/<< pipeline.number >>' style='display: inline-block; padding: 5px 10px; background-color: #4caf50; color: white; text-decoration: none;'>Click here</a>
                         to see job details.<br>
-                    </p><h2 style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center;'>List of broken URLs:</h2>$broken_urls"
+                    </p><h2 style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center;'>List of broken URLs:</h2>$hyperlinks"
             fi
   
   netlify_manual:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,34 +14,34 @@ jobs:
         NODE_OPTIONS: '--max_old_space_size=3584'
       steps:
         - checkout
-        - run:
-            name: Install dependencies
-            command: yarn install --frozen-lockfile
+        # - run:
+        #     name: Install dependencies
+        #     command: yarn install --frozen-lockfile
         # - run:
         #     name: Build 
         #     command: yarn build
         # - run:
         #     name: Run checks
         #     command: ./scripts/yarn-checks-ci.sh
-        - run:
-            name: Run script and capture logs
-            command: yarn build
-        - run:
-            name: Run link checker
-            command: yarn broken-link-checker:external > output.txt 2>&1 || true
-        - run:
-            name: Extract URLs from log
-            command: |
-              grep -o 'Link: https\?://[^[:space:]]*' output.txt | sed 's/Link: //' > urls.txt
-            when: always
-        - run:
-            name: Remove False Positives
-            command: |
-              comm -23 <(sort urls.txt | uniq) <(sort falsepos.txt | uniq) > broken_external_urls.txt
-        - run:
-            name: Print urls to log
-            command: |
-              cat broken_external_urls.txt
+        # - run:
+        #     name: Run script and capture logs
+        #     command: yarn build
+        # - run:
+        #     name: Run link checker
+        #     command: yarn broken-link-checker:external > output.txt 2>&1 || true
+        # - run:
+        #     name: Extract URLs from log
+        #     command: |
+        #       grep -o 'Link: https\?://[^[:space:]]*' output.txt | sed 's/Link: //' > urls.txt
+        #     when: always
+        # - run:
+        #     name: Remove False Positives
+        #     command: |
+        #       comm -23 <(sort urls.txt | uniq) <(sort falsepos.txt | uniq) > broken_external_urls.txt
+        # - run:
+        #     name: Print urls to log
+        #     command: |
+        #       cat broken_external_urls.txt
         - run:
             name: Send failure email if broken URLs found
             when: on_success

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,20 @@ jobs:
           name: Print urls to log
           command: |
             cat broken_external_urls.txt
+      - run:
+          name: Send failure email if broken URLs found
+          when: on_success
+          command: |
+            broken_urls=($(comm -23 <(sort urls.txt | uniq) <(sort falsepos.txt | uniq)))
+            broken_urls=("${broken_urls[@]/%/<br/>}")
+            if [ -n "$broken_urls" ]; then
+              curl --location --request POST 'https://www.cinotify.cc/api/notify' \
+                        -d "to=test-circleci-notif-aaaam4adaseamnmgdfiwsb4h3i@okta.org.slack.com&subject=FAILED: Dev Docs Nightly Job&type=text/html&body=<p style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center; background-color: #ffcccc; padding: 10px;'>
+                        <span style='font-weight: bold;'>Nightly link checker job failed. See the list of broken URLs below.</span><br><br>
+                        <a href='https://app.circleci.com/pipelines/github/okta/okta-developer-docs/<< pipeline.number >>' style='display: inline-block; padding: 5px 10px; background-color: #4caf50; color: white; text-decoration: none;'>Click here</a>
+                        to see job details.<br>
+                    </p><h2 style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center;'>List of broken URLs:</h2>$broken_urls"
+            fi
   
   netlify_manual:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,20 +46,8 @@ jobs:
             name: Send failure email if broken URLs found
             when: on_success
             command: |
-              broken_urls=($(comm -23 <(sort urls.txt | uniq) <(sort falsepos.txt | uniq)))
-              urls=$(echo "$broken_urls" | tr ' ' '\n')
-              hyperlinks=""
-              while IFS= read -r url; do               
-                  hyperlinks+="<a href=\"$url\">$url</a><br/>"
-              done <<< "$urls"
-              if [ -n "$broken_urls" ]; then
-                curl --location --request POST 'https://www.cinotify.cc/api/notify' \
-                          -d "to=${NOTIFY_EMAIL}&subject=FAILED: Dev Docs Nightly Job&type=text/html&body=<p style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center; background-color: #ffcccc; padding: 10px;'>
-                          <span style='font-weight: bold;'>Nightly link checker job failed. See the list of broken URLs below.</span><br><br>
-                          <a href='https://app.circleci.com/pipelines/github/okta/okta-developer-docs/<< pipeline.number >>' style='display: inline-block; padding: 5px 10px; background-color: #4caf50; color: white; text-decoration: none;'>Click here</a>
-                          to see job details.<br>
-                      </p><h2 style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center;'>List of broken URLs:</h2>$hyperlinks"
-              fi
+              chmod +x ./scripts/send-nightly-email.sh
+              ./scripts/send-nightly-email.sh
 
   nightly_link_checker:
     docker:
@@ -95,20 +83,8 @@ jobs:
           name: Send failure email if broken URLs found
           when: on_success
           command: |
-            broken_urls=($(comm -23 <(sort urls.txt | uniq) <(sort falsepos.txt | uniq)))
-            urls=$(echo "$broken_urls" | tr ' ' '\n')
-            hyperlinks=""
-            while IFS= read -r url; do               
-                hyperlinks+="<a href=\"$url\">$url</a><br/>"
-            done <<< "$urls"
-            if [ -n "$broken_urls" ]; then
-              curl --location --request POST 'https://www.cinotify.cc/api/notify' \
-                        -d "to=${NOTIFY_EMAIL}&subject=FAILED: Dev Docs Nightly Job&type=text/html&body=<p style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center; background-color: #ffcccc; padding: 10px;'>
-                        <span style='font-weight: bold;'>Nightly link checker job failed. See the list of broken URLs below.</span><br><br>
-                        <a href='https://app.circleci.com/pipelines/github/okta/okta-developer-docs/<< pipeline.number >>' style='display: inline-block; padding: 5px 10px; background-color: #4caf50; color: white; text-decoration: none;'>Click here</a>
-                        to see job details.<br>
-                    </p><h2 style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center;'>List of broken URLs:</h2>$hyperlinks"
-            fi
+            chmod +x ./scripts/send-nightly-email.sh
+            ./scripts/send-nightly-email.sh
   
   netlify_manual:
     docker:

--- a/falsepos.txt
+++ b/falsepos.txt
@@ -19,5 +19,13 @@ https://developer.spotify.com/documentation/general/guides/authorization/scopes/
 https://regionalevents.okta.com/enterprisereadyworkshops/
 https://app.getpostman.com/run-collection/1a927e3b353fd0e1b158/
 https://app.getpostman.com/run-collection/ff723148292df05bb58b/
+https://app.getpostman.com/run-collection/3295add9e852d8728ef2/
+https://app.getpostman.com/run-collection/519c04869c17079762f9/
+https://app.getpostman.com/run-collection/9daeb4b935a423c39009/
+https://app.getpostman.com/run-collection/c85985861f9b277913ae/
+https://app.getpostman.com/run-collection/f443644517abb15117af/
 https://csrc.nist.gov/pubs/sp/800/63/b/upd2/final/
 https://accounts.google.com/signup/
+https://8gwifi.org/jwkconvertfunctions.jsp
+https://okta.com/free-trial/workforce-identity/
+https://www.jsonwebtoken.dev/

--- a/falsepos.txt
+++ b/falsepos.txt
@@ -19,13 +19,5 @@ https://developer.spotify.com/documentation/general/guides/authorization/scopes/
 https://regionalevents.okta.com/enterprisereadyworkshops/
 https://app.getpostman.com/run-collection/1a927e3b353fd0e1b158/
 https://app.getpostman.com/run-collection/ff723148292df05bb58b/
-https://app.getpostman.com/run-collection/3295add9e852d8728ef2/
-https://app.getpostman.com/run-collection/519c04869c17079762f9/
-https://app.getpostman.com/run-collection/9daeb4b935a423c39009/
-https://app.getpostman.com/run-collection/c85985861f9b277913ae/
-https://app.getpostman.com/run-collection/f443644517abb15117af/
 https://csrc.nist.gov/pubs/sp/800/63/b/upd2/final/
 https://accounts.google.com/signup/
-https://8gwifi.org/jwkconvertfunctions.jsp
-https://okta.com/free-trial/workforce-identity/
-https://www.jsonwebtoken.dev/

--- a/scripts/send-nightly-email.sh
+++ b/scripts/send-nightly-email.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
-broken_urls=$(comm -23 <(sort urls.txt | uniq) <(sort falsepos.txt | uniq))
+# broken_urls=$(comm -23 <(sort urls.txt | uniq) <(sort falsepos.txt | uniq))
 
-# Use sed to replace spaces with newlines
-broken_urls=$(echo "$broken_urls" | sed 's/ /\n/g')
+# # Use sed to replace spaces with newlines
+# broken_urls=$(echo "$broken_urls" | sed 's/ /\n/g')
 
-# Use awk to format each URL into an HTML anchor tag with line break
-formatted_broken_urls=$(echo "$broken_urls" | awk '{printf "<a href=\"%s\">%s</a><br/>\n", $0, $0}')
+# # Use awk to format each URL into an HTML anchor tag with line break
+# formatted_broken_urls=$(echo "$broken_urls" | awk '{printf "<a href=\"%s\">%s</a><br/>\n", $0, $0}')
 
-if [ -n "$formatted_broken_urls" ]; then
+# if [ -n "$formatted_broken_urls" ]; then
     curl --location --request POST 'https://www.cinotify.cc/api/notify' \
             -d "to=${NOTIFY_EMAIL}&subject=FAILED: Dev Docs Nightly Job&type=text/html&body=<p style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center; background-color: #ffcccc; padding: 10px;'>
             <span style='font-weight: bold;'>Nightly link checker job failed. See the list of broken URLs below.</span><br><br>
-            <a href='https://app.circleci.com/pipelines/github/okta/okta-developer-docs/<< pipeline.number >>' style='display: inline-block; padding: 5px 10px; background-color: #4caf50; color: white; text-decoration: none;'>Click here</a>
+            <a href='https://app.circleci.com/pipelines/github/okta/okta-developer-docs/${pipeline.number}' style='display: inline-block; padding: 5px 10px; background-color: #4caf50; color: white; text-decoration: none;'>Click here</a>
             to see job details.<br>
         </p><h2 style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center;'>List of broken URLs:</h2>$formatted_broken_urls"
-fi
+# fi

--- a/scripts/send-nightly-email.sh
+++ b/scripts/send-nightly-email.sh
@@ -8,11 +8,13 @@
 # # Use awk to format each URL into an HTML anchor tag with line break
 # formatted_broken_urls=$(echo "$broken_urls" | awk '{printf "<a href=\"%s\">%s</a><br/>\n", $0, $0}')
 
+PIPELINE_NUMBER=${pipeline.number} 
+
 # if [ -n "$formatted_broken_urls" ]; then
 curl --location --request POST 'https://www.cinotify.cc/api/notify' \
         -d "to=${NOTIFY_EMAIL}&subject=FAILED: Dev Docs Nightly Job&type=text/html&body=<p style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center; background-color: #ffcccc; padding: 10px;'>
         <span style='font-weight: bold;'>Nightly link checker job failed. See the list of broken URLs below.</span><br><br>
-        <a href='https://app.circleci.com/pipelines/github/okta/okta-developer-docs/${pipeline.number}' style='display: inline-block; padding: 5px 10px; background-color: #4caf50; color: white; text-decoration: none;'>Click here</a>
+        <a href='https://app.circleci.com/pipelines/github/okta/okta-developer-docs/${PIPELINE_NUMBER}' style='display: inline-block; padding: 5px 10px; background-color: #4caf50; color: white; text-decoration: none;'>Click here</a>
         to see job details.<br>
     </p><h2 style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center;'>List of broken URLs:</h2>$formatted_broken_urls"
 # fi

--- a/scripts/send-nightly-email.sh
+++ b/scripts/send-nightly-email.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
 broken_urls=($(comm -23 <(sort urls.txt | uniq) <(sort falsepos.txt | uniq)))
-urls=$(echo "$broken_urls" | tr ' ' '\n')
-hyperlinks=""
-while IFS= read -r url; do
-    hyperlinks+="<a href=\"$url\">$url</a><br/>"
-done <<< "$urls"
-
+echo $broken_urls
+for ((i=0; i<${#broken_urls[@]}; i++)); do
+    broken_urls[$i]="<a href=\"${broken_urls[$i]}\">${broken_urls[$i]}</a><br/>"
+done
+echo $broken_urls
 if [ -n "$broken_urls" ]; then
     curl --location --request POST 'https://www.cinotify.cc/api/notify' \
             -d "to=${NOTIFY_EMAIL}&subject=FAILED: Dev Docs Nightly Job&type=text/html&body=<p style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center; background-color: #ffcccc; padding: 10px;'>

--- a/scripts/send-nightly-email.sh
+++ b/scripts/send-nightly-email.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
 
-broken_urls=($(comm -23 <(sort urls.txt | uniq) <(sort falsepos.txt | uniq)))
-echo $broken_urls
-for ((i=0; i<${#broken_urls[@]}; i++)); do
-    broken_urls[$i]="<a href=\"${broken_urls[$i]}\">${broken_urls[$i]}</a><br/>"
-done
-echo $broken_urls
-if [ -n "$broken_urls" ]; then
+broken_urls=$(comm -23 <(sort urls.txt | uniq) <(sort falsepos.txt | uniq))
+
+# Use sed to replace spaces with newlines
+broken_urls=$(echo "$broken_urls" | sed 's/ /\n/g')
+
+# Use awk to format each URL into an HTML anchor tag with line break
+formatted_broken_urls=$(echo "$broken_urls" | awk '{printf "<a href=\"%s\">%s</a><br/>\n", $0, $0}')
+
+if [ -n "$formatted_broken_urls" ]; then
     curl --location --request POST 'https://www.cinotify.cc/api/notify' \
             -d "to=${NOTIFY_EMAIL}&subject=FAILED: Dev Docs Nightly Job&type=text/html&body=<p style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center; background-color: #ffcccc; padding: 10px;'>
             <span style='font-weight: bold;'>Nightly link checker job failed. See the list of broken URLs below.</span><br><br>
             <a href='https://app.circleci.com/pipelines/github/okta/okta-developer-docs/<< pipeline.number >>' style='display: inline-block; padding: 5px 10px; background-color: #4caf50; color: white; text-decoration: none;'>Click here</a>
             to see job details.<br>
-        </p><h2 style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center;'>List of broken URLs:</h2>$hyperlinks"
+        </p><h2 style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center;'>List of broken URLs:</h2>$formatted_broken_urls"
 fi

--- a/scripts/send-nightly-email.sh
+++ b/scripts/send-nightly-email.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+broken_urls=($(comm -23 <(sort urls.txt | uniq) <(sort falsepos.txt | uniq)))
+urls=$(echo "$broken_urls" | tr ' ' '\n')
+hyperlinks=""
+while IFS= read -r url; do
+    hyperlinks+="<a href=\"$url\">$url</a><br/>"
+done <<< "$urls"
+
+if [ -n "$broken_urls" ]; then
+    curl --location --request POST 'https://www.cinotify.cc/api/notify' \
+            -d "to=${NOTIFY_EMAIL}&subject=FAILED: Dev Docs Nightly Job&type=text/html&body=<p style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center; background-color: #ffcccc; padding: 10px;'>
+            <span style='font-weight: bold;'>Nightly link checker job failed. See the list of broken URLs below.</span><br><br>
+            <a href='https://app.circleci.com/pipelines/github/okta/okta-developer-docs/<< pipeline.number >>' style='display: inline-block; padding: 5px 10px; background-color: #4caf50; color: white; text-decoration: none;'>Click here</a>
+            to see job details.<br>
+        </p><h2 style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center;'>List of broken URLs:</h2>$hyperlinks"
+fi

--- a/scripts/send-nightly-email.sh
+++ b/scripts/send-nightly-email.sh
@@ -9,10 +9,10 @@
 # formatted_broken_urls=$(echo "$broken_urls" | awk '{printf "<a href=\"%s\">%s</a><br/>\n", $0, $0}')
 
 # if [ -n "$formatted_broken_urls" ]; then
-    curl --location --request POST 'https://www.cinotify.cc/api/notify' \
-            -d "to=${NOTIFY_EMAIL}&subject=FAILED: Dev Docs Nightly Job&type=text/html&body=<p style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center; background-color: #ffcccc; padding: 10px;'>
-            <span style='font-weight: bold;'>Nightly link checker job failed. See the list of broken URLs below.</span><br><br>
-            <a href='https://app.circleci.com/pipelines/github/okta/okta-developer-docs/${pipeline.number}' style='display: inline-block; padding: 5px 10px; background-color: #4caf50; color: white; text-decoration: none;'>Click here</a>
-            to see job details.<br>
-        </p><h2 style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center;'>List of broken URLs:</h2>$formatted_broken_urls"
+curl --location --request POST 'https://www.cinotify.cc/api/notify' \
+        -d "to=${NOTIFY_EMAIL}&subject=FAILED: Dev Docs Nightly Job&type=text/html&body=<p style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center; background-color: #ffcccc; padding: 10px;'>
+        <span style='font-weight: bold;'>Nightly link checker job failed. See the list of broken URLs below.</span><br><br>
+        <a href='https://app.circleci.com/pipelines/github/okta/okta-developer-docs/${pipeline.number}' style='display: inline-block; padding: 5px 10px; background-color: #4caf50; color: white; text-decoration: none;'>Click here</a>
+        to see job details.<br>
+    </p><h2 style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center;'>List of broken URLs:</h2>$formatted_broken_urls"
 # fi

--- a/scripts/send-nightly-email.sh
+++ b/scripts/send-nightly-email.sh
@@ -8,7 +8,7 @@
 # # Use awk to format each URL into an HTML anchor tag with line break
 # formatted_broken_urls=$(echo "$broken_urls" | awk '{printf "<a href=\"%s\">%s</a><br/>\n", $0, $0}')
 
-PIPELINE_NUMBER=${pipeline.number} 
+PIPELINE_NUMBER="<< pipeline.number >>"
 
 # if [ -n "$formatted_broken_urls" ]; then
 curl --location --request POST 'https://www.cinotify.cc/api/notify' \

--- a/scripts/send-nightly-email.sh
+++ b/scripts/send-nightly-email.sh
@@ -8,7 +8,7 @@
 # # Use awk to format each URL into an HTML anchor tag with line break
 # formatted_broken_urls=$(echo "$broken_urls" | awk '{printf "<a href=\"%s\">%s</a><br/>\n", $0, $0}')
 
-PIPELINE_NUMBER="<< pipeline.number >>"
+PIPELINE_NUMBER=<< pipeline.number >>
 
 # if [ -n "$formatted_broken_urls" ]; then
 curl --location --request POST 'https://www.cinotify.cc/api/notify' \


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** This PR contains changes to send notification email to slack channel #test-circleci-notif (temporary) when the nightly job catches any broken urls in dev docs.
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-726318](https://oktainc.atlassian.net/browse/OKTA-726318)
