### PR TITLE
OKTA-726318 - Added step to send failure email on nightly job failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,22 @@ jobs:
           name: Print urls to log
           command: |
             cat broken_external_urls.txt
+      - run:
+          name: Send failure email if broken URLs found
+          when: on_success
+          command: |
+            broken_urls=$(comm -23 <(sort urls.txt | uniq) <(sort falsepos.txt | uniq))
+            broken_urls=$(echo "$broken_urls" | sed 's/ /\n/g')
+            formatted_broken_urls=$(echo "$broken_urls" | awk '{printf "<a href=\"%s\">%s</a><br/>\n", $0, $0}')
+            
+            if [ -n "$broken_urls" ]; then
+                curl --location --request POST 'https://www.cinotify.cc/api/notify' \
+                        -d "to=${NOTIFY_EMAIL}&subject=FAILED: Dev Docs Nightly Job&type=text/html&body=<p style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center; background-color: #ffcccc; padding: 10px;'>
+                        <span style='font-weight: bold;'>Nightly link checker job failed. See the list of broken URLs below.</span><br><br>
+                        <a href='https://app.circleci.com/pipelines/github/okta/okta-developer-docs/<< pipeline.number >>' style='display: inline-block; padding: 5px 10px; background-color: #4caf50; color: white; text-decoration: none;'>Click here</a>
+                        to see job details.<br>
+                    </p><h2 style='font-family: Arial, sans-serif; font-size: 16px; color: #333; line-height: 1.6; text-align: center;'>List of broken URLs:</h2>$formatted_broken_urls"
+            fi
   
   netlify_manual:
     docker:


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** This PR contains changes to send notification email to slack channel #test-circleci-notif (temporary) when the nightly job catches any broken urls in dev docs.
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-726318](https://oktainc.atlassian.net/browse/OKTA-726318)
