### PR TITLE
[OKTA-726234]: Add preview link to PRs on netlify manual build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,12 @@ jobs:
       - run:
           name: Deploy preview to Netlify
           command: |
-            netlify deploy --filter @okta/vuepress-site
+            netlify deploy --alias=preview-${CIRCLE_PULL_REQUEST##*/} --filter @okta/vuepress-site
+      - run:
+          name: Update PR with preview link
+          command: |
+            chmod +x ./scripts/update-dev-docs-pr-cci.sh
+            ./scripts/update-dev-docs-pr-cci.sh
 
 orbs:
   general-platform-helpers: okta/general-platform-helpers@1.8

--- a/scripts/update-dev-docs-pr-cci.sh
+++ b/scripts/update-dev-docs-pr-cci.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+export PR_DETAILS=$(curl -s \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer ${OKTA_GH_TOKEN}" \
+    https://api.github.com/repos/okta/okta-developer-docs/pulls?head="okta:${CIRCLE_BRANCH}")
+
+export PR_NUMBER=$(echo ${PR_DETAILS} | jq -r '.[0].number')
+
+TARGET_NAME=""
+
+if [ "${URL}" != "null" ]; then
+    TARGET_NAME="https://preview-${PR_NUMBER}--reverent-murdock-829d24.netlify.app"
+    ALL_COMMENTS=$(curl -L \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer ${OKTA_GH_TOKEN}" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        https://api.github.com/repos/okta/okta-developer-docs/issues/${PR_NUMBER}/comments)
+    
+    ALL_COMMENTS_JSON=$(cat <<EOF
+${ALL_COMMENTS}
+EOF
+)
+    # Filter comments by github okta bot on the PR.
+    okta_gh_bot_comments=$(echo "$ALL_COMMENTS_JSON" | jq '[.[] | select(.user.id == 164419112)]')
+    count_of_okta_gh_bot_comments=$(echo "$okta_gh_bot_comments" | jq 'length')
+    okta_gh_bot_comments_with_preview_link=$(echo "$okta_gh_bot_comments" | jq '.[] | select(.body | contains("Preview URL for the changes:"))')
+    okta_gh_bot_comments_with_preview_link_length=$(echo "$okta_gh_bot_comments_with_preview_link" | jq 'length')
+
+    # Add the preview link only if there are no previous comments by the gh bot containing preview link on the PR since the preview link will remain the same everytime.
+    if [[ "$okta_gh_bot_comments_with_preview_link_length" -eq 0 ]]; then
+        echo Adding preview link to PR
+        curl -L -s \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${OKTA_GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/okta/okta-developer-docs/issues/${PR_NUMBER}/comments \
+            -d '{"body":"Netlify Preview URL for the changes: '"${TARGET_NAME}"'"}'
+    fi
+else
+    echo There is no PR associated with ${CIRCLE_BRANCH}
+fi
+
+echo Preview Link: ${TARGET_NAME}


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Adds a PR comment from gh okta bot containing netlify preview URL of the changes whenever anyone triggers netlify manual job on circleci on the topic branch.
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-726234](https://oktainc.atlassian.net/browse/OKTA-726234)
