### PR TITLE
OKTA-520454 SCIM reference update for the GET /Groups with filtering request

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/scim/scim-11/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/scim/scim-11/index.md
@@ -641,6 +641,10 @@ The response to this request is a JSON list of all the Group objects found in th
 You must also implement filtering results with the `eq` (equals) operator on your SCIM server.
 Okta checks that the Group object exists on the SCIM server through a GET method request with the `filter=displayName eq "${groupName}"` path parameter. This check is performed using the `eq` (equal) operator against the group name on the target app.
 
+Okta uses the `GET /Groups` request with `displayName` filtering when you want to update a group, but the external group ID isn't known.
+
+> **Note:** One case where the external group ID isn't known is when admins configure the provisioning app integration and unselects the **Import Groups** checkbox. See [Configure provisioning for an app integration](https://help.okta.com/okta_help.htm?id=ext_prov_lcm_prov_app).
+
 The following is an example of a request to the SCIM server:
 
 ```http

--- a/packages/@okta/vuepress-site/docs/reference/scim/scim-11/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/scim/scim-11/index.md
@@ -639,11 +639,11 @@ Authorization: <Authorization credentials>
 The response to this request is a JSON list of all the Group objects found in the SCIM application.
 
 You must also implement filtering results with the `eq` (equals) operator on your SCIM server.
-Okta checks that the Group object exists on the SCIM server through a GET method request with the `filter=displayName eq "${groupName}"` path parameter. This check is performed using the `eq` (equal) operator against the group name on the target app.
+Okta checks that the Group object exists on the SCIM server through a GET method request with the `filter=displayName eq "${groupName}"` path parameter, where `groupName` is the group name on the target app.
 
-Okta uses the `GET /Groups` request with `displayName` filtering when you want to update a group, but the external group ID isn't known.
+Okta uses the `GET /Groups` request with a group name filter when you want to update a group, but the external group ID isn't known.
 
-> **Note:** One case where the external group ID isn't known is when admins configure the provisioning app integration and unselect the **Import Groups** checkbox. See [Configure provisioning for an app integration](https://help.okta.com/okta_help.htm?id=ext_prov_lcm_prov_app).
+> **Note:** One case where the external group ID isn't known is when admins configure the provisioning app integration and clear the **Import Groups** checkbox. See [Configure provisioning for an app integration](https://help.okta.com/okta_help.htm?id=ext_prov_lcm_prov_app).
 
 The following is an example of a request to the SCIM server:
 

--- a/packages/@okta/vuepress-site/docs/reference/scim/scim-11/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/scim/scim-11/index.md
@@ -643,7 +643,7 @@ Okta checks that the Group object exists on the SCIM server through a GET method
 
 Okta uses the `GET /Groups` request with `displayName` filtering when you want to update a group, but the external group ID isn't known.
 
-> **Note:** One case where the external group ID isn't known is when admins configure the provisioning app integration and unselects the **Import Groups** checkbox. See [Configure provisioning for an app integration](https://help.okta.com/okta_help.htm?id=ext_prov_lcm_prov_app).
+> **Note:** One case where the external group ID isn't known is when admins configure the provisioning app integration and unselect the **Import Groups** checkbox. See [Configure provisioning for an app integration](https://help.okta.com/okta_help.htm?id=ext_prov_lcm_prov_app).
 
 The following is an example of a request to the SCIM server:
 

--- a/packages/@okta/vuepress-site/docs/reference/scim/scim-20/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/scim/scim-20/index.md
@@ -602,11 +602,11 @@ Authorization: <Authorization credentials>
 The response to this request is a JSON list of all the Group objects found in the SCIM application.
 
 You must also implement filtering results with the `eq` (equals) operator on your SCIM server.
-Okta checks that the Group object exists on the SCIM server through a GET method request with the `filter=displayName eq "${groupName}"` path parameter. This check is performed using the `eq` (equal) operator against the group name on the target app.
+Okta checks that the Group object exists on the SCIM server through a GET method request with the `filter=displayName eq "${groupName}"` path parameter, where `groupName` is the group name on the target app.
 
-Okta uses the `GET /Groups` request with `displayName` filtering when you want to update a group, but the external group ID isn't known.
+Okta uses the `GET /Groups` request with a group name filter when you want to update a group, but the external group ID isn't known.
 
-> **Note:** One case where the external group ID isn't known is when admins configure the provisioning app integration and unselect the **Import Groups** checkbox. See [Configure provisioning for an app integration](https://help.okta.com/okta_help.htm?id=ext_prov_lcm_prov_app).
+> **Note:** One case where the external group ID isn't known is when admins configure the provisioning app integration and clear the **Import Groups** checkbox. See [Configure provisioning for an app integration](https://help.okta.com/okta_help.htm?id=ext_prov_lcm_prov_app).
 
 The following is an example of a request to the SCIM server:
 

--- a/packages/@okta/vuepress-site/docs/reference/scim/scim-20/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/scim/scim-20/index.md
@@ -606,7 +606,7 @@ Okta checks that the Group object exists on the SCIM server through a GET method
 
 Okta uses the `GET /Groups` request with `displayName` filtering when you want to update a group, but the external group ID isn't known.
 
-> **Note:** One case where the external group ID isn't known is when admins configure the provisioning app integration and unselects the **Import Groups** checkbox. See [Configure provisioning for an app integration](https://help.okta.com/okta_help.htm?id=ext_prov_lcm_prov_app).
+> **Note:** One case where the external group ID isn't known is when admins configure the provisioning app integration and unselect the **Import Groups** checkbox. See [Configure provisioning for an app integration](https://help.okta.com/okta_help.htm?id=ext_prov_lcm_prov_app).
 
 The following is an example of a request to the SCIM server:
 

--- a/packages/@okta/vuepress-site/docs/reference/scim/scim-20/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/scim/scim-20/index.md
@@ -604,6 +604,10 @@ The response to this request is a JSON list of all the Group objects found in th
 You must also implement filtering results with the `eq` (equals) operator on your SCIM server.
 Okta checks that the Group object exists on the SCIM server through a GET method request with the `filter=displayName eq "${groupName}"` path parameter. This check is performed using the `eq` (equal) operator against the group name on the target app.
 
+Okta uses the `GET /Groups` request with `displayName` filtering when you want to update a group, but the external group ID isn't known.
+
+> **Note:** One case where the external group ID isn't known is when admins configure the provisioning app integration and unselects the **Import Groups** checkbox. See [Configure provisioning for an app integration](https://help.okta.com/okta_help.htm?id=ext_prov_lcm_prov_app).
+
 The following is an example of a request to the SCIM server:
 
 ```http


### PR DESCRIPTION
## Description:
- **What's changed?**  SCIM reference: Add when Okta calls the GET /Groups with filtering request
- **Is this PR related to a Monolith release?** No

### Preview:
![image](https://github.com/okta/okta-developer-docs/assets/80703015/3526f063-6935-42de-97ff-392df0502060)

https://preview-4854--reverent-murdock-829d24.netlify.app/docs/reference/scim/scim-20/#retrieve-groups

### Resolves:

* [OKTA-520454](https://oktainc.atlassian.net/browse/OKTA-520454)
