### PR TITLE
Fix-It Days: Placeholder revert on Velocity Templating Language

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/custom-email/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-email/main/index.md
@@ -266,7 +266,7 @@ To delete all custom translations and revert to the Okta template, click **Reset
 - All attributes in the Okta [User Profile object](/docs/reference/api/users/#profile-object)
 - Some of the org attributes in the VTL variables
 
-Email templates use both common and unique VTL variables. When you interpolate variables in the template, precede them with a dollar sign. Use dot notation to reference subobjects. For example, reference the first name of a user with `{user.profile.firstName}`.
+Email templates use both common and unique VTL variables. When you interpolate variables in the template, precede them with a dollar sign. Use dot notation to reference subobjects. For example, reference the first name of a user with `${user.profile.firstName}`.
 
 See [Use VTL variables](#use-vtl-variables) for available email template variables.
 
@@ -276,17 +276,17 @@ In your email templates, you can use any conditional logic that VTL supports, su
 
 ### Customization example
 
-The following example uses the `{app.name}` variable, which is only available in Identity Engine.
+The following example uses the `${app.name}` variable, which is only available in Identity Engine.
 
 ```html
-#if({app.name} == "Toys R' Fun")
+#if(${app.name} == "Toys R' Fun")
 <img src="https://cdn.toysrfun.com/logo" height="37">
 <a id="support-link" href="https://support.toysrfun.com/help/?language=en_US" style="text-decoration: none;"> Contact Toy Support </a>
-#elseif({app.name} == "Fidget Spinners Unlimited")
+#elseif(${app.name} == "Fidget Spinners Unlimited")
 <img src="https://cdn.fidgetsu.com/logo" height="37">
 <a id="support-link" href="https://support.fidgetsu.com/help/?language=en_US" style="text-decoration: none;"> Contact Fidget SU Support </a>
 #else
-<img src="{parentLogoUrl}" height="37">
+<img src="${parentLogoUrl}" height="37">
 #end
 ```
 
@@ -298,70 +298,70 @@ You can reference any Okta User Profile attribute in your email templates.
 
 | Variable       | Template availability         |
 |---------------------------------------------------------------|------------------------------------------------------------------------|
-| `{user.profile.login}` | Available in all templates |
-| `{user.profile.email}` | Available in all templates |
-| `{user.profile.secondEmail}` | Available in all templates |
-| `{user.profile.firstName}` | Available in all templates |
-| `{user.profile.lastName}` | Available in all templates |
-| `{user.profile.locale}` | Available in all templates |
-| `{user.profile.mobilePhone}` | Available in all templates |
-| `{user.profile.primaryPhone}` | Available in all templates |
-| `{user.profile.username}` | Available in all templates |
-| `{user.profile.fullName}` | Available in all templates |
-| `{user.profile.city}` | Available in all templates |
-| `{user.profile.state}` | Available in all templates |
-| `{user.profile.streetAddress}` | Available in all templates |
-| `{user.profile.zipCode}` | Available in all templates |
-| `{user.profile.countryCode}` | Available in all templates |
-| `{user.groups.names}` | Available in all templates |
-| `{user.groups.ids}` | Available in all templates |
-| `{app.id}` | Available in all templates</br></br><ApiLifecycle access="ie" /> |
-| `{app.name}` | Available in all templates</br></br><ApiLifecycle access="ie" /> |
-| `{app.label}` | Available in all templates</br></br><ApiLifecycle access="ie" /> |
-| `{org.name}` | Available in all templates |
-| `{org.locale}` | Available in all templates |
-| `{org.subDomain}` | Available in all templates |
-| `{org.activationTokenExpirationHours}` | Available in all templates |
-| `{baseURL}` | Available in all templates |
-| `{oktaLogoUrl}` | Available in all templates |
-| `{activationLink}` | Available in these templates:</br><ul><li>User Activation</li><li>Active Directory User Activation</li><li>Registration - Activation</li></ul> |
-| `{activationToken}` | Available in these templates:</br><ul><li>User Activation</li><li>Active Directory User Activation</li><li>Registration - Activation</li></ul> |
-| `{samAccountName}` | Available in these templates:</br><ul><li>Active Directory User Activation</li><li>Active Directory Password Reset</li><li>Active Directory Self-Service Unlock Account</li><li>Active Directory Password Unlock</li><li>Active Directory Self-Service Unlock Account</li></ul> |
-| `{technicalContact.login}` | Available in these templates:</br><ul><li>User Activation</li><li>Password Reset by Admin</li></ul> |
-| `{technicalContact.email}` | Available in these templates:</br><ul><li>User Activation</li><li>Password Reset by Admin</li></ul> |
-| `{technicalContact.secondEmail}` | Available in these templates:</br><ul><li>User Activation</li><li>Password Reset by Admin</li></ul> |
-| `{technicalContact.firstName}` | Available in these templates:</br><ul><li>User Activation</li><li>Password Reset by Admin</li></ul> |
-| `{technicalContact.lastName}` | Available in these templates:</br><ul><li>User Activation</li><li>Password Reset by Admin</li></ul> |
-| `{technicalContact.locale}` | Available in these templates:</br><ul><li>User Activation</li><li>Password Reset by Admin</li></ul> |
-| `{technicalContact.fullName}` | Available in Password Reset by Admin |
-| `{pushVerifyActivationLink}` | Available in Send Push Verify Activation Link |
-| `{androidOktaVerifyAppLink}` | Available in Send Push Verify Activation Link |
-| `{iosOktaVerifyAppLink}` | Available in Send Push Verify Activation Link |
-| `{registrationEmailVerificationLink}` | Available in these templates:</br><ul><li>Registration - Email Verification</li><li>Registration - Activation</li></ul> |
-| `{registrationEmailVerificationToken}` | Available in these templates:</br><ul><li>Registration - Email Verification</li><li>Registration - Activation</li></ul> |
-| `{instanceDisplayName}` | Available in these templates:</br><ul><li>Email Factor Verification</li><li>Registration - Email Verification</li><li>Registration - Activation</li></ul> |
-| `{unlockAccountLink}` | Available in these templates:</br><ul><li>Self-Service Unlock Account</li><li>Active Directory Self-Service Unlock Account</li><li>Active Directory Password Unlock</li><li>LDAP Self-Service Unlock Account</li><li>LDAP Self-Service Unlock Account</li></ul> |
-| `{recoveryLink}` | Available in these templates:</br><ul><li>Reset Factor</li><li>Active Directory Password Reset</li><li>Unlock Factor</li></ul> |
-| `{factorDisplayName}` | Available in these templates:</br><ul><li>Reset Factor</li><li>Active Directory Password Reset</li><li>Unlock Factor</li></ul> |
-| `{orgTechSupportEmail}` | Available in these templates:</br><ul><li>Reset Factor</li><li>Active Directory Password Reset</li><li>Unlock Factor</li></ul> |
-| `{unlockAccountTokenExpirationDate}` | Available in these templates:</br><ul><li>Self-Service Unlock Account</li><li>Active Directory Self-Service Unlock Account</li><li>Active Directory Password Unlock</li><li>LDAP Self-Service Unlock Account</li><li>LDAP Self-Service Unlock Account</li></ul> |
-| `{resetPasswordLink}` | Available in these templates:</br><ul><li>Forgot Password</li><li>Forgot Password Denied</li><li>Active Directory Reset Password</li><li>LDAP Forgot Password</li><li>LDAP Forgot Password Denied</li><li>Password Reset by Admin</li></ul> |
-| `{oneTimePassword}` | Available in these templates:</br><ul><li>Forgot Password</li><li>Active Directory Password Reset</li><li>LDAP Forgot Password</li><li>Self-Service Unlock Account</li><li>Active Directory Self-Service Unlock Account</li><li>LDAP Self-Service Unlock Account</li></ul> |
-| `{resetPasswordTokenExpirationDate}` | Available in these templates:</br><ul><li>Forgot Password</li><li>Forgot Password Denied</li><li>Active Directory Password Reset</li><li>LDAP Forgot Password</li><li>LDAP Forgot Password Denied</li></ul> |
-| `{request.date}` | Available in Authenticator Enrolled |
-| `{request.time}` | Available in these templates:</br><ul><li>Authenticator Enrolled</li><li>Authenticator Reset</li><li>Factor Enrolled</li><li>Factor Reset</li><li>Sign In From New Device</li></ul> |
-| `{request.location}` | Available in Authenticator Enrolled |
-| `{request.performedBySubject}` | Available in Authenticator Enrolled |
-| `{request.factor}` | Available in Factor Enrolled |
-| `{request.factors}` | Available in Factor Reset |
-| `{request.ipAddress}` | Available in Sign In From New Device |
-| `{request.reportSuspiciousActivityToken}` | Available in Authenticator Enrolled (with Report Suspicious Activity button) |
-| `{request.browser}` | Available in Sign In From New Device |
-| `{request.relayState}` | Available in these templates:</br><ul><li>Registration Activation</li><li>Forgot Password</li><li>Email Challenge</li><li>Email Factor Verification</li><li>Self-Service Unlock Account</li></ul> |
-| `{request.verificationLink}` | Available in Email Factor Verification |
-| `{verificationToken}` | Available in these templates:</br><ul><li>Email Challenge</li><li>Activation</li><li>Registration - Email Verification</li><li>Change Email Confirmation</li></ul> |
-| `{emailAuthenticationLink}` | Available in Email Challenge |
-| `{email}` | Available in these templates:</br><ul><li>Email Challenge</li><li>Email Factor Verification</li></ul> |
+| `${user.profile.login}` | Available in all templates |
+| `${user.profile.email}` | Available in all templates |
+| `${user.profile.secondEmail}` | Available in all templates |
+| `${user.profile.firstName}` | Available in all templates |
+| `${user.profile.lastName}` | Available in all templates |
+| `${user.profile.locale}` | Available in all templates |
+| `${user.profile.mobilePhone}` | Available in all templates |
+| `${user.profile.primaryPhone}` | Available in all templates |
+| `${user.profile.username}` | Available in all templates |
+| `${user.profile.fullName}` | Available in all templates |
+| `${user.profile.city}` | Available in all templates |
+| `${user.profile.state}` | Available in all templates |
+| `${user.profile.streetAddress}` | Available in all templates |
+| `${user.profile.zipCode}` | Available in all templates |
+| `${user.profile.countryCode}` | Available in all templates |
+| `${user.groups.names}` | Available in all templates |
+| `${user.groups.ids}` | Available in all templates |
+| `${app.id}` | Available in all templates</br></br><ApiLifecycle access="ie" /> |
+| `${app.name}` | Available in all templates</br></br><ApiLifecycle access="ie" /> |
+| `${app.label}` | Available in all templates</br></br><ApiLifecycle access="ie" /> |
+| `${org.name}` | Available in all templates |
+| `${org.locale}` | Available in all templates |
+| `${org.subDomain}` | Available in all templates |
+| `${org.activationTokenExpirationHours}` | Available in all templates |
+| `${baseURL}` | Available in all templates |
+| `${oktaLogoUrl}` | Available in all templates |
+| `${activationLink}` | Available in these templates:</br><ul><li>User Activation</li><li>Active Directory User Activation</li><li>Registration - Activation</li></ul> |
+| `${activationToken}` | Available in these templates:</br><ul><li>User Activation</li><li>Active Directory User Activation</li><li>Registration - Activation</li></ul> |
+| `${samAccountName}` | Available in these templates:</br><ul><li>Active Directory User Activation</li><li>Active Directory Password Reset</li><li>Active Directory Self-Service Unlock Account</li><li>Active Directory Password Unlock</li><li>Active Directory Self-Service Unlock Account</li></ul> |
+| `${technicalContact.login}` | Available in these templates:</br><ul><li>User Activation</li><li>Password Reset by Admin</li></ul> |
+| `${technicalContact.email}` | Available in these templates:</br><ul><li>User Activation</li><li>Password Reset by Admin</li></ul> |
+| `${technicalContact.secondEmail}` | Available in these templates:</br><ul><li>User Activation</li><li>Password Reset by Admin</li></ul> |
+| `${technicalContact.firstName}` | Available in these templates:</br><ul><li>User Activation</li><li>Password Reset by Admin</li></ul> |
+| `${technicalContact.lastName}` | Available in these templates:</br><ul><li>User Activation</li><li>Password Reset by Admin</li></ul> |
+| `${technicalContact.locale}` | Available in these templates:</br><ul><li>User Activation</li><li>Password Reset by Admin</li></ul> |
+| `${technicalContact.fullName}` | Available in Password Reset by Admin |
+| `${pushVerifyActivationLink}` | Available in Send Push Verify Activation Link |
+| `${androidOktaVerifyAppLink}` | Available in Send Push Verify Activation Link |
+| `${iosOktaVerifyAppLink}` | Available in Send Push Verify Activation Link |
+| `${registrationEmailVerificationLink}` | Available in these templates:</br><ul><li>Registration - Email Verification</li><li>Registration - Activation</li></ul> |
+| `${registrationEmailVerificationToken}` | Available in these templates:</br><ul><li>Registration - Email Verification</li><li>Registration - Activation</li></ul> |
+| `${instanceDisplayName}` | Available in these templates:</br><ul><li>Email Factor Verification</li><li>Registration - Email Verification</li><li>Registration - Activation</li></ul> |
+| `${unlockAccountLink}` | Available in these templates:</br><ul><li>Self-Service Unlock Account</li><li>Active Directory Self-Service Unlock Account</li><li>Active Directory Password Unlock</li><li>LDAP Self-Service Unlock Account</li><li>LDAP Self-Service Unlock Account</li></ul> |
+| `${recoveryLink}` | Available in these templates:</br><ul><li>Reset Factor</li><li>Active Directory Password Reset</li><li>Unlock Factor</li></ul> |
+| `${factorDisplayName}` | Available in these templates:</br><ul><li>Reset Factor</li><li>Active Directory Password Reset</li><li>Unlock Factor</li></ul> |
+| `${orgTechSupportEmail}` | Available in these templates:</br><ul><li>Reset Factor</li><li>Active Directory Password Reset</li><li>Unlock Factor</li></ul> |
+| `${unlockAccountTokenExpirationDate}` | Available in these templates:</br><ul><li>Self-Service Unlock Account</li><li>Active Directory Self-Service Unlock Account</li><li>Active Directory Password Unlock</li><li>LDAP Self-Service Unlock Account</li><li>LDAP Self-Service Unlock Account</li></ul> |
+| `${resetPasswordLink}` | Available in these templates:</br><ul><li>Forgot Password</li><li>Forgot Password Denied</li><li>Active Directory Reset Password</li><li>LDAP Forgot Password</li><li>LDAP Forgot Password Denied</li><li>Password Reset by Admin</li></ul> |
+| `${oneTimePassword}` | Available in these templates:</br><ul><li>Forgot Password</li><li>Active Directory Password Reset</li><li>LDAP Forgot Password</li><li>Self-Service Unlock Account</li><li>Active Directory Self-Service Unlock Account</li><li>LDAP Self-Service Unlock Account</li></ul> |
+| `${resetPasswordTokenExpirationDate}` | Available in these templates:</br><ul><li>Forgot Password</li><li>Forgot Password Denied</li><li>Active Directory Password Reset</li><li>LDAP Forgot Password</li><li>LDAP Forgot Password Denied</li></ul> |
+| `${request.date}` | Available in Authenticator Enrolled |
+| `${request.time}` | Available in these templates:</br><ul><li>Authenticator Enrolled</li><li>Authenticator Reset</li><li>Factor Enrolled</li><li>Factor Reset</li><li>Sign In From New Device</li></ul> |
+| `${request.location}` | Available in Authenticator Enrolled |
+| `${request.performedBySubject}` | Available in Authenticator Enrolled |
+| `${request.factor}` | Available in Factor Enrolled |
+| `${request.factors}` | Available in Factor Reset |
+| `${request.ipAddress}` | Available in Sign In From New Device |
+| `${request.reportSuspiciousActivityToken}` | Available in Authenticator Enrolled (with Report Suspicious Activity button) |
+| `${request.browser}` | Available in Sign In From New Device |
+| `${request.relayState}` | Available in these templates:</br><ul><li>Registration Activation</li><li>Forgot Password</li><li>Email Challenge</li><li>Email Factor Verification</li><li>Self-Service Unlock Account</li></ul> |
+| `${request.verificationLink}` | Available in Email Factor Verification |
+| `${verificationToken}` | Available in these templates:</br><ul><li>Email Challenge</li><li>Activation</li><li>Registration - Email Verification</li><li>Change Email Confirmation</li></ul> |
+| `${emailAuthenticationLink}` | Available in Email Challenge |
+| `${email}` | Available in these templates:</br><ul><li>Email Challenge</li><li>Email Factor Verification</li></ul> |
 
 ## Use functions for email templates
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Okta uses Velocity Templating Language (VTL) for email customization. VTL uses the `$` placeholder. Need to revert the changes.
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-729831](https://oktainc.atlassian.net/browse/OKTA-729831)
