### PR TITLE
OKTA-532916 | Search result links with stack selector doesn't work with left-nav

### DIFF
--- a/packages/@okta/vuepress-theme-prose/mixins/SidebarItems.vue
+++ b/packages/@okta/vuepress-theme-prose/mixins/SidebarItems.vue
@@ -68,8 +68,18 @@ export default {
       }
 
       if (link.path) {
-        // Add state to leaf link
-        link.iHaveChildrenActive = link.path === this.$page.regularPath;
+        if (
+          this.$page.regularPath.indexOf('/-/') > 0 &&
+          guideFromPath(this.$page.regularPath).guideName === link.guideName &&
+          link.frameworks &&
+          link.frameworks.length > 0
+        ) {
+          let updatedPath = this.$page.regularPath.replace('/-/', `/${link.frameworks[0]}/`);
+          link.iHaveChildrenActive = link.path === updatedPath;
+        } else {
+          // Add state to leaf link
+          link.iHaveChildrenActive = link.path === this.$page.regularPath;
+        }
       }
       if (link.subLinks) {
         for (const subLink of link.subLinks) {


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. --> Logic for finding the active sidebar item
- **Is this PR related to a Monolith release?** <!-- If so, which one? --> No

### Resolves:

* [OKTA-532916](https://oktainc.atlassian.net/browse/OKTA-532916)
<img width="1725" alt="Screenshot 2024-06-24 at 2 28 25 PM" src="https://github.com/okta/okta-developer-docs/assets/158277016/ed6bb257-9b1b-41d1-a89f-067b76758b3c">
