### PR TITLE
OKTA-745788 - Event Hook org limit update

### DIFF
--- a/packages/@okta/vuepress-site/docs/concepts/event-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/event-hooks/index.md
@@ -17,7 +17,7 @@ Okta event hooks are an implementation of the industry concept of webhooks. Okta
 
 Before the introduction of event hooks, polling the [System Log API](/docs/reference/api/system-log/) was the only method your external software systems could use to detect the occurrence of specific events in your Okta org. Event hooks provide an Okta-initiated push notification.
 
-You can have a maximum of 10 active and verified event hooks set up in your org at any time. Each event hook can be configured to deliver multiple event types.
+You can have a maximum of 25 active and verified event hooks set up in your org at any time. Each event hook can be configured to deliver multiple event types.
 
 > **Note:** To deliver event information, event hooks use the data structure associated with the [System Log API](/docs/reference/api/system-log/).
 

--- a/packages/@okta/vuepress-site/docs/reference/hooks-best-practices/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/hooks-best-practices/index.md
@@ -65,7 +65,7 @@ Your external service that processes hook requests must consider that the order 
 | Hook Type | Limit Type | Limit | Description |
 | --------- | -----------| ----- | ----------- |
 | Event hook | Number of daily events | 400,000 | A maximum of 400,000 applicable events, per org, per day, that trigger event hooks. Event hooks aren't recorded or replayed after this point. If a request times out after three seconds, event hooks are retried once. Retries don't count toward the org limit.
-|            | Maximum number of event hooks per org | 10 | A maximum of 10 active event hooks can be configured per org. You can configure each event hook to deliver multiple event types. |
+|            | Maximum number of event hooks per org | 25 | A maximum of 25 active event hooks can be configured per org. You can configure each event hook to deliver multiple event types. |
 | Inline hook | Timeout | 3 seconds | Inline hooks have a completion timeout of three seconds with a single retry. However, a request isn't retried if your endpoint returns a 4xx HTTP error code. Any 2xx code is considered successful, and the request is not retried. If the external service endpoint responds with a redirect, it isn't followed. |
 |             | Maximum number of inline hooks per org | 100 | The maximum number of inline hooks that you can configure per org is 100, which is a combined total for any combination of inline hook types. |
 |             | Concurrent rate limit | Variable | The maximum number of inline hooks that can be sent concurrently based on org type. See [Concurrent rate limits](/docs/reference/rl-additional-limits/#concurrent-rate-limits).|


### PR DESCRIPTION

## Description:
- **What's changed?** Updating number of event hooks available per org from 10 to 25 on the [Event hooks](https://developer.okta.com/docs/concepts/event-hooks/) concept and [Best practices guide](https://developer.okta.com/docs/reference/hooks-best-practices/). 


- **Is this PR related to a Monolith release?** `2024.07.0`

### Resolves:

* [OKTA-741766](https://oktainc.atlassian.net/browse/OKTA-741766)
