### PR TITLE
chore(ci): Reduce resource class size of two pipeline jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
   nightly_link_checker:
     docker:
       - image: cimg/node:14.21.3-browsers
-    resource_class: xlarge
+    resource_class: large
     environment:
       NODE_OPTIONS: '--max_old_space_size=3584'
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
   node_build_checks:
       docker:
         - image: cimg/node:14.21.3-browsers
-      resource_class: xlarge
+      resource_class: large
       environment:
         NODE_OPTIONS: '--max_old_space_size=3584'
       steps:


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:

Looking at the resource usage for the build checks job, the CPU seems like it could be tuned down, and while RAM does at one point spike between 1/3 to just below 1/2 usage of 16 GB on XLarge, the job itself seems to set a Node limit of roughly 4GB, far below the 8GB which is on a Large resource class. So thought it would be wise to try to see if we can tune this down for improved resource usage.

Same seems to apply to nightly, so made that change too.

Sample run from a recent mainline build:

<img width="1443" alt="image" src="https://github.com/okta/okta-developer-docs/assets/167119170/9cb5751a-e66c-4723-a7f6-62590877da30">

https://app.circleci.com/pipelines/github/okta/okta-developer-docs/3586/workflows/23e11945-8f10-4cb5-bb2b-cc49f254eb81/jobs/7256/steps

### Resolves:

* n/a
