### PR TITLE
OKTA-745531 | Filter text are clipped off

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_search.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_search.scss
@@ -146,12 +146,13 @@
 }
 
 #SearchPage .coveo-facet-value-caption {
-  margin: 0 0 8px;
+  margin: 0 0 6px;
 
   font-weight: 400;
   font-size: 16px;
   line-height: 16px;
   color: cv("text", "darker");
+  height: 18px;
 }
 
 #SearchPage .coveo-pager-list-item,

--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_search.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_search.scss
@@ -147,12 +147,13 @@
 
 #SearchPage .coveo-facet-value-caption {
   margin: 0 0 6px;
+  
+  height: 18px;
 
   font-weight: 400;
   font-size: 16px;
   line-height: 16px;
   color: cv("text", "darker");
-  height: 18px;
 }
 
 #SearchPage .coveo-pager-list-item,


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. --> CSS to fix text being cut off
- **Is this PR related to a Monolith release?** <!-- If so, which one? --> No

### Resolves:

* [OKTA-745531](https://oktainc.atlassian.net/browse/OKTA-745531)
 
<img width="377" alt="Screenshot 2024-07-11 at 5 39 32 PM" src="https://github.com/okta/okta-developer-docs/assets/158277016/83f7f7b1-ac03-4fbc-ab94-2441919e5705">
