### PR TITLE
chore(ci): Yarn caching enhancements and pipeline tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,31 @@ version: 2.1
 
 orbs:
   general-platform-helpers: okta/general-platform-helpers@1.8
-  
+
 parameters:
   preview:
     type: string
     default: ""
+
+commands:
+  install-deps:
+    steps:
+      - restore_cache:
+          name: Restore Yarn dependency cache
+          keys:
+            # Find a cache corresponding to this specific yarn.lock checksum
+            # when this file is changed, this key will fail (correctly)
+            - v1-yarn-deps-{{ checksum "yarn.lock" }}
+            # Find the most recently generated cache used from any branch
+            - v1-yarn-deps-
+      - run:
+          name: Install dependencies
+          command: yarn install --frozen-lockfile
+      - save_cache:
+          name: Save Yarn dependency Cache
+          key: v1-yarn-deps-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules/
 
 jobs:
   inclusive-linting:
@@ -25,9 +45,7 @@ jobs:
         NODE_OPTIONS: '--max_old_space_size=3584'
       steps:
         - checkout
-        - run:
-            name: Install dependencies
-            command: yarn install --frozen-lockfile
+        - install-deps
         - run:
             name: Lint
             command: yarn lint-all
@@ -46,9 +64,7 @@ jobs:
       NODE_OPTIONS: '--max_old_space_size=3584'
     steps:
       - checkout
-      - run:
-          name: Install dependencies
-          command: yarn install --frozen-lockfile
+      - install-deps
       - run:
           name: Run script and capture logs
           command: yarn build
@@ -98,10 +114,7 @@ jobs:
               exit 1
             fi
       - checkout
-      - run:
-          name: Install dependencies
-          command: |
-            yarn install --frozen-lockfile
+      - install-deps
       - run:
           name: Build preview
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,31 +2,12 @@ version: 2.1
 
 orbs:
   general-platform-helpers: okta/general-platform-helpers@1.8
+  node: circleci/node@5.2
 
 parameters:
   preview:
     type: string
     default: ""
-
-commands:
-  install-deps:
-    steps:
-      - restore_cache:
-          name: Restore Yarn dependency cache
-          keys:
-            # Find a cache corresponding to this specific yarn.lock checksum
-            # when this file is changed, this key will fail (correctly)
-            - v1-yarn-deps-{{ checksum "yarn.lock" }}
-            # Find the most recently generated cache used from any branch
-            - v1-yarn-deps-
-      - run:
-          name: Install dependencies
-          command: yarn install --frozen-lockfile
-      - save_cache:
-          name: Save Yarn dependency Cache
-          key: v1-yarn-deps-{{ checksum "yarn.lock" }}
-          paths:
-            - node_modules/
 
 jobs:
   inclusive-linting:
@@ -45,7 +26,8 @@ jobs:
         NODE_OPTIONS: '--max_old_space_size=3584'
       steps:
         - checkout
-        - install-deps
+        - node/install-packages:
+            pkg-manager: yarn
         - run:
             name: Lint
             command: yarn lint-all
@@ -68,7 +50,8 @@ jobs:
       NODE_OPTIONS: '--max_old_space_size=3584'
     steps:
       - checkout
-      - install-deps
+      - node/install-packages:
+          pkg-manager: yarn
       - run:
           name: Run script and capture logs
           command: yarn build
@@ -118,7 +101,8 @@ jobs:
               exit 1
             fi
       - checkout
-      - install-deps
+      - node/install-packages:
+          pkg-manager: yarn
       - run:
           name: Build preview
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ commands:
             - v2-yarn-deps-
       - run:
           name: Install dependencies with Yarn
-          command: yarn install --frozen-lockfile
+          command: yarn install --frozen-lockfile --verbose
       - save_cache:
           name: Save Yarn dependency cache
           key: v2-yarn-deps-{{ checksum "yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,15 +14,15 @@ commands:
       - restore_cache:
           name: Restore Yarn dependency cache
           keys:
-            - v1-yarn-deps-{{ checksum "yarn.lock" }}
+            - v2-yarn-deps-{{ checksum "yarn.lock" }}
             # allow for partial cache hits
-            - v1-yarn-deps-
+            - v2-yarn-deps-
       - run:
           name: Install dependencies with Yarn
           command: yarn install --frozen-lockfile
       - save_cache:
           name: Save Yarn dependency cache
-          key: v1-yarn-deps-{{ checksum "yarn.lock" }}
+          key: v2-yarn-deps-{{ checksum "yarn.lock" }}
           paths:
             - node_modules/
             - packages/@okta/vuepress-plugin-active-header-links/node_modules/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
   netlify_manual:
     docker:
       - image: cimg/node:14.21.3-browsers
-    resource_class: xlarge
+    resource_class: large
     steps:
       - run:
           name: Has secrets?

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,20 +14,20 @@ commands:
       - restore_cache:
           name: Restore Yarn dependency cache
           keys:
-            - v4-yarn-deps-{{ checksum "yarn.lock" }}
+            - v6-yarn-deps-{{ checksum "yarn.lock" }}
             # allow for partial cache hits
-            - v4-yarn-deps-
+            - v6-yarn-deps-
       - run:
           name: Install dependencies with Yarn
           command: yarn install --frozen-lockfile
       - save_cache:
           name: Save Yarn dependency cache
-          key: v4-yarn-deps-{{ checksum "yarn.lock" }}
+          key: v6-yarn-deps-{{ checksum "yarn.lock" }}
           paths:
             - node_modules/
             - packages/@okta/vuepress-plugin-active-header-links/node_modules/
             - packages/@okta/vuepress-site/node_modules/
-            - ~/.cache/yarn/
+            - ~/.cache/
 
 jobs:
   inclusive-linting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,16 @@ commands:
   install-deps:
     steps:
       - restore_cache:
+          name: Restore Yarn dependency cache
           keys:
             - v1-yarn-deps-{{ checksum "yarn.lock" }}
             # allow for partial cache hits
             - v1-yarn-deps-
+      - run:
+          name: Install dependencies with Yarn
+          command: yarn install --frozen-lockfile
       - save_cache:
+          name: Save Yarn dependency cache
           key: v1-yarn-deps-{{ checksum "yarn.lock" }}
           paths:
             - node_modules/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,10 @@ jobs:
         - run:
             name: Run checks
             command: ./scripts/yarn-checks-ci.sh
+        - store_test_results:
+            path: test_results
+        - store_artifacts:
+            path: test_results
 
   nightly_link_checker:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
   netlify_manual:
     docker:
       - image: cimg/node:14.21.3-browsers
-    resource_class: large
+    resource_class: xlarge
     steps:
       - run:
           name: Has secrets?

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
         - checkout
         - node/install-packages:
             pkg-manager: yarn
+            include-branch-in-cache-key: false
         - run:
             name: Lint
             command: yarn lint-all
@@ -52,6 +53,7 @@ jobs:
       - checkout
       - node/install-packages:
           pkg-manager: yarn
+          include-branch-in-cache-key: false
       - run:
           name: Run script and capture logs
           command: yarn build
@@ -103,6 +105,7 @@ jobs:
       - checkout
       - node/install-packages:
           pkg-manager: yarn
+          include-branch-in-cache-key: false
       - run:
           name: Build preview
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
 jobs:
   inclusive-linting:
     docker:
-      - image: cimg/node:18.19.0
+      - image: cimg/base:current
     resource_class: small
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  general-platform-helpers: okta/general-platform-helpers@1.8
+  
 parameters:
   preview:
     type: string
@@ -117,8 +120,6 @@ jobs:
             chmod +x ./scripts/update-dev-docs-pr-cci.sh
             ./scripts/update-dev-docs-pr-cci.sh
 
-orbs:
-  general-platform-helpers: okta/general-platform-helpers@1.8
 
 workflows:
   semgrep:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,19 +14,20 @@ commands:
       - restore_cache:
           name: Restore Yarn dependency cache
           keys:
-            - v2-yarn-deps-{{ checksum "yarn.lock" }}
+            - v3-yarn-deps-{{ checksum "yarn.lock" }}
             # allow for partial cache hits
-            - v2-yarn-deps-
+            - v3-yarn-deps-
       - run:
           name: Install dependencies with Yarn
           command: yarn install --frozen-lockfile --verbose
       - save_cache:
           name: Save Yarn dependency cache
-          key: v2-yarn-deps-{{ checksum "yarn.lock" }}
+          key: v3-yarn-deps-{{ checksum "yarn.lock" }}
           paths:
             - node_modules/
             - packages/@okta/vuepress-plugin-active-header-links/node_modules/
             - packages/@okta/vuepress-site/node_modules/
+            - ~/.yarn-cache
 
 jobs:
   inclusive-linting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,15 +14,15 @@ commands:
       - restore_cache:
           name: Restore Yarn dependency cache
           keys:
-            - v3-yarn-deps-{{ checksum "yarn.lock" }}
+            - v4-yarn-deps-{{ checksum "yarn.lock" }}
             # allow for partial cache hits
-            - v3-yarn-deps-
+            - v4-yarn-deps-
       - run:
           name: Install dependencies with Yarn
           command: yarn install --frozen-lockfile --verbose
       - save_cache:
           name: Save Yarn dependency cache
-          key: v3-yarn-deps-{{ checksum "yarn.lock" }}
+          key: v4-yarn-deps-{{ checksum "yarn.lock" }}
           paths:
             - node_modules/
             - packages/@okta/vuepress-plugin-active-header-links/node_modules/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ jobs:
             name: Install dependencies
             command: yarn install --frozen-lockfile
         - run:
+            name: Lint
+            command: yarn lint-all
+        - run:
             name: Build
             command: yarn build
         - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ commands:
             - v4-yarn-deps-
       - run:
           name: Install dependencies with Yarn
-          command: yarn install --frozen-lockfile --verbose
+          command: yarn install --frozen-lockfile
       - save_cache:
           name: Save Yarn dependency cache
           key: v4-yarn-deps-{{ checksum "yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ commands:
             - node_modules/
             - packages/@okta/vuepress-plugin-active-header-links/node_modules/
             - packages/@okta/vuepress-site/node_modules/
-            - ~/.yarn-cache
+            - ~/.cache/yarn/
 
 jobs:
   inclusive-linting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,26 @@ version: 2.1
 
 orbs:
   general-platform-helpers: okta/general-platform-helpers@1.8
-  node: circleci/node@5.2
 
 parameters:
   preview:
     type: string
     default: ""
+
+commands:
+  install-deps:
+    steps:
+      - restore_cache:
+          keys:
+            - v1-yarn-deps-{{ checksum "yarn.lock" }}
+            # allow for partial cache hits
+            - v1-yarn-deps-
+      - save_cache:
+          key: v1-yarn-deps-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules/
+            - packages/@okta/vuepress-plugin-active-header-links/node_modules/
+            - packages/@okta/vuepress-site/node_modules/
 
 jobs:
   inclusive-linting:
@@ -26,9 +40,7 @@ jobs:
         NODE_OPTIONS: '--max_old_space_size=3584'
       steps:
         - checkout
-        - node/install-packages:
-            pkg-manager: yarn
-            include-branch-in-cache-key: false
+        - install-deps
         - run:
             name: Lint
             command: yarn lint-all
@@ -51,9 +63,7 @@ jobs:
       NODE_OPTIONS: '--max_old_space_size=3584'
     steps:
       - checkout
-      - node/install-packages:
-          pkg-manager: yarn
-          include-branch-in-cache-key: false
+      - install-deps
       - run:
           name: Run script and capture logs
           command: yarn build
@@ -103,9 +113,7 @@ jobs:
               exit 1
             fi
       - checkout
-      - node/install-packages:
-          pkg-manager: yarn
-          include-branch-in-cache-key: false
+      - install-deps
       - run:
           name: Build preview
           command: |

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "yarn dev & yarn test:test-local && yarn stop-all",
     "test:ci": "node scripts/test-ci-build & yarn test:test-local && yarn stop-all",
     "cy:open": "cypress open",
-    "cy:run": "cypress run",
+    "cy:run": "cypress run --reporter junit --reporter-options \"mochaFile=test_results/cypress.xml,toConsole=true\"",
     "test:unit": "jest tests/unit",
     "test-only": "yarn test:unit && yarn cy:run",
     "test:test-local": "yarn test:wait-on-local && yarn test-only || exit 1",
@@ -85,5 +85,6 @@
     "tough-cookie": "^4.1.3",
     "semver": "^7.5.2"
   },
-  "version": "0.0.0"
+  "version": "0.0.0",
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   ],
   "scripts": {
     "dev": "yarn workspace @okta/vuepress-site dev",
-    "build": "yarn lint-all && yarn workspace @okta/vuepress-site build",
+    "build": "yarn workspace @okta/vuepress-site build",
     "broken-link-checker:all": "node scripts/broken-link-checker all",
     "broken-link-checker:internal": "node scripts/broken-link-checker internal",
     "broken-link-checker:external": "node scripts/broken-link-checker external",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,5 @@
     "tough-cookie": "^4.1.3",
     "semver": "^7.5.2"
   },
-  "version": "0.0.0",
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  "version": "0.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "yarn dev & yarn test:test-local && yarn stop-all",
     "test:ci": "node scripts/test-ci-build & yarn test:test-local && yarn stop-all",
     "cy:open": "cypress open",
-    "cy:run": "cypress run --reporter junit --reporter-options \"mochaFile=test_results/cypress.xml,toConsole=true\"",
+    "cy:run": "cypress run --reporter junit --reporter-options \"mochaFile=test_results/cypress.xml\"",
     "test:unit": "jest tests/unit",
     "test-only": "yarn test:unit && yarn cy:run",
     "test:test-local": "yarn test:wait-on-local && yarn test-only || exit 1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint": "eslint \"packages/@okta/vuepress-theme-prose/**/*.vue\"",
     "lint-all": "yarn eslint --max-warnings=0 && yarn stylelint"
   },
-  "repository": "git@github.com:okta/okta.github.io",
+  "repository": "git@github.com:okta/okta-developer-docs",
   "author": "Brian Retterer <brian.retterer@okta.com>",
   "license": "Apache-2.0",
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10345,7 +10345,7 @@ qs@6.9.7:
 
 qs@~6.5.2:
   version "6.5.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
+  resolved "https://artifacts.aue1e.internal:443/artifactory/api/npm/npm-okta-master/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
   integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
 query-string@^7.1.3:

--- a/yarn.lock
+++ b/yarn.lock
@@ -10345,7 +10345,7 @@ qs@6.9.7:
 
 qs@~6.5.2:
   version "6.5.3"
-  resolved "https://artifacts.aue1e.internal:443/artifactory/api/npm/npm-okta-master/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
   integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
 query-string@^7.1.3:


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:

This PR provides a number of enhancements to the CI/CD pipeline in the repo.

* Implement Yarn dependency caching.
  * Currently, each Yarn install step seems to take roughly 35 seconds.
  * By caching the dependencies into CircleCI, and restoring them, the restore + install collecitvely seems to take on average 21 seconds. 
  * This is *unscientifically* a 40% reduction in that step. 😉
  * Practically, it just shaves a little over 10 seconds of a job which takes ~10 minutes.
* Use CircleCI Test features.
  *  The Cypress reporter for JUnit was added, as well as the pipeline collecting those values.
  * CircleCI will now be able to calculate test metrics, and more easily raise their values/results into the UI.
  * Overtime, this'll allow the project to make use of features like automated flaky test detection, trends, etc.
  * Right now, Cypress only runs two tests, technically, so this might be a direction to start to enhance that or break out individual steps of one test into multiple tests for test clarity.
* Reduce Netlify resource class size.
  * This job seems to have a bit more room than it needs, so downgraded it from an XLarge to a Large.
  * <img width="1507" alt="image" src="https://github.com/user-attachments/assets/557af70b-0342-4412-a6cf-be9c50fb235e">
* Fixed Artifactory reference in `yarn.lock`.
  * I believe I noticed some delays in downloads, and if I ran a `yarn install` locally, the lock file for this updated.
  * Believe this should be correct, as external CCI open source cloud runners would not have access to that Artifactory, so it probably adds delay we don't need or warnings, and would mean potential issues for open source contributors installing the dependencies on their local. Correct me if I'm missing an aspect here!
* Fixed repo name in `package.json`.

### Resolves:

* [OKTA-750775](https://oktainc.atlassian.net/browse/OKTA-750775)
