### PR TITLE
OKTA-744028: Removed extra underline from external links

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/abstracts/_colors.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/abstracts/_colors.scss
@@ -101,6 +101,7 @@
   --c-body-base: var(--c-lightgray-200);
   --c-body-lighter: var(--c-lightgray-300);
   --c-header-base: var(--c-gray-950);
+  --c-external-link-base: var(--c-gray-000);
   --c-text-darker: var(--c-gray-900);
   --c-text-base: var(--c-gray-700);
   --c-text-lighter: var(--c-gray-300);
@@ -193,6 +194,7 @@
   --c-body-base: var(--c-gray-800);
   --c-body-lighter: var(--c-gray-800);
   --c-header-base: var(--c-gray-900);
+  --c-external-link-base: var(--c-gray-800);
   --c-footer-base: var(--c-gray-700);
   --c-text-darker: var(--c-gray-100);
   --c-text-base: var(--c-gray-100);

--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_content.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_content.scss
@@ -148,6 +148,11 @@
   word-break: break-word;
 }
 
+.content--container .content-area a span {
+  outline: 2px solid var(--c-external-link-base);
+  outline-offset: -2px;
+}
+
 .content--container .content-area .language-tabs a,
 .content--container .content-area .language-ctas a,
 .content--container .content-area a.card {


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Did a workaround to hide extra underline in external links. This is a bug on vuepress side as evident on their docs as well. Since we enter content in md and that gets converted into html by vuepress automatically, there is no way for us to directly change the html of the external link icon on our website to remove the extra underline. Hence, a workaround is needed to fix this.
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-744028](https://oktainc.atlassian.net/browse/OKTA-744028)
