### PR TITLE
Added Okta Developer Day event timed banner

### DIFF
--- a/packages/@okta/vuepress-theme-prose/layouts/Layout.vue
+++ b/packages/@okta/vuepress-theme-prose/layouts/Layout.vue
@@ -8,7 +8,16 @@
         banner-id="v1"
         @updateHeight="updateHeaderHeight"
       >
-        <p>
+        <p v-if="shouldShowTimedTopBanner">
+          Join Aaron and Semona to learn more about the OAuth Global Token Revocation standard and how it can impact your applications via Okta's new feature: Universal Logout.
+          <a
+            href="https://a0.to/devday24/okta-dev"
+            target="_blank"
+          >
+            Save your spot now.
+          </a>
+        </p>
+        <p v-else>
           Is it easy or difficult to use our developer documentation?
           <a
             href="#"
@@ -154,6 +163,16 @@ export default {
     };
   },
   computed: {
+    shouldShowTimedTopBanner() {
+      const bannerStartTime = new Date('2024-09-02T01:00:00-04:00');
+      const bannerStartTimeEpoch = Math.floor(bannerStartTime.getTime() / 1000);
+      const bannerEndTime = new Date('2024-09-24T23:59:00-04:00');
+      const bannerEndTimeEpoch = Math.floor(bannerEndTime.getTime() / 1000);
+
+      const currentTimeEpoch = Math.floor(Date.now() / 1000);
+
+      return currentTimeEpoch >= bannerStartTimeEpoch && currentTimeEpoch <= bannerEndTimeEpoch;
+    },
     editLink() {
       if (this.$page.frontmatter.editLink === false) {
         return;


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Added timed top banner for okta developer day
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-793877](https://oktainc.atlassian.net/browse/OKTA-793877)


<img width="1725" alt="Screenshot 2024-08-29 at 1 43 01 PM" src="https://github.com/user-attachments/assets/7771cdad-7fd2-4f61-b1c5-a5eab0cc7a93">


