### PR TITLE
OKTA-743108 Deprecate Release lifecycle page

### DIFF
--- a/packages/@okta/vuepress-site/code/library-versions/index.md
+++ b/packages/@okta/vuepress-site/code/library-versions/index.md
@@ -4,7 +4,7 @@ title: Library versions
 
 # Library versions
 
-Okta publishes a number of officially-supported libraries and SDKs on [GitHub](https://github.com/okta). These libraries follow a consistent versioning and release pattern, described here. Note that this is separate from how Okta;s HTTP APIs are [versioned and released](https://developer.okta.com/docs/api/openapi/okta-management/guides/release-lifecycle/).
+Okta publishes a number of officially-supported libraries and SDKs on [GitHub](https://github.com/okta). These libraries follow a consistent versioning and release pattern, described here. Note that this is separate from how Okta's HTTP APIs are [versioned and released](https://developer.okta.com/docs/api/openapi/okta-management/guides/release-lifecycle/).
 
 The most up-to-date version information for each library and SDK is always available from the project GitHub readmes.
 

--- a/packages/@okta/vuepress-site/code/library-versions/index.md
+++ b/packages/@okta/vuepress-site/code/library-versions/index.md
@@ -4,7 +4,7 @@ title: Library versions
 
 # Library versions
 
-Okta publishes a number of officially-supported libraries and SDKs on [GitHub](https://github.com/okta). These libraries follow a consistent versioning and release pattern, described here. Note that this is separate from how Okta;s HTTP APIs are [versioned and released](/docs/reference/releases-at-okta/).
+Okta publishes a number of officially-supported libraries and SDKs on [GitHub](https://github.com/okta). These libraries follow a consistent versioning and release pattern, described here. Note that this is separate from how Okta;s HTTP APIs are [versioned and released](https://developer.okta.com/docs/api/openapi/okta-management/guides/release-lifecycle/).
 
 The most up-to-date version information for each library and SDK is always available from the project GitHub readmes.
 

--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -430,7 +430,7 @@ redirects:
   - from: /use_cases/relationships/index.html
     to: /docs/reference/api/linked-objects/
   - from: /docs/api/getting_started/releases-at-okta/index.html
-    to: /docs/reference/releases-at-okta/
+    to: https://developer.okta.com/docs/api/openapi/okta-management/guides/release-lifecycle/
   - from: /docs/api/getting_started/rate-limits/index.html
     to: /docs/reference/rate-limits/
   - from: /docs/api/getting_started/finding_your_app_credentials/index.html
@@ -768,7 +768,7 @@ redirects:
   - from: /use_cases/relationships
     to: /docs/reference/api/linked-objects/
   - from: /docs/api/getting_started/releases-at-okta
-    to: /docs/reference/releases-at-okta/
+    to: https://developer.okta.com/docs/api/openapi/okta-management/guides/release-lifecycle/
   - from: /docs/api/getting_started/rate-limits
     to: /docs/reference/rate-limits/
   - from: /docs/api/getting_started/finding_your_app_credentials

--- a/packages/@okta/vuepress-site/docs/concepts/okta-organizations/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/okta-organizations/index.md
@@ -23,11 +23,11 @@ Each organization also has an administrator URL to sign in to the administrator 
 ### Preview and production
 Okta orgs come in two varieties: preview orgs and production orgs.
 
-Preview orgs allow you to see the next release early and play with Beta features. Preview orgs include [Beta](/docs/reference/releases-at-okta/#beta) and [Early Access](/docs/reference/releases-at-okta/#early-access-ea) (EA) features by invitation and include all features that are [Generally Available](/docs/reference/releases-at-okta/#general-availability-ga) (GA).
+Preview orgs allow you to see the next release early and play with Beta features. Preview orgs include [Beta](https://developer.okta.com/docs/api/openapi/okta-management/guides/release-lifecycle/#beta) and [Early Access](https://developer.okta.com/docs/api/openapi/okta-management/guides/release-lifecycle/#early-access-ea) (EA) features by invitation and include all features that are [Generally Available](https://developer.okta.com/docs/api/openapi/okta-management/guides/release-lifecycle/#general-availability-ga) (GA).
 
 > **Note:** Preview orgs can't be converted into Production orgs, and Production orgs can't be converted into Preview orgs.
 
-Production orgs are always a known-stable release, covered by our Software License Agreement, and don't include [Beta](/docs/reference/releases-at-okta/#beta) features. Production orgs include EA features by request and include all features that are GA.
+Production orgs are always a known-stable release, covered by our Software License Agreement, and don't include [Beta](https://developer.okta.com/docs/api/openapi/okta-management/guides/release-lifecycle/#beta) features. Production orgs include EA features by request and include all features that are GA.
 
 > **Tip:** To verify which type of org you have, look at the footer of any page of your Okta Admin. Preview org footers have the word `Preview` in the cell name (for example: `OP1 Preview Cell (US)`) and include `oktapreview` as part of the org URL (for example: `companyname.oktapreview.com`). Production orgs don't have production indicators in their URLs or cells.
 

--- a/packages/@okta/vuepress-site/docs/concepts/okta-organizations/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/okta-organizations/index.md
@@ -27,7 +27,7 @@ Preview orgs allow you to see the next release early and play with Beta features
 
 > **Note:** Preview orgs can't be converted into Production orgs, and Production orgs can't be converted into Preview orgs.
 
-Production orgs are always a known-stable release, covered by our Software License Agreement, and don't include [Beta](https://developer.okta.com/docs/api/openapi/okta-management/guides/release-lifecycle/#beta) features. Production orgs include EA features by request and include all features that are GA.
+Production orgs are always a stable release, covered by our Software License Agreement, and don't include [Beta](https://developer.okta.com/docs/api/openapi/okta-management/guides/release-lifecycle/#beta) features. Production orgs include EA features by request and include all features that are GA.
 
 > **Tip:** To verify which type of org you have, look at the footer of any page of your Okta Admin. Preview org footers have the word `Preview` in the cell name (for example: `OP1 Preview Cell (US)`) and include `oktapreview` as part of the org URL (for example: `companyname.oktapreview.com`). Production orgs don't have production indicators in their URLs or cells.
 

--- a/packages/@okta/vuepress-site/docs/reference/releases-at-okta/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/releases-at-okta/index.md
@@ -1,6 +1,9 @@
 ---
 title: Release lifecycle
 ---
+
+The Release lifecycle is now available at the new [Okta API reference portal](https://developer.okta.com/docs/api/openapi/okta-management/guides/release-lifecycle/).
+
 <!--
 # Release lifecycle
 

--- a/packages/@okta/vuepress-site/docs/reference/releases-at-okta/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/releases-at-okta/index.md
@@ -1,7 +1,7 @@
 ---
 title: Release lifecycle
 ---
-
+<!--
 # Release lifecycle
 
 Okta features travel through a regular lifecycle:
@@ -103,4 +103,4 @@ Other exceptions include:
 Such features may spend more than one month between Preview and Production for their GA release.
 - Features exposed in the Admin Console may be EA or GA without the corresponding API being in the same lifecycle stage, or available at all.
 
-As with all changes that affect our customers, changes outside the regular Beta-EA-GA lifecycle are reported in the [Okta API Release Notes](/docs/release-notes/).
+As with all changes that affect our customers, changes outside the regular Beta-EA-GA lifecycle are reported in the [Okta API Release Notes](/docs/release-notes/).-->

--- a/packages/@okta/vuepress-theme-prose/const/navbar.const.js
+++ b/packages/@okta/vuepress-theme-prose/const/navbar.const.js
@@ -1141,7 +1141,7 @@ export const reference = [
          },
          {
             title: "Release lifecycle",
-            path: "/docs/reference/releases-at-okta/",
+            path: "https://developer.okta.com/docs/api/openapi/okta-management/guides/release-lifecycle/",
          },
          {
             title: 'Architecture Center',

--- a/packages/@okta/vuepress-theme-prose/global-components/ApiLifecycle.vue
+++ b/packages/@okta/vuepress-theme-prose/global-components/ApiLifecycle.vue
@@ -40,10 +40,10 @@
 </template>
 
 <script>
-const DEFAULT_LINK = "/docs/reference/releases-at-okta/";
+const DEFAULT_LINK = "https://developer.okta.com/docs/api/openapi/okta-management/guides/release-lifecycle/";
 const IE_LINK = "/docs/concepts/oie-intro/";
-const DEPRECATED_LINK = "/docs/reference/releases-at-okta/#deprecation";
-const EA_LINK = "/docs/reference/releases-at-okta/#early-access-ea"
+const DEPRECATED_LINK = "https://developer.okta.com/docs/api/openapi/okta-management/guides/release-lifecycle/#deprecation";
+const EA_LINK = "https://developer.okta.com/docs/api/openapi/okta-management/guides/release-lifecycle/#early-access-ea"
 
 export default {
   name: "ApiLifecycle",


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Deprecating the [Release lifecycles page](https://developer.okta.com/docs/reference/releases-at-okta/) on dev.okta.com. The old page now redirects to the new site and all links are updated to point to the page on the new site.
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-743108](https://oktainc.atlassian.net/browse/OKTA-743108)
