### PR TITLE
OKTA-727513 - Deprecate Event Hooks Mgmt API on VuePress

### DIFF
--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -460,7 +460,7 @@ redirects:
   - from: /docs/api/resources/events/index.html
     to: /docs/reference/api/system-log/
   - from: /docs/api/resources/event-hooks/index.html
-    to: /docs/reference/api/event-hooks/
+    to: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/EventHook/
   - from: /docs/api/resources/event-types/index.html
     to: /docs/reference/api/event-types/
   - from: /docs/api/resources/event-types
@@ -794,7 +794,7 @@ redirects:
   - from: /docs/api/resources/events
     to: /docs/reference/api/system-log/
   - from: /docs/api/resources/event-hooks
-    to: /docs/reference/api/event-hooks/
+    to: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/EventHook/
   - from: /docs/api/resources/factors
     to: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/UserFactor/
   - from: /docs/api/resources/groups
@@ -896,7 +896,7 @@ redirects:
   - from: /docs/api/resources/events.html
     to: /docs/reference/api/system-log/
   - from: /docs/api/resources/event-hooks.html
-    to: /docs/reference/api/event-hooks/
+    to: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/EventHook/
   - from: /docs/api/resources/factors.html
     to: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/UserFactor/
   - from: /docs/api/resources/groups.html

--- a/packages/@okta/vuepress-site/docs/guides/event-hook-hookdeck/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/event-hook-hookdeck/main/index.md
@@ -101,7 +101,7 @@ Hookdeck URLs are reusable and permanent (when you create a free account) and se
 
 ## Create an Okta event hook
 
-Create the Okta event hook to work with your local application. Set up and verify your event hook using the following Admin Console procedure or through the [Event Hooks Management API](/docs/reference/api/event-hooks/).
+Create the Okta event hook to work with your local application. Set up and verify your event hook using the following Admin Console procedure or through the [Event Hooks Management API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/EventHook/).
 
 <EventHookEANoteProcedure/>
 

--- a/packages/@okta/vuepress-site/docs/guides/event-hook-implementation/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/event-hook-implementation/main/index.md
@@ -102,7 +102,7 @@ Set up and verify the event hook within your Admin Console.
 
 9. You can complete the one-time verification Okta call now or verify the event hook later. If you're using the Glitch example, proceed to verification.
 
-> **Note:** You can also set up an event hook using an API. See [Event Hooks Management](/docs/reference/api/event-hooks/#create-event-hook).
+> **Note:** You can also set up an event hook using an API. See [Event Hooks Management](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/EventHook/#tag/EventHook/operation/createEventHook).
 
 ### Verify the event hook
 

--- a/packages/@okta/vuepress-site/docs/reference/api/event-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/event-hooks/index.md
@@ -8,7 +8,7 @@ excerpt:
 
 # Event Hooks Management API
 
-The Event Hooks Management API reference is now available at the new [Okta API reference portal](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/EventHook/#tag/EventHook).
+The Event Hooks Management API reference is now available at the new [Okta API reference portal](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/EventHook/#tag/EventHook/).
 
 Explore the [Okta Public API Collections](https://www.postman.com/okta-eng/workspace/okta-public-api-collections/overview) workspace to get started with the Event Hooks Management API Postman collection.
 

--- a/packages/@okta/vuepress-site/docs/reference/api/event-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/event-hooks/index.md
@@ -8,6 +8,12 @@ excerpt:
 
 # Event Hooks Management API
 
+The Event Hooks Management API reference is now available at the new [Okta API reference portal](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/EventHook/#tag/EventHook).
+
+Explore the [Okta Public API Collections](https://www.postman.com/okta-eng/workspace/okta-public-api-collections/overview) workspace to get started with the Event Hooks Management API Postman collection.
+
+<!--
+
 For general information on event hooks and how to create and use them, see [Event hooks](/docs/concepts/event-hooks/). The following documentation is only for the management API, which provides a CRUD interface for registering event hooks.
 
 For a step-by-step guide on implementing an example event hook, see the [Event hook](/docs/guides/event-hook-implementation/) guide.
@@ -693,4 +699,4 @@ Explore the event hooks API with filters: [![Run in Postman](https://run.pstmn.i
 
 ## Supported events for subscription
 
-When you register an event hook, you need to specify what events you want to subscribe to. To see the list of event types currently eligible for use in event hooks, use the [Event Types catalog](/docs/reference/api/event-types/#catalog) and search with the parameter `event-hook-eligible`.
+When you register an event hook, you need to specify what events you want to subscribe to. To see the list of event types currently eligible for use in event hooks, use the [Event Types catalog](/docs/reference/api/event-types/#catalog) and search with the parameter `event-hook-eligible`. -->

--- a/packages/@okta/vuepress-site/docs/release-notes/2019/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2019/index.md
@@ -182,7 +182,7 @@ The maximum length of the `client.userAgent.rawUserAgent` property value was inc
 
 #### Event Hooks API is Generally Available
 
-The [Event Hooks API](/docs/reference/api/event-hooks/) is Generally Available (GA) in Production.
+The [Event Hooks API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/EventHook/#tag/EventHook/operation/createEventHook) is Generally Available (GA) in Production.
 
 #### User Types API in Early Access
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2021/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2021/index.md
@@ -448,7 +448,7 @@ You can use the SAML 2.0 Assertion flow to request an access token when you want
 
 #### Event hook preview tab is now GA in Preview
 
-Event hooks that you configure in the Admin Console or by [Event Hooks Management API](/docs/reference/api/event-hooks/) can now preview the JSON body of the event hook in the Admin Console, as well as delivering the preview request to your external service without manually triggering an actual event. See [Event Hook Preview](https://help.okta.com/okta_help.htm?id=ext-event-hooks-preview).
+Event hooks that you configure in the Admin Console or by [Event Hooks Management API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/EventHook/#tag/EventHook/operation/createEventHook) can now preview the JSON body of the event hook in the Admin Console, as well as delivering the preview request to your external service without manually triggering an actual event. See [Event Hook Preview](https://help.okta.com/okta_help.htm?id=ext-event-hooks-preview).
 
 #### Bugs fixed in 2021.07.0
 
@@ -836,11 +836,11 @@ The Okta Org API is now available in Self-Service EA. This API allows you to man
 
 #### Automatically mark a flow hook as "VERIFIED"
 
-When a request is made to `/api/v1/eventHooks/{eventHookId}/lifecycle/verify` for an [Event hook](/docs/reference/api/event-hooks/) that has an Okta Workflows endpoint configured, the event hook is automatically marked as "VERIFIED". The verification step isn't required.<!--OKTA-364393-->
+When a request is made to `/api/v1/eventHooks/{eventHookId}/lifecycle/verify` for an [Event hook](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/EventHook/#tag/EventHook/operation/createEventHook) that has an Okta Workflows endpoint configured, the event hook is automatically marked as "VERIFIED". The verification step isn't required.<!--OKTA-364393-->
 
 #### Event Hook preview tab now in Early Access (EA)
 
-Event hooks configured in the Admin Console or by [Event Hooks Management API](/docs/reference/api/event-hooks/) can now preview the JSON body of the event hook in the Admin Console, as well as delivering the preview request to your external service without manually triggering an actual event.
+Event hooks configured in the Admin Console or by [Event Hooks Management API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/EventHook/#tag/EventHook/operation/createEventHook) can now preview the JSON body of the event hook in the Admin Console, as well as delivering the preview request to your external service without manually triggering an actual event.
 
 Previewing the JSON body of the event hook assists developers or administrators create or troubleshoot the request syntax. The JSON body can also be edited for different request scenarios.
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2021/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2021/index.md
@@ -836,7 +836,7 @@ The Okta Org API is now available in Self-Service EA. This API allows you to man
 
 #### Automatically mark a flow hook as "VERIFIED"
 
-When a request is made to `/api/v1/eventHooks/{eventHookId}/lifecycle/verify` for an [Event hook](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/EventHook/#tag/EventHook/operation/createEventHook) that has an Okta Workflows endpoint configured, the event hook is automatically marked as "VERIFIED". The verification step isn't required.<!--OKTA-364393-->
+When a request is made to `/api/v1/eventHooks/{eventHookId}/lifecycle/verify` for an [Event hook](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/EventHook/#tag/EventHook/) that has an Okta Workflows endpoint configured, the event hook is automatically marked as "VERIFIED". The verification step isn't required.<!--OKTA-364393-->
 
 #### Event Hook preview tab now in Early Access (EA)
 

--- a/packages/@okta/vuepress-theme-prose/const/navbar.const.js
+++ b/packages/@okta/vuepress-theme-prose/const/navbar.const.js
@@ -1112,7 +1112,7 @@ export const reference = [
             subLinks: [
                {
                   title: "Event Hooks Management API",
-                  path: "https://developer.okta.com/docs/api/openapi/okta-management/management/tag/EventHook/#tag/EventHook/operation/createEventHook",
+                  path: "https://developer.okta.com/docs/api/openapi/okta-management/management/tag/EventHook/#tag/EventHook/",
                },
                {
                   title: "Inline Hooks Management API",

--- a/packages/@okta/vuepress-theme-prose/const/navbar.const.js
+++ b/packages/@okta/vuepress-theme-prose/const/navbar.const.js
@@ -1112,7 +1112,7 @@ export const reference = [
             subLinks: [
                {
                   title: "Event Hooks Management API",
-                  path: "/docs/reference/api/event-hooks/",
+                  path: "https://developer.okta.com/docs/api/openapi/okta-management/management/tag/EventHook/#tag/EventHook/operation/createEventHook",
                },
                {
                   title: "Inline Hooks Management API",


### PR DESCRIPTION

## Description:
- **What's changed?** Deprecated the [Event Hooks Mgmt API](https://developer.okta.com/docs/reference/api/event-hooks/) to point to the [OAS3 version](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/EventHook/#tag/EventHook).
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* [OKTA-727513](https://oktainc.atlassian.net/browse/OKTA-727513)
