### PR TITLE
OKTA-806715 - Deprecate Inline Hooks Mgmt API on vuepress

### DIFF
--- a/packages/@okta/vuepress-site/conductor.yml
+++ b/packages/@okta/vuepress-site/conductor.yml
@@ -472,7 +472,7 @@ redirects:
   - from: /docs/api/resources/idps/index.html
     to: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/IdentityProvider/
   - from: /docs/api/resources/inline-hooks/index.html
-    to: /docs/reference/api/inline-hooks/
+    to: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/InlineHook/#tag/InlineHook
   - from: /docs/api/resources/linked-objects/index.html
     to: /docs/reference/api/linked-objects/
   - from: /docs/api/resources/policy/index.html
@@ -800,7 +800,7 @@ redirects:
   - from: /docs/api/resources/groups
     to: /docs/reference/api/groups/
   - from: /docs/api/resources/inline-hooks
-    to: /docs/reference/api/inline-hooks/
+    to: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/InlineHook/#tag/InlineHook
   - from: /docs/api/resources/linked-objects
     to: /docs/reference/api/linked-objects/
   - from: /docs/api/resources/policy

--- a/packages/@okta/vuepress-site/docs/concepts/inline-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/inline-hooks/index.md
@@ -198,7 +198,7 @@ After creating your external service, you need to tell Okta it exists, and enabl
 
 1. Create an external service.
 
-1. Register your service's endpoint with Okta. You can do this in the Admin Console by going to **Workflow > Inline Hooks** and clicking **Add Inline Hook**. Alternatively, you can do this using a REST API call by making a `POST` request to `/api/v1/inlineHooks`; see [Inline Hooks Management API](/docs/reference/api/inline-hooks/) for information.
+1. Register your service's endpoint with Okta. You can do this in the Admin Console by going to **Workflow > Inline Hooks** and clicking **Add Inline Hook**. Alternatively, you can do this using a REST API call by making a `POST` request to `/api/v1/inlineHooks`; see [Inline Hooks Management API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/InlineHook/#tag/InlineHook) for information.
 
 1. Associate the endpoint with a particular Okta process flow. This step varies by inline hook type.
 

--- a/packages/@okta/vuepress-site/docs/guides/archive-registration-inline-hook/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/archive-registration-inline-hook/main/index.md
@@ -68,7 +68,7 @@ To set up and activate the registration inline hook:
 
 The registration inline hook is now set up with an active status.
 
-> **Note:** You can also set up an inline hook using the API. See [Inline Hooks Management API](/docs/reference/api/inline-hooks/#create-inline-hook).
+> **Note:** You can also set up an inline hook using the API. See [Inline Hooks Management API](/https://developer.okta.com/docs/api/openapi/okta-management/management/tag/InlineHook/#tag/InlineHook/operation/createInlineHook).
 
 ### Enable the registration inline hook in the Classic Engine
 

--- a/packages/@okta/vuepress-site/docs/guides/archive-registration-inline-hook/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/archive-registration-inline-hook/main/index.md
@@ -4,16 +4,16 @@ excerpt: Code the external service for a registration inline hook
 layout: Guides
 ---
 
-> **Note:** This document is only for Okta Classic Engine. If you are using Okta Identity Engine, see [Configure a registration inline hook](/docs/guides/registration-inline-hook/nodejs/main/). See [Identify your Okta solution](https://help.okta.com/okta_help.htm?type=oie&id=ext-oie-version) to determine your Okta version.
+> **Note:** This document is only for Okta Classic Engine. If you’re using Okta Identity Engine, see [Configure a registration inline hook](/docs/guides/registration-inline-hook/nodejs/main/). See [Identify your Okta solution](https://help.okta.com/okta_help.htm?type=oie&id=ext-oie-version) to determine your Okta version.
 
-This guide provides a working example of an Okta registration inline hook. It uses the web site [Glitch.com](https://glitch.com) to act as an external service and receive and respond to registration inline hook calls.
+This guide provides a functional example of an Okta registration inline hook. It uses the web site [Glitch.com](https://glitch.com) to act as an external service and receive and respond to registration inline hook calls.
 
 ---
 
 **Learning outcomes**
 
 * Understand the Okta registration inline hook calls and responses.
-* Implement a simple working example of a registration inline hook with a Glitch.com project.
+* Implement a simple functional example of a registration inline hook with a Glitch.com project.
 * Preview and test a registration inline hook.
 
 **What you need**
@@ -35,12 +35,12 @@ At a high-level, the following workflow occurs:
 
 1. A user attempts to self-register with your Okta org.
 1. A registration inline hook triggers during this process and sends a call to the external service with the user's data.
-1. The external service evaluates the Okta call to ensure the user is from domain `example.com`.
+1. The external service evaluates the Okta call to ensure the user is from the domain `example.com`.
 1. The external service responds to Okta with a command to allow or deny the registration based on the email domain.
 
 ## Add request code
 
-This step includes the code that parses the body of the request received from Okta, which gets the values of `data.userProfile`. These properties contain the credentials submitted by the end user who is trying to self register.
+This step includes the code that parses the body of the request received from Okta, which gets the values of `data.userProfile`. These properties contain the credentials submitted by the end user who is trying to self-register.
 
 <StackSnippet snippet="get-submitted-credentials"/>
 
@@ -52,13 +52,13 @@ The external service responds to Okta indicating whether to accept the user self
 
 ## Activate and enable
 
-The registration inline hook must be set up, activated, and enabled within your Okta Admin Console.
+The registration inline hook must be set up, activated, and enabled within your Admin Console.
 
 To set up and activate the registration inline hook:
 
 1. In the Admin Console, go to **Workflow** > **Inline Hooks**.
 2. Click **Add Inline Hook** and select **Registration** from the dropdown menu.
-3. Add a name for the hook (in this example, use "Guide Registration Hook Code").
+3. Add a name for the hook (in this example, use "Guide registration hook code").
 4. Add your external service URL, including the endpoint. For example, use your Glitch project name with the endpoint:  `https://your-glitch-projectname.glitch.me/registrationHook`.
 5. Include the authentication field and secret. In this example:
 
@@ -82,11 +82,11 @@ To enable the registration inline hook on the self-service registration page:
 
 1. Click **Edit**.
 
-1. From the **Extension** dropdown menu, select the hook that you set up and activated previously ("Guide Registration Hook Code").
+1. From the **Extension** dropdown menu, select the hook that you set up and activated previously ("Guide registration hook code").
 
 1. Click **Save**.
 
-The registration inline hook is now enabled for self-service registration. You are now ready to preview and test the example.
+The registration inline hook is now enabled for self-service registration. You’re now ready to preview and test the example.
 
 ## Preview and test
 
@@ -99,7 +99,7 @@ In your Okta org, you can preview the request and response JSON right from the A
 To preview the registration inline hook:
 
 1. In the Admin Console, go to **Workflow** > **Inline Hooks**.
-2. Select the registration inline hook name (in this example, select "Guide Registration Hook Code").
+2. Select the registration inline hook name (in this example, select "Guide registration hook code").
 3. Click the **Preview** tab.
 4. In the **Configure Inline Hook request** block, select an end user from your org in the **data.userProfile** field. That is, select a value from your `data.user.profile` object.
 5. From the **Preview example Inline Hook request** block, click **Generate Request**.
@@ -114,7 +114,7 @@ To run a test of your registration inline hook, go to the Okta sign-in page for 
 * If you use an allowable email domain, such as `john@example.com`, the user registration goes through.
 * If you use an incorrect email domain, the user registration is denied. Review the error message that displays the error summary from the external service code and is passed back to Okta.
 
-> **Note:** Review [Troubleshooting hook implementations](/docs/guides/common-hook-set-up-steps/nodejs/main/#troubleshoot-hook-implementations) if you encounter any set up or configuration difficulties.
+> **Note:** Review [Troubleshooting hook implementations](/docs/guides/common-hook-set-up-steps/nodejs/main/#troubleshoot-hook-implementations) if you encounter any setup or configuration difficulties.
 
 ## Next steps
 

--- a/packages/@okta/vuepress-site/docs/guides/archive-registration-inline-hook/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/archive-registration-inline-hook/main/index.md
@@ -68,7 +68,7 @@ To set up and activate the registration inline hook:
 
 The registration inline hook is now set up with an active status.
 
-> **Note:** You can also set up an inline hook using the API. See [Inline Hooks Management API](/https://developer.okta.com/docs/api/openapi/okta-management/management/tag/InlineHook/#tag/InlineHook/operation/createInlineHook).
+> **Note:** You can also set up an inline hook using the API. See [Inline Hooks Management API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/InlineHook/#tag/InlineHook/operation/createInlineHook).
 
 ### Enable the registration inline hook in the Classic Engine
 

--- a/packages/@okta/vuepress-site/docs/guides/migrate-to-okta-password-hooks/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/migrate-to-okta-password-hooks/main/index.md
@@ -132,7 +132,7 @@ For Okta to use your app, you must register the external service endpoint.
 
 In the Admin Console, go to **Workflow** > **Inline Hooks**. Click **Add Inline Hook**.
 
-You can also accomplish this using the [Inline Hooks Management API](/docs/reference/api/inline-hooks/).
+You can also accomplish this using the [Inline Hooks Management API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/InlineHook/#tag/InlineHook).
 
 ## End the migration program
 

--- a/packages/@okta/vuepress-site/docs/guides/password-import-inline-hook/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/password-import-inline-hook/main/index.md
@@ -82,7 +82,7 @@ To set up and activate the password import inline hook:
 
 The password import inline hook is now set up with a status of "Active".
 
-> **Note:** You can also set up an inline hook using an API. See [Inline Hooks Management API](/docs/reference/api/inline-hooks/#create-inline-hook).
+> **Note:** You can also set up an inline hook using an API. See [Inline Hooks Management API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/InlineHook/#tag/InlineHook/operation/createInlineHook).
 
 ## Import test users
 

--- a/packages/@okta/vuepress-site/docs/guides/registration-inline-hook/main/nodejs/apisetup.md
+++ b/packages/@okta/vuepress-site/docs/guides/registration-inline-hook/main/nodejs/apisetup.md
@@ -1,1 +1,1 @@
-> **Note:** You can also set up an inline hook using the API. See [Inline Hooks Management API](/docs/reference/api/inline-hooks/#create-inline-hook).
+> **Note:** You can also set up an inline hook using the API. See [Inline Hooks Management API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/InlineHook/#tag/InlineHook/operation/createInlineHook).

--- a/packages/@okta/vuepress-site/docs/guides/telephony-inline-hook/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/telephony-inline-hook/main/index.md
@@ -100,7 +100,7 @@ Update the **Okta Dashboard** [preset authentication policy](https://help.okta.c
 
 Activate the telephony inline hook in your Okta org. Activating the telephony inline hook registers the hook with the Okta org and associates it with your external service.
 
-Alternatively, you can use the Inline Hooks Management API to create an inline hook. See [Inline Hooks Management API](/docs/reference/api/inline-hooks/#create-inline-hook).
+Alternatively, you can use the Inline Hooks Management API to create an inline hook. See [Inline Hooks Management API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/InlineHook/#tag/InlineHook/operation/createInlineHook).
 
 1. Go to the **Workflow** > **Inline Hooks** page.
 1. Click **Add Inline Hook** and select **Telephony** from the dropdown list.

--- a/packages/@okta/vuepress-site/docs/reference/api/hook-keys/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/hook-keys/index.md
@@ -8,7 +8,7 @@ excerpt:
 
 # Key Management API
 
-The Okta Key Management API provides a CRUD interface for JSON Web Keys (JWK) used with other parts of the application, such as inline hooks. For information on how to create inline hooks, see [Inline hooks management API](/docs/reference/api/inline-hooks/).
+The Okta Key Management API provides a CRUD interface for JSON Web Keys (JWK) used with other parts of the application, such as inline hooks. For information on how to create inline hooks, see [Inline hooks management API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/InlineHook/#tag/InlineHook).
 
 <ApiAuthMethodWarning />
 

--- a/packages/@okta/vuepress-site/docs/reference/api/inline-hooks/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/inline-hooks/index.md
@@ -8,6 +8,12 @@ excerpt:
 
 # Inline Hooks Management API
 
+The Inline Hooks Management API reference is now available at the new [Okta API reference portal](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/InlineHook/#tag/InlineHook).
+
+Explore the [Okta Public API Collections](https://www.postman.com/okta-eng/workspace/okta-public-api-collections/overview) workspace to get started with the Inline Hooks Management API Postman collection.
+
+<!--
+
 For general information on inline hooks and how to create and use them, see [inline hooks](/docs/concepts/inline-hooks/). The following documentation is only for the management API, which provides a CRUD interface for registering inline hooks.
 
 ## Get started
@@ -900,3 +906,4 @@ When registering an inline hook, you need to specify what type it is. The follow
 | `com.okta.telephony.provider`      | [Telephony inline hook](/docs/reference/telephony-hook/) |
 | `com.okta.user.credential.password.import` | [Password import inline hook](/docs/reference/password-hook/) |
 | `com.okta.user.pre-registration`   | [Registration inline hook](/docs/reference/registration-hook/) |
+-->

--- a/packages/@okta/vuepress-site/docs/reference/import-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/import-hook/index.md
@@ -13,7 +13,7 @@ This page provides reference documentation for user import inline hooks, one typ
 
 For a general introduction to Okta inline hooks, see [inline hooks](/docs/concepts/inline-hooks/).
 
-For information on the API for registering external service endpoints with Okta, see [Inline Hooks Management API](/docs/reference/api/inline-hooks/).
+For information on the API for registering external service endpoints with Okta, see [Inline Hooks Management API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/InlineHook/#tag/InlineHook).
 
 For steps to enable this inline hook, see [Enabling a user import inline hook](#enabling-a-user-import-inline-hook).
 
@@ -280,7 +280,7 @@ If the external service times out after receiving an Okta request, the Okta proc
 
 ## Enabling a user import inline hook
 
-To activate the inline hook, you first need to register your external service endpoint with Okta using the [Inline Hooks Management API](/docs/reference/api/inline-hooks/).
+To activate the inline hook, you first need to register your external service endpoint with Okta using the [Inline Hooks Management API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/InlineHook/#tag/InlineHook/).
 
 You then need to associate the registered inline hook with an app by completing the following steps in Admin Console:
 

--- a/packages/@okta/vuepress-site/docs/reference/password-hook/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/password-hook/index.md
@@ -11,7 +11,7 @@ This page provides reference documentation for password import inline hooks, one
 
 For a general introduction to Okta inline hooks, see [inline hooks](/docs/concepts/inline-hooks/).
 
-For information on the API for registering external service endpoints with Okta, see [Inline Hooks Management API](/docs/reference/api/inline-hooks/).
+For information on the API for registering external service endpoints with Okta, see [Inline Hooks Management API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/InlineHook/#tag/InlineHook/).
 
 For steps to enable this inline hook, see below, [Enabling a password import inline hook](#enabling-a-password-import-inline-hook).
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2019/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2019/index.md
@@ -287,7 +287,7 @@ The public metadata endpoints for Authorization Servers are now each assigned se
 
 #### Bugs Fixed in 2019.08.3
 
-* The [Update inline hook call](/docs/reference/api/inline-hooks/#update-inline-hook) wasn't replacing the whole object. (OKTA-229337)
+* The [Update inline hook call](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/InlineHook/#tag/InlineHook/operation/updateInlineHook) wasn't replacing the whole object. (OKTA-229337)
 
 * IP addresses identified as malicious by Okta ThreatInsight were missing from Events API ("security.threat.detected") event messages. See the [Event Types catalog](/docs/reference/api/event-types/#catalog) for more information on this event message. (OKTA-242795)
 

--- a/packages/@okta/vuepress-theme-prose/const/navbar.const.js
+++ b/packages/@okta/vuepress-theme-prose/const/navbar.const.js
@@ -1116,7 +1116,7 @@ export const reference = [
                },
                {
                   title: "Inline Hooks Management API",
-                  path: "/docs/reference/api/inline-hooks/",
+                  path: "https://developer.okta.com/docs/api/openapi/okta-management/management/tag/InlineHook/#tag/InlineHook/",
                },
                {
                   title: "Inline Hook Types",


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Deprecating the existing [Inline Hooks Management API](https://developer.okta.com/docs/reference/api/inline-hooks/) on VuePress to now point to the latest version on [OAS3](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/InlineHook/).
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* [OKTA-806715](https://oktainc.atlassian.net/browse/OKTA-806715)
