### PR TITLE
Catches errors

### DIFF
--- a/packages/@okta/vuepress-theme-prose/util/coveo/endpoint.js
+++ b/packages/@okta/vuepress-theme-prose/util/coveo/endpoint.js
@@ -17,16 +17,18 @@ const _getToken = () => {
   // Strip " if present (breaks coveo)
   token = token.replace('"', "");
 
-  // Invalidate token if about to expire
-  const decoded = jwt_decode(token);
-  const now = DateTime.now();
-  const expWithBuffer = DateTime.fromSeconds(decoded['exp']).minus({ minutes: 5 });
-  if (now > expWithBuffer) {
-    storage.removeItem(COVEO_KEY);
-    return;
-  } else {
-    return token;
+  try {
+    // Invalidate token if about to expire
+    const decoded = jwt_decode(token);
+    const now = DateTime.now();
+    const expWithBuffer = DateTime.fromSeconds(decoded['exp']).minus({ minutes: 5 });
+    if (now < expWithBuffer) {
+      return token;
+    }
+  } catch (err) {
+    console.log('Failed to parse token:', err.message);
   }
+  storage.removeItem(COVEO_KEY);
 };
 
 const _renewToken = () => {


### PR DESCRIPTION
### Changes
- catches error in token processing

I've copied broken_coveo token to a preview site, after refreshing the page script handled error and reset token to a valid value
<img width="1051" alt="image" src="https://github.com/user-attachments/assets/b9f6b7b8-57fe-44d3-a497-33973b9f7a89">


### Resolves:
* [OKTA-820519](https://oktainc.atlassian.net/browse/OKTA-820519)
