### PR TITLE
OKTA-405221 Fixed incorrect parameter in response sample

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/session-cookie/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/session-cookie/main/index.md
@@ -51,7 +51,7 @@ The `prompt=none` parameter guarantees that the user isn't prompted for credenti
 ```
 HTTP/1.1 302 Moved Temporarily
 Set-Cookie: sid=lGj4FPxaG63Wm89TpJnaDF6; Path=/
-Location: https://your-app.example.com?id_token=S4sx3uixdsalasd&state=Af0ifjslDkj&nonce=n-0S6_WzA2Mj
+Location: https://your-app.example.com#id_token=S4sx3uixdsalasd&state=Af0ifjslDkj&nonce=n-0S6_WzA2Mj
 ```
 
 The response also includes an [ID token](https://developer.okta.com/docs/api/openapi/okta-oauth/guides/overview/#id-token) that describes the authenticated user and can contain more claims such as user profile attributes or email.


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Changed the `id_token` response parameter from a query to a fragment
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-405221](https://oktainc.atlassian.net/browse/OKTA-405221)
