### PR TITLE
OKTA-821460 | Improvement for canonical urls

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/config.js
+++ b/packages/@okta/vuepress-site/.vuepress/config.js
@@ -432,7 +432,9 @@ module.exports = ctx => ({
       };
     }
     
-    frontmatter.canonicalUrl = `https://developer.okta.com${path}`;
+    if(!frontmatter.canonicalUrl) {
+      frontmatter.canonicalUrl = `https://developer.okta.com${path}`;
+    }
 
     if (path === '/') {
       $page.newsFeedDataJson = null;

--- a/packages/@okta/vuepress-site/docs/concepts/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/index.md
@@ -1,7 +1,6 @@
 ---
 layout: Landing
 title: Concepts
-canonicalUrl: https://developer.okta.com/docs/test/
 ---
 
 # Concepts

--- a/packages/@okta/vuepress-site/docs/concepts/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/index.md
@@ -1,6 +1,7 @@
 ---
 layout: Landing
 title: Concepts
+canonicalUrl: https://developer.okta.com/docs/test/
 ---
 
 # Concepts


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:

- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. --> We currently set the canonical URL for every page in `.vuepress/config.js`. However, Vuepress also allows setting the canonical URL directly within each page's frontmatter block. Since the canonical URL can be managed at the page level, it's redundant to override it globally in config.js. This change updates the global override in config.js.
 
- **Is this PR related to a Monolith release?** <!-- If so, which one? --> No

### Resolves:

* [OKTA-821460](https://oktainc.atlassian.net/browse/OKTA-821460)
