### PR TITLE
OKTA-794747 | CSS issue on Dev Docs

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_button.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_button.scss
@@ -196,6 +196,10 @@
   @include media("<tablet") {
     padding: 0 12px;
   }
+
+  > span {
+    outline: none !important;
+  }
 }
 
 .Button--blueOutline {

--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_button.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_button.scss
@@ -179,6 +179,10 @@
   white-space: nowrap;
   color: cv("blue", "900");
 
+  > span {
+    outline: none !important;
+  }
+
   &:active,
   &:hover {
     border-color: cv("blue", "900");
@@ -195,10 +199,6 @@
 
   @include media("<tablet") {
     padding: 0 12px;
-  }
-
-  > span {
-    outline: none !important;
   }
 }
 

--- a/packages/@okta/vuepress-theme-prose/assets/css/themes/dark/_button.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/themes/dark/_button.scss
@@ -14,4 +14,8 @@
   background-color: cv("body", "obscure");
 
   color: cv("text", "base");
+
+  > span {
+    outline: none !important;
+  }
 }


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. --> Override span's css to fix text clipping
- **Is this PR related to a Monolith release?** <!-- If so, which one? --> No

### Resolves:

* [OKTA-794747](https://oktainc.atlassian.net/browse/OKTA-794747)

<img width="720" alt="Screenshot 2024-11-08 at 12 33 26 PM" src="https://github.com/user-attachments/assets/7e955e76-9466-450e-8e5b-3e1e4a74d2d0">

