### PR TITLE
Update Angular quickstart guide to latest versions and sample project

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/addconfigpkg.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/addconfigpkg.md
@@ -2,5 +2,5 @@ Use Okta's Angular SDK and Okta's JavaScript SDK in your Angular app. Add the np
 
 ```shell
 cd okta-angular-quickstart
-npm install @okta/okta-angular@6.1 @okta/okta-auth-js@7.2
+npm install @okta/okta-angular@6.4 @okta/okta-auth-js@7.8
 ```

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/configmid.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/configmid.md
@@ -1,17 +1,15 @@
 The Okta Angular SDK requires an instance of an `OktaAuth` object with configuration properties. Set the `clientID` and `issuer` properties with the values that you got from the CLI earlier. This can happen by directly setting the properties, with variable replacement that happens as part of the build process, or during app load time.
 
-Make the following changes to `src/app/app.module.ts`:
+Make the following changes to `src/app/app.config.ts`:
 
 1. Add the following import lines to the code to pull in the dependencies:
 
    ```ts
-   import { OktaAuthModule, OKTA_CONFIG } from '@okta/okta-angular';
+   import { OktaAuthModule } from '@okta/okta-angular';
    import { OktaAuth } from '@okta/okta-auth-js';
    ```
 
-2. Add `OktaAuthModule` to the `@NgModule` `imports` array.
-
-3. Add an `OktaAuth` object as follows, replacing the placeholder values with your own values:
+2. Add an `OktaAuth` object before the `appConfig` as follows, replacing the placeholder values with your own values:
 
    ```ts
    const oktaAuth = new OktaAuth({
@@ -22,8 +20,15 @@ Make the following changes to `src/app/app.module.ts`:
    });
    ```
 
-4. Add the Okta configuration to the `OktaAuthModule` using the `forRoot` static method:
+3. Add the Okta configuration to the `OktaAuthModule` static `forRoot` method in the `ApplicationConfig` object using the `importProvidersFrom` function:
 
    ```ts
-   OktaAuthModule.forRoot({ oktaAuth })
+   export const appConfig: ApplicationConfig = {
+    providers: [
+      // other providers as required
+      importProvidersFrom(
+           OktaAuthModule.forRoot({ oktaAuth })
+      )
+    ]
+   };
    ```

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/createproject.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/createproject.md
@@ -1,14 +1,14 @@
 
-You need recent versions of [Node](https://nodejs.org/en/) and [npm](https://www.npmjs.com/). Okta also recommends installing the [Angular CLI](https://angular.io/cli).
+You need recent versions of [Node](https://nodejs.org/en/) and [npm](https://www.npmjs.com/). Okta also recommends installing the [Angular CLI](https://angular.dev/tools/cli).
 
-Create an Angular app named **okta-angular-quickstart** with routing in your current directory using the following command. Choose **CSS** when it asks you what style sheet format you want to use.
+Create an Angular app named **okta-angular-quickstart** using the following command. Choose any style sheet format you want when it asks you which format you want to use.
 
 ```shell
-npx @angular/cli@15 new okta-angular-quickstart --routing
+npx @angular/cli@19 new okta-angular-quickstart --ssr=false
 ```
 
-This creates an Angular app using version 14 regardless of the version of the Angular CLI installed on your system.
+This creates an Angular app using version 19 regardless of the version of the Angular CLI installed on your system.
 
-> **Note**: This guide uses Angular CLI v15, okta-angular v6.1.0, and Okta Auth JavaScript SDK v7.2.0.
+> **Note**: This guide uses Angular CLI v19, okta-angular v6.4.0, and Okta Auth JavaScript SDK v7.8.0.
 
 > **Note**: You can also install the Okta CLI and run `okta start angular` to download and configure an Angular app with Okta integrated. This quickstart uses the basic Angular CLI output instead, as it's easier to understand the Okta-specific additions if you work through them yourself.

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/getuserinfo.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/getuserinfo.md
@@ -45,4 +45,4 @@ The `authState$` subject in `OktaAuthStateService` contains an `idToken` that co
     { path: 'profile', component: ProfileComponent }
     ```
 
-5. Add an instance of `<a routerLink="/profile">Profile</a>` into the `app.component.html`, again inside the main node. This displays the text, `Profile`, after you're signed in. Clicking the text displays your name in the view.
+5. Add an instance of `<a routerLink="/profile">Profile</a>` into the `app.component.html`, inside the `@if (isAuthenticated$ | async){}`. This displays the text, `Profile`, after you're signed in. Clicking the text displays your name in the view.

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/getuserinfo.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/getuserinfo.md
@@ -5,41 +5,38 @@ The `authState$` subject in `OktaAuthStateService` contains an `idToken` that co
 2. Update `profile.component.ts` as follows:
 
    ```ts
-   import { Component, OnInit } from '@angular/core';
+   import { Component, inject } from '@angular/core';
    import { OktaAuthStateService } from '@okta/okta-angular';
-   import { filter, map, Observable } from 'rxjs';
+   import { filter, map } from 'rxjs';
    import { AuthState } from '@okta/okta-auth-js';
+   import { AsyncPipe } from '@angular/common';
 
    @Component({
      selector: 'app-profile',
+     imports: [AsyncPipe],
      template: `
-     <div class="profile-card">
-       <div class="shield"></div>
-       <p *ngIf="name$ | async as name">
-           Hello {{name}}!
-       </p>
-     </div>
+        <div class="profile-card">
+           <div class="shield"></div>
+           <p>You're logged in!
+           @if(name$ | async; as name) {
+              <span>Welcome, {{name}} </span>
+           }
+          </p>
+       </div>
      `,
      styleUrls: ['./profile.component.css']
    })
+   export class ProfileComponent {
+     private oktaAuthStateService = inject(OktaAuthStateService);
 
-   export class ProfileComponent implements OnInit {
-
-     public name$!: Observable<string>;
-
-     constructor(private _oktaAuthStateService: OktaAuthStateService) { }
-
-     public ngOnInit(): void {
-       this.name$ = this._oktaAuthStateService.authState$.pipe(
-         filter((authState: AuthState) => !!authState && !!authState.isAuthenticated),
-         map((authState: AuthState) => authState.idToken?.claims.name ?? '')
-       );
-
-     }
+     public name$ = this.oktaAuthStateService.authState$.pipe(
+       filter((authState: AuthState) => !!authState && !!authState.isAuthenticated),
+       map((authState: AuthState) => authState.idToken?.claims.name ?? '')
+     );
    }
    ```
 
-3. Import the `ProfileComponent` component into `app-routing.module.ts`:
+3. Import the `ProfileComponent` component into `app.routes.ts`:
 
     ```typescript
     import { ProfileComponent } from './profile/profile.component';
@@ -51,4 +48,4 @@ The `authState$` subject in `OktaAuthStateService` contains an `idToken` that co
     { path: 'profile', component: ProfileComponent }
     ```
 
-5. Add an instance of `<a routerLink="/profile">Profile</a>` into the `app.component.html`, again inside the toolbar. This displays the text, `Profile`, after you're signed in. Clicking the text displays your name in the toolbar.
+5. Add an instance of `<a routerLink="/profile">Profile</a>` into the `app.component.html`, again inside the main node. This displays the text, `Profile`, after you're signed in. Clicking the text displays your name in the view.

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/getuserinfo.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/getuserinfo.md
@@ -15,14 +15,11 @@ The `authState$` subject in `OktaAuthStateService` contains an `idToken` that co
      selector: 'app-profile',
      imports: [AsyncPipe],
      template: `
-        <div class="profile-card">
-           <div class="shield"></div>
-           <p>You're logged in!
+        <p>You're logged in!
            @if(name$ | async; as name) {
               <span>Welcome, {{name}} </span>
            }
-          </p>
-       </div>
+        </p>
      `,
      styleUrls: ['./profile.component.css']
    })

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/getuserinfo.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/getuserinfo.md
@@ -15,10 +15,10 @@ The `authState$` subject in `OktaAuthStateService` contains an `idToken` that co
      selector: 'app-profile',
      imports: [AsyncPipe],
      template: `
-        <p>You're logged in!
-           @if(name$ | async; as name) {
-              <span>Welcome, {{name}} </span>
-           }
+        <p>Welcome
+          @if(name$ | async; as name) {
+            <span>, {{name}} </span>
+          }
         </p>
      `,
      styleUrls: ['./profile.component.css']

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/handlecallback.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/handlecallback.md
@@ -1,4 +1,4 @@
-The Okta Angular SDK has a callback component that handles the token exchange. Okta uses this inside `app-routing.module.ts` to handle the callback routing.
+The Okta Angular SDK has a callback component that handles the token exchange. Okta uses this inside `app.routes.ts` to handle the callback routing.
 
 1. Import the component with the following line:
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/loginredirect.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/loginredirect.md
@@ -7,7 +7,7 @@ The `OktaAuth` service has methods for sign-in and sign-out actions.
    ```html
    @if (isAuthenticated$ | async) {
      <button (click)="signOut()">Sign out</button>
-   } else {
+   } @else {
      <button (click)="signIn()"> Sign in </button>
    }
    ```

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/loginredirect.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/loginredirect.md
@@ -2,46 +2,48 @@ The `OktaAuthStateService` and `OktaAuth` services are used together to support 
 
 The `OktaAuth` service has methods for sign-in and sign-out actions.
 
-1. Add buttons, to support sign-in and sign-out actions, to the component template (`app.component.html`), just inside the top of `<div class="toolbar" role="banner"></div>` so that they’re visible. Display either the sign-in or sign-out button based on the current authenticated state.
+1. Add buttons, to support sign-in and sign-out actions, to the component template (`app.component.html`), just inside the `<main class="main"></main>` so that they’re visible. Display either the sign-in or sign-out button based on the current authenticated state.
 
    ```html
-   <ng-container *ngIf="(isAuthenticated$ | async) === false; else signout">
-     <button (click)="signIn()"> Sign in </button>
-   </ng-container>
-
-   <ng-template #signout>
+   @if (isAuthenticated$ | async) {
      <button (click)="signOut()">Sign out</button>
-   </ng-template>
+   } else {
+     <button (click)="signIn()"> Sign in </button>
+   }
    ```
 
-2. Update the component TypeScript file (`app.component.ts`) with the following imports and updated export to get authenticated state and support sign-in and sign-out actions.
+2. Update the component TypeScript file (`app.component.ts`) with the following imports and updated component definition to get authenticated state and support sign-in and sign-out actions.
 
    ```ts
-   import { Component, Inject, OnInit } from '@angular/core';
-   import { Router } from '@angular/router';
+   import { AsyncPipe } from '@angular/common';
+   import { Component, inject } from '@angular/core';
+   import { RouterLink, RouterOutlet } from '@angular/router';
    import { OktaAuthStateService, OKTA_AUTH } from '@okta/okta-angular';
-   import { AuthState, OktaAuth } from '@okta/okta-auth-js';
-   import { filter, map, Observable } from 'rxjs';
+   import { AuthState } from '@okta/okta-auth-js';
+   import { filter, map } from 'rxjs';
 
-   export class AppComponent implements OnInit {
+   @Component({
+      selector: 'app-root',
+      imports: [RouterOutlet, AsyncPipe, RouterLink],
+      templateUrl: './app.component.html',
+      styleUrls: ['./app.component.css']
+   })
+   export class AppComponent {
+     private oktaStateService = inject(OktaAuthStateService);
+     private oktaAuth = inject(OKTA_AUTH);
+
      title = 'okta-angular-quickstart';
-     public isAuthenticated$!: Observable<boolean>;
-
-     constructor(private _router: Router, private _oktaStateService: OktaAuthStateService, @Inject(OKTA_AUTH) private _oktaAuth: OktaAuth) { }
-
-     public ngOnInit(): void {
-       this.isAuthenticated$ = this._oktaStateService.authState$.pipe(
-         filter((s: AuthState) => !!s),
-         map((s: AuthState) => s.isAuthenticated ?? false)
-       );
-     }
+     public isAuthenticated$ = this.oktaStateService.authState$.pipe(
+        filter((s: AuthState) => !!s),
+        map((s: AuthState) => s.isAuthenticated ?? false)
+     );
 
      public async signIn() : Promise<void> {
-       await this._oktaAuth.signInWithRedirect();
+       await this.oktaAuth.signInWithRedirect();
      }
 
      public async signOut(): Promise<void> {
-       await this._oktaAuth.signOut();
+       await this.oktaAuth.signOut();
      }
    }
    ```

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/reqautheverything.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/reqautheverything.md
@@ -1,6 +1,6 @@
 The Okta Angular SDK has a guard to check for the authenticated state that you can add to protected routes. It's common in Angular to use feature modules and protect the route to the feature so that all child routes are also guarded.
 
-In `app-routing.module.ts`, add the `OktaAuthGuard` to protect the route accessing a lazy loaded feature module using the `canActivate` property.
+In `app.routes.ts`, add the `OktaAuthGuard` to protect the route accessing a lazy loaded feature module using the `canActivate` property.
 
 1. Update the Okta import statement to:
 
@@ -13,11 +13,21 @@ In `app-routing.module.ts`, add the `OktaAuthGuard` to protect the route accessi
    ```ts
    {
      path: 'protected',
-     loadChildren: () => import('./protected/protected.module').then(m => m.ProtectedModule),
-     canActivate: [OktaAuthGuard]
+     loadChildren: () => import('./protected/routes').then(m => m.PROTECTED_FEATURE_ROUTES),    canActivate: [OktaAuthGuard]
    },
    ```
 
-3. Create a new protected module with the CLI command `ng generate module protected`.
+3. Create a new protected feature route with the CLI command `ng generate component protected`.
 
-4. Make sure that you’re signed out, and then try going to `/protected`. You’re automatically redirected to the Okta sign-in page. Any child routes are also protected.
+4. Add a new file `app/protected/routes.ts` and define the route for this feature:
+
+   ```ts
+   import { Route } from '@angular/router';
+   import { ProtectedComponent } from './protected.component';
+
+   export const PROTECTED_FEATURE_ROUTES: Route[] = [
+      { path: '', component: ProtectedComponent }
+   ];
+   ```
+
+5. Make sure that you’re signed out, and then try going to `/protected`. You’re automatically redirected to the Okta sign-in page. Any child routes are also protected.

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/reqauthspecific.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/reqauthspecific.md
@@ -1,6 +1,6 @@
 The `OktaAuthGuard` can protect a route to a single component as well with `canActivate` property.
 
-1. Add the `canActivate` property to the `routes` array in `app-routing.module.ts`:
+1. Add the `canActivate` property to the `routes` array in `app.routes.ts`:
 
    ```ts
    { path: 'profile', component: ProfileComponent, canActivate: [OktaAuthGuard] }

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/specificlinks.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/specificlinks.md
@@ -1,10 +1,9 @@
 Angular documentation:
 
-See [Get started with Angular](https://angular.io/start) to learn about the framework from Angular's official documentation.
+See [What is Angular?](https://angular.dev/overview) to learn about the framework from Angular's official documentation.
 
 Okta Developer Blog:
 
+* [Flexible Authentication Configurations in Angular Applications Using Okta](https://developer.okta.com/blog/2024/02/28/okta-authentication-angular)
 * [Streamline Your Okta Configuration in Angular Apps](https://developer.okta.com/blog/2023/03/07/angular-forroot)
-* [Three Ways to Configure Modules in Your Angular App](https://developer.okta.com/blog/2022/02/24/angular-async-config)
-* [Build a Beautiful App + Login with Angular Material](https://developer.okta.com/blog/2020/01/21/angular-material-login)
 * [Use the Okta CLI to Quickly Build Secure Angular Apps](https://developer.okta.com/blog/2020/12/03/angular-okta)

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/useaccesstoken.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/useaccesstoken.md
@@ -1,53 +1,38 @@
 The recommended way to add your access token to HTTP calls in Angular is to use an interceptor. To follow security best practices, the access token should only be added on calls to allowed origins.
 
-1. Create an [Angular interceptor](https://angular.io/guide/http#intercepting-requests-and-responses) called `auth.interceptor`, using the CLI command `ng generate interceptor auth`.
+1. Create an [Angular interceptor](https://angular.dev/guide/http/interceptors) called `auth.interceptor`, using the CLI command `ng generate interceptor auth`.
 
 2. Add the following imports into `app.module.ts`:
 
    ```ts
-   import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
-   import { AuthInterceptor } from './auth.interceptor';
+   import { provideHttpClient, withInterceptors } from '@angular/common/http';
+   import { authInterceptor } from './auth.interceptor';
    ```
 
-3. Register the interceptor in `app.module.ts` by adding the following into the `providers` array:
+3. Register the interceptor in `app.config.ts` by adding the following into the `providers` array:
 
    ```ts
-   { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true }
+   provideHttpClient(withInterceptors([
+      authInterceptor
+    ]))
    ```
 
-4. Update `auth.interceptor.ts` to add the access code when calling a trusted origin:
+4. Update `auth.interceptor.ts` to add the access token when calling a trusted origin:
 
    ```ts
-   import { Inject, Injectable } from '@angular/core';
-   import {
-     HttpRequest,
-     HttpHandler,
-     HttpEvent,
-     HttpInterceptor
-   } from '@angular/common/http';
-   import { Observable } from 'rxjs';
+   import { inject } from '@angular/core';
+   import { HttpInterceptorFn } from '@angular/common/http';
    import { OKTA_AUTH } from '@okta/okta-angular';
-   import { OktaAuth } from '@okta/okta-auth-js';
 
-   @Injectable()
-   export class AuthInterceptor implements HttpInterceptor {
-
-     constructor(@Inject(OKTA_AUTH) private _oktaAuth: OktaAuth) {}
-
-     intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
-       return next.handle(this.addAuthHeaderToAllowedOrigins(request));
-     }
-
-     private addAuthHeaderToAllowedOrigins(request: HttpRequest<unknown>): HttpRequest<unknown> {
-       let req = request;
-       const allowedOrigins = ['http://localhost'];
-       if (!!allowedOrigins.find(origin => request.url.includes(origin))) {
-         const authToken = this._oktaAuth.getAccessToken();
-         req = request.clone({ setHeaders: { 'Authorization': `Bearer {authToken}` } });
+   export const authInterceptor: HttpInterceptorFn = (req, next, oktaAuth = inject(OKTA_AUTH)) => {
+      let request = req;
+      const allowedOrigins = ['http://localhost'];
+      const accessToken = oktaAuth.getAccessToken();
+      if (accessToken && !!allowedOrigins.find(origin => request.url.includes(origin))) {
+         request = req.clone({ setHeaders: { 'Authorization': `Bearer {accessToken}` } });
        }
 
-       return req;
-     }
+      return next(request);
    }
    ```
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/useaccesstoken.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/useaccesstoken.md
@@ -2,7 +2,7 @@ The recommended way to add your access token to HTTP calls in Angular is to use 
 
 1. Create an [Angular interceptor](https://angular.dev/guide/http/interceptors) called `auth.interceptor`, using the CLI command `ng generate interceptor auth`.
 
-2. Add the following imports into `app.module.ts`:
+2. Add the following imports into `app.config.ts`:
 
    ```ts
    import { provideHttpClient, withInterceptors } from '@angular/common/http';


### PR DESCRIPTION
## Description:
- **What's changed?** These changes updates the Angular quickstart to use Angular v19, standalone architecture, controlflow, Okta Angular v6.4, Okta AuthJS v7.8. It matches the code for the quickstart sample:

https://github.com/okta-samples/okta-angular-quickstart/pull/6

- **Is this PR related to a Monolith release?** No
