### PR TITLE
Update falsepos.txt

### DIFF
--- a/falsepos.txt
+++ b/falsepos.txt
@@ -29,3 +29,4 @@ https://app.getpostman.com/run-collection/f443644517abb15117af/
 https://odyssey.okta.design/latest/foundations/accessibility/color-9O9a4XAU/
 https://okta.com/free-trial/workforce-identity/
 https://www.jsonwebtoken.dev/
+https://www.w3.org/Security/wiki/Same_Origin_Policy/

--- a/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-url-domain/main/index.md
@@ -280,7 +280,7 @@ You can also use a tool such as `dig` or `nslookup` to test and verify that your
 
 2. Verify that the configured domain, for example, `org.Subdomain.customdomains.oktapreview.com` appears in the answer section of the output.
 
-> **Note:** There are also external tool versions of [dig](https://toolbox.googleapps.com/apps/dig) and [nslookup](https://network-tools.com/nslookup/) that you can use to validate that your custom domain is configured correctly.
+> **Note:** There are also external tool versions of [dig](https://toolbox.googleapps.com/apps/dig) and [nslookup](https://www.nslookup.io/) that you can use to validate that your custom domain is configured correctly.
 
 ### Flush the DNS cache
 


### PR DESCRIPTION


## Description:
- **What's changed?** The automated link checker is flagging this URL: [https://www.w3.org/Security/wiki/Same_Origin_Policy/](https://www.w3.org/Security/wiki/Same_Origin_Policy/) -- note trailing slash. This URL is in our repo, but without the trailing slash and renders fine ([https://www.w3.org/Security/wiki/Same_Origin_Policy](https://www.w3.org/Security/wiki/Same_Origin_Policy)). Adding the "broken", trailing slash to our false positives list.

I reviewed our documented false positives and noted one that is now a true positive. Updated the one reference to: [https://network-tools.com/nslookup/](https://network-tools.com/nslookup/)>
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* n/a
