### PR TITLE
Add back a URL mistakenly removed from falsepos.txt file

### DIFF
--- a/falsepos.txt
+++ b/falsepos.txt
@@ -25,5 +25,6 @@ https://app.getpostman.com/run-collection/f443644517abb15117af/
 https://odyssey.okta.design/latest/foundations/accessibility/color-9O9a4XAU/
 https://okta.com/free-trial/workforce-identity/
 https://www.jsonwebtoken.dev/
+https://www.w3.org/Security/wiki/Same_Origin_Policy/
 https://azure.microsoft.com/free/?WT.mc_id=A261C142F/
 https://azure.microsoft.com/free/


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Added back the URL: `https://www.w3.org/Security/wiki/Same_Origin_Policy/`, which is incorrectly flagged by the broken link checker script.
- **Is this PR related to a Monolith release?** n/a
### Resolves:

* n/a
