### PR TITLE
Fix typo in json response body for 3-number verification

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
@@ -4805,7 +4805,7 @@ curl -v -X POST \
         "timeZone": "America/Los_Angeles"
       }
     },
-    "factors": {
+    "factor": {
       "id": "opfh52xcuft3J4uZc0g3",
       "factorType": "push",
       "provider": "OKTA",


### PR DESCRIPTION
The response body for a 3-number verification contains a singlular "factor" not "factors". Update the example body to reflect this.

<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
