### PR TITLE
Client secret rotation and key mgmt - typo fix

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/client-secret-rotation-key/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/client-secret-rotation-key/main/index.md
@@ -20,11 +20,11 @@ This guide shows you how to rotate and manage your client secrets without servic
 #### What you need
 
 * [Okta Developer Edition organization](https://developer.okta.com/signup)
-* **OAuth secrets and key management** feature enabled in the Admin Console (**Settings** | **Features**)
-* Access to the new APIs: Client Secret Management `/api/v1/apps/{appId}/credentials/secrets` and JWKS Management `/api/v1/apps/{appId}/credentials/jwks`
+* **OAuth secrets and key management** enabled in the Admin Console (**Settings** | **Features**)
+* Access to client secret management APIs: `/api/v1/apps/{appId}/credentials/secrets` and JWKS management `/api/v1/apps/{appId}/credentials/jwks`. See [Application Client Auth Credentials](/openapi/okta-management/management/tag/ApplicationSSOCredentialOAuth2ClientAuth/).
 * An existing OpenID Connect client app in Okta for testing in Okta
 [Postman client](https://www.getpostman.com/downloads/) to test requests. See [Get Started with the Okta APIs](https://developer.okta.com/docs/reference/rest/) for information on setting up Postman.
-* The Client Secret Rotation and Key Management Postman Collection that allows you to test the API calls that are described in this guide. Click **Run in Postman** to add the collection to Postman.
+* The client secret rotation and Key management Postman Collection that allows you to test the API calls that are described in this guide. Click **Run in Postman** to add the collection to Postman.
 
   [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/8e9d91cef0d5ab9e9fa7)
 
@@ -34,17 +34,17 @@ This guide shows you how to rotate and manage your client secrets without servic
 
 Just like periodically changing passwords, regularly rotating the client secret that your app uses to authenticate is a security best practice. The challenge with rotating the client secret is to facilitate a seamless client secret rotation without service or app downtime. You need the ability to create overlapping client secrets.
 
-Also, depending on what type of credentials that a [client uses to authenticate](https://developer.okta.com/docs/api/openapi/okta-oauth/guides/client-auth/#client-authentication-methods), the use of a JSON Web Key (JWK) public/private key pair may be required. Apps that use private/public key pairs for client authentication have substantially higher security. This is because only the client can access the private key. But, private/public key pair generation is laborious and time-consuming, and using the API can lead to errors.
+Depending on what type of credentials that a [client uses to authenticate](https://developer.okta.com/docs/api/openapi/okta-oauth/guides/client-auth/#client-authentication-methods), a JSON Web Key (JWK) public/private key pair may be required. Apps that use private/public key pairs for client authentication have substantially higher security. This is because only the client can access the private key. But, private/public key pair generation is laborious and time-consuming, and using the API can lead to errors.
 
 ### Generate more secrets and JWKS
 
-To make client secret rotation more seamless, you can generate an additional client secret for web apps, service apps, and native apps in the Admin Console. You can also generate a JWK public/private key pair (in JWK format) or define a JWKS URI for your app using the Admin Console.
+To make client secret rotation more seamless, generate an additional client secret for web apps, service apps, and native apps in the Admin Console. You can also generate a JWK public/private key pair (in JWK format) or define a JWKS URI for your app using the Admin Console.
 
-> **Note:** Using client authentication with a client secret isn’t recommended for native apps because they’re public clients. The default authorization type for native apps is **Authorization Code with PKCE**. See [Recommended flow by application type](/docs/concepts/oauth-openid/#recommended-flow-by-application-type) and [Implement authorization by grant type](https://developer.okta.com/docs/guides/implement-grant-type/authcodepkce/main/) for more information on the type of flow to use for your app and how to implement that flow.
+> **Note:** Using client authentication with a client secret isn’t recommended for native apps because they’re public clients. The default authorization type for native apps is **Authorization Code with PKCE**. See [Choose an OAuth 2.0 flow](/docs/concepts/oauth-openid/#choose-an-oauth-2-0-flow) for more information on the type of flow to use. See [Implement authorization by grant type](https://developer.okta.com/docs/guides/implement-grant-type/authcodepkce/main/) for more information on how to implement that flow.
 
 ### About the Postman Collection
 
-It’s up to you how you make requests to the APIs to generate client secrets and manage JWKs. In this guide, Okta provides examples of the required API calls using a Postman Collection to demonstrate them in a language/platform neutral way. The collection contains two subcollections: Secret Management API for client secret generation and management tasks and JSON Web Key (JWK) Management API for key management tasks.
+It’s up to you how you make requests to the APIs to generate client secrets and manage JWKs. In this guide, Okta provides examples of the required API calls using a Postman Collection to demonstrate them in a language/platform neutral way. The collection contains two subcollections: secret management API for client secret generation and management tasks and JSON Web Key (JWK) management API for key management tasks.
 
 ## Rotate a client secret
 
@@ -52,35 +52,33 @@ When you’re ready to rotate a client secret for an app, follow these steps:
 
 1. Sign in to your Okta organization with your administrator account and go to **Applications** > **Applications**.
 
-2. Select the OpenID Connect app that you want to rotate the client secret for, and then click **Edit** in the **Client Credentials** section.
+1. Select the OpenID Connect app that you want to rotate the client secret for, and then click **Edit** in the **Client Credentials** section.
 
-3. Click **Generate new secret** in the **CLIENT SECRETS** section to create a client secret as a backup to your existing one. A second secret appears with the creation date. The maximum number of secrets that you can generate is two for each app.
+1. Click **Generate new secret** in the **CLIENT SECRETS** section to create a client secret as a backup to your existing one. A second secret appears with the creation date. The maximum number of secrets that you can generate is two for each app.
 
     > **Note:** You can try this in Postman using the **Add a client secret: auto-generated** request.
 
-    When you generate a new secret, the original secret remains in **Active** status. Both secrets are stored in parallel, allowing clients to continue using the old secret during secret rotation. Any requests for a secret return the newly generated client secret. Any requests that are sent using the previous secret still work. The requests continue to work until the status of that client secret is set to **Inactive**.
+    When you generate a new secret, the original secret remains in **Active** status. Both secrets are stored in parallel, allowing clients to continue using the old secret during secret rotation. Any request for a secret return the newly generated client secret. Any requests that are sent using the previous secret still work. The requests continue to work until the status of that client secret is set to **Inactive**.
 
-4. [Update your web app](/docs/guides/sign-into-web-app-redirect/-/main/#configure-your-app) to start using the newly generated client secret.
+1. [Update your web app](/docs/guides/sign-into-web-app-redirect/-/main/#configure-your-app) to start using the newly generated client secret. Test your app and ensure that all functionality works with the newly generated client secret.
 
-5. Test your app and ensure that all functionality works with the newly generated client secret.
-
-6. Return to the app's **Client secrets** section and change the old client secret status from **Active** to **Inactive**.
+1. Return to the app's **Client secrets** section and change the old client secret status from **Active** to **Inactive**.
 
     > **Note:** You can try this in Postman using the **Deactivate a client secret** request.
 
-7. Revalidate that your app works after changing the old client secret status to rule out any possibility that your app is using older credentials. Should there be any issues with your app, you can change the status of the old client secret back to **Active** and troubleshoot.
+1. Revalidate that your app works after changing the old client secret status to rule out any possibility that your app is using older credentials. Should there be any issues with your app, you can change the status of the old client secret back to **Active** and troubleshoot.
 
-8. Delete the old secret using the Admin Console by changing the status of the old secret from **Inactive** to **Delete**. This ensures that the older secret isn’t used by mistake.
+1. Delete the old secret using the Admin Console by changing the status of the old secret from **Inactive** to **Delete**. This ensures that the older secret isn’t used by mistake.
 
     > **Note:** You can try this in Postman using the **Delete a client secret** request.
 
-    > **Note:** If you turn off the **OAuth secrets and key management** feature in your org, and you have two secrets for an app, Okta retains the secret with the most recent **Creation date**.
+    > **Note:** If you turn off **OAuth secrets and key management**, and you have two secrets for an app, Okta retains the secret with the most recent **Creation date**.
 
 ## Generate JWK Key Pairs
 
 To use the Admin Console to generate a JWK key pair for your app for testing, follow these steps:
 
-> **Note:** Use the Admin Console to generate a JWK public/private key pair for testing purposes only. For a production use case, use your own internal instance of the key pair generator. See this [key pair generator](https://github.com/mitreid-connect/mkjwk.org) for an example.
+> **Note:** Use the Admin Console to generate a JWK public/private key pair for testing purposes only. For a production use case, use your own internal instance of the key pair generator. For an example, see [key pair generator](https://github.com/mitreid-connect/mkjwk.org).
 
 1. Sign in to your Okta organization with your administrator account and go to **Applications** > **Applications**.
 
@@ -102,13 +100,13 @@ This option allows you to bring your own keys or use the Okta key generator. The
 
 1. Leave the default of **Save keys in Okta**, and then click **Add key**.
 2. Click **Add**. The **Add a public key** dialog appears.
-3. Paste your own public key or click **Generate new key** to auto-generate a new 2048 bit RSA key:
+3. Paste your own public key or click **Generate new key** to auto-generate a new 2048-bit RSA key:
 
     * Paste your own public key into the box. Be sure to include a `kid` as all keys in the JWKS must have a unique ID.<br><br>
     **OR**<br>
     * Click **Generate new key** and the public and private keys appear in JWK format.
 
-        Some Okta SDKs require that keys be in Privacy Enhanced Mail (PEM) format. If you’re working with an Okta SDK that requires this format, click **PEM**. The private key appears in PEM format.
+        Some Okta SDKs require that keys be in privacy enhanced mail (PEM) format. If you’re using an Okta SDK that requires this format, click **PEM**. The private key appears in PEM format.
 
         This is your only opportunity to save the private key. Click **Copy to clipboard** to copy the private key and store it somewhere safe.
 
@@ -121,7 +119,7 @@ This option allows you to host your public key in a URI and paste the link to th
 
 > **Note:** If you switch from saving keys in Okta to using a URL to fetch keys dynamically, any saved public keys are deleted.
 
-1. After you select **Use a URL to fetch keys dynamically**, enter the URL where you’re hosting your public key in the **URL** box, for example: `https:/{yourOktaDomain}/oauth2/v1/keys`.
+1. After you select **Use a URL to fetch keys dynamically**, enter the URL that hosts your public key in the **URL** box, for example: `https:/{yourOktaDomain}/oauth2/v1/keys`.
 
     > **Note:** You can try this in Postman using the **Add a JWK URI** request.
 
@@ -143,7 +141,7 @@ To add more keys, deactivate a key, or delete a key, follow these steps:
     **OR**<br>
     * Click **Generate new key** and the public and private keys appear in JWK format.
 
-        Some Okta SDKs require that keys be in Privacy Enhanced Mail (PEM) format. If you’re working with an Okta SDK that requires this format, click **PEM**. The private key appears in PEM format.
+        Some Okta SDKs require that keys be in privacy enhanced mail (PEM) format. If you’re using an Okta SDK that requires this format, click **PEM**. The private key appears in PEM format.
 
         This is your only opportunity to save the private key. Click **Copy to clipboard** to copy the private key and store it somewhere safe.
 

--- a/packages/@okta/vuepress-site/docs/guides/client-secret-rotation-key/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/client-secret-rotation-key/main/index.md
@@ -21,7 +21,7 @@ This guide shows you how to rotate and manage your client secrets without servic
 
 * [Okta Developer Edition organization](https://developer.okta.com/signup)
 * **OAuth secrets and key management** feature enabled in the Admin Console (**Settings** | **Features**)
-* Access to the new APIs: Client Secret Management `/api/v1/apps/{appId}//credentials/secrets` and JWKS Management `/api/v1/apps/{appId}/credentials/jwks`
+* Access to the new APIs: Client Secret Management `/api/v1/apps/{appId}/credentials/secrets` and JWKS Management `/api/v1/apps/{appId}/credentials/jwks`
 * An existing OpenID Connect client app in Okta for testing in Okta
 [Postman client](https://www.getpostman.com/downloads/) to test requests. See [Get Started with the Okta APIs](https://developer.okta.com/docs/reference/rest/) for information on setting up Postman.
 * The Client Secret Rotation and Key Management Postman Collection that allows you to test the API calls that are described in this guide. Click **Run in Postman** to add the collection to Postman.

--- a/packages/@okta/vuepress-site/docs/guides/client-secret-rotation-key/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/client-secret-rotation-key/main/index.md
@@ -20,11 +20,10 @@ This guide shows you how to rotate and manage your client secrets without servic
 #### What you need
 
 * [Okta Developer Edition organization](https://developer.okta.com/signup)
-* **OAuth secrets and key management** enabled in the Admin Console (**Settings** | **Features**)
 * Access to client secret management APIs: `/api/v1/apps/{appId}/credentials/secrets` and JWKS management `/api/v1/apps/{appId}/credentials/jwks`. See [Application Client Auth Credentials](/openapi/okta-management/management/tag/ApplicationSSOCredentialOAuth2ClientAuth/).
 * An existing OpenID Connect client app in Okta for testing in Okta
 [Postman client](https://www.getpostman.com/downloads/) to test requests. See [Get Started with the Okta APIs](https://developer.okta.com/docs/reference/rest/) for information on setting up Postman.
-* The client secret rotation and Key management Postman Collection that allows you to test the API calls that are described in this guide. Click **Run in Postman** to add the collection to Postman.
+* The client secret rotation and key management Postman Collection that allows you to test the API calls that are described in this guide. Click **Run in Postman** to add the collection to Postman.
 
   [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/8e9d91cef0d5ab9e9fa7)
 
@@ -58,7 +57,7 @@ When you’re ready to rotate a client secret for an app, follow these steps:
 
     > **Note:** You can try this in Postman using the **Add a client secret: auto-generated** request.
 
-    When you generate a new secret, the original secret remains in **Active** status. Both secrets are stored in parallel, allowing clients to continue using the old secret during secret rotation. Any request for a secret return the newly generated client secret. Any requests that are sent using the previous secret still work. The requests continue to work until the status of that client secret is set to **Inactive**.
+    When you generate a new secret, the original secret remains in **Active** status. Both secrets are stored in parallel, allowing clients to continue using the old secret during secret rotation. Any request for a secret returns the newly generated client secret. Any requests that are sent using the previous secret still work. The requests continue to work until the status of that client secret is set to **Inactive**.
 
 1. [Update your web app](/docs/guides/sign-into-web-app-redirect/-/main/#configure-your-app) to start using the newly generated client secret. Test your app and ensure that all functionality works with the newly generated client secret.
 


### PR DESCRIPTION


## Description:
- **What's changed?** Removed extraneous backslash from request path

See: https://developer.okta.com/docs/guides/client-secret-rotation-key/main/ , third bullet of What you need

As per: https://github.com/okta/okta-developer-docs/pull/5270
- **Is this PR related to a Monolith release?** n/a

### Resolves:

* https://github.com/okta/okta-developer-docs/pull/5270
