### PR TITLE
fixed misleading description

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/aspnetcore3/configureapi.md
+++ b/packages/@okta/vuepress-site/docs/guides/protect-your-api/main/aspnetcore3/configureapi.md
@@ -4,7 +4,7 @@
    {
      "Okta": {
        "OktaDomain": "https://{yourOktaDomain}",
-       "AuthorizationServerId": "{yourAuthServerName}",
+       "AuthorizationServerId": "{yourAuthServerId}",
        "Audience": "{yourAudience}"
      }
    }


### PR DESCRIPTION
We need the AuthServerId in the config and not the AuthServerName

<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)
