### PR TITLE
Update Style the Sign-In Widget (third generation) Guide

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -140,9 +140,9 @@ To update UI elements, consider the following example:
 
     oktaSignIn.on('afterRender', function (ctx) { // ← Restores the context
       // Resets the global context object for reference using the callback function
-      contextObj = context;
+      contextObj = ctx;
       // The following condition only executes the observer for specific views/forms
-      if (context.formName === 'identify' || context.formName === 'reset-authenticator') {
+      if (ctx.formName === 'identify' || ctx.formName === 'reset-authenticator') {
         // Pauses
         observer.disconnect();
 


### PR DESCRIPTION

## Description:
- **What's changed?** As per @askouras and [PR#5282](https://github.com/okta/okta-developer-docs/pull/5282/files), updates to [Style the Sign-In Widget (third generation) guide](https://developer.okta.com/docs/guides/custom-widget-gen3/main/).

Corrected code sample for MutationObserver method to replace references to the non-existent 'context' with the existing 'ctx'

- **Is this PR related to a Monolith release?** n/a

### Resolves:

* n/a
