### PR TITLE
OKTA-636257 - Update deprecated Google documentation link in the Social Login page

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/social-login/main/google/appatidp.md
+++ b/packages/@okta/vuepress-site/docs/guides/social-login/main/google/appatidp.md
@@ -2,7 +2,7 @@ At Google, create the client application that you want to use for authenticating
 
 1. Make sure that you can access the [Google Developers Console](https://console.developers.google.com/).
 
-1. Create a Google project using these [instructions](https://developers.google.com/identity/sign-in/web/sign-in#before_you_begin).
+1. Create a Google project using these [instructions](https://developers.google.com/identity/gsi/web/guides/get-google-api-clientid).
 
 1. In the **Authorized redirect URIs** section of the creation wizard, click **ADD URI** to add the Okta redirect URI for your app integration.
 

--- a/packages/@okta/vuepress-site/docs/guides/social-login/main/google/appatidp.md
+++ b/packages/@okta/vuepress-site/docs/guides/social-login/main/google/appatidp.md
@@ -1,4 +1,4 @@
-At Google, create the client application that you want to use for authenticating and authorizing your users.
+At Google, create the client app that you want to use for authenticating and authorizing your users.
 
 1. Make sure that you can access the [Google Developers Console](https://console.developers.google.com/).
 
@@ -8,12 +8,12 @@ At Google, create the client application that you want to use for authenticating
 
 1. Paste your redirect URI into the text box.
 
-    The redirect URI is the location where the Identity Provider (IdP) sends the authentication response (the access token and the ID token). The URI sent in the authorize request from the client needs to match the redirect URI set at the IdP. The URI needs to be located in a secure domain that you own. This URI has the same structure for most Identity Providers in Okta and is constructed using your Okta subdomain and the callback endpoint.
+    The redirect URI is the location where the Identity Provider (IdP) sends the authentication response (the access token and the ID token). The URI sent in the authorized request from the client needs to match the redirect URI set at the IdP. The URI needs to be located in a secure domain that you own. This URI has the same structure for most Identity Providers in Okta and is constructed using your Okta subdomain and the callback endpoint.
 
-    For example, if your Okta subdomain is called `company`, then the URL would be: `https://company.okta.com/oauth2/v1/authorize/callback`. If you have configured a custom domain in your Okta Org, use that value to construct your redirect URI, such as `https://login.company.com/oauth2/v1/authorize/callback`.
+    For example, if your Okta subdomain is called `company`, then the URL would be: `https://company.okta.com/oauth2/v1/authorize/callback`. If you’ve configured a custom domain in your Okta Org, use that value to construct your redirect URI, such as `https://login.company.com/oauth2/v1/authorize/callback`.
 
     Include all base domains (Okta domain and custom domain) that your users will interact with in the allowed redirect URI list.
 
 1. Save the generated Client ID and Client Secret values so that you can add them to your Okta configuration.
 
-> **Note:** There may be additional settings on the [Google Developers Console](https://console.developers.google.com) site that you can configure for your application. The steps in this guide address the quickest route to setting up Google as an Identity Provider with Okta. See the Google documentation for more information on additional configuration settings.
+> **Note:** There may be additional settings on the [Google Developers Console](https://console.developers.google.com) site that you can configure for your app. The steps in this guide address the quickest route to setting up Google as an Identity Provider with Okta. See the Google documentation for more information on additional configuration settings.


### PR DESCRIPTION
## Description:
- **What's changed?** Update deprecated Google documentation link in the Social Login page based on customer feedback.
- **Is this PR related to a Monolith release?** No
### Resolves:

* [OKTA-636257](https://oktainc.atlassian.net/browse/OKTA-636257)
