### PR TITLE
OKTA-921857| Updated based on Support ticket - Remove dev org reference

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/scim-with-entitlements/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/scim-with-entitlements/main/index.md
@@ -17,7 +17,6 @@ This guide teaches you how to create a System for Cross-domain Identity Manageme
 
 #### What you need
 
-* [Okta Developer Edition org](https://developer.okta.com/signup)
 * Some basic development experience with the SCIM [core schema](https://datatracker.ietf.org/doc/html/rfc7643) and [protocol](https://datatracker.ietf.org/doc/html/rfc7644)
 * [Okta Identity Governance](https://help.okta.com/okta_help.htm?type=oie&id=ext-iga) to use [entitlements](https://help.okta.com/okta_help.htm?type=oie&id=ext-entitlement-mgt)
 


### PR DESCRIPTION

## Description:
- **What's changed?** Remove the reference to Okta Developer Edition org as Entitlements are associated with Okta Identity Governance which cannot be enabled in a dev org. Updated based on the Support ticket. 
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-921857](https://oktainc.atlassian.net/browse/OKTA-921857)
