### PR TITLE
OKTA-940225 - Update broken link

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/loginredirect.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/loginredirect.md
@@ -1,4 +1,4 @@
-The `OktaAuthStateService` and `OktaAuth` services are used together to support sign-in and sign-out actions. The `OktaAuthStateService` contains `authState$`, an [RxJS Observable](https://rxjs.dev/guide/observable) that you can use to get the current authenticated state.
+The `OktaAuthStateService` and `OktaAuth` services are used together to support sign-in and sign-out actions. The `OktaAuthStateService` contains `authState$`, an [RxJS Observable](https://rxjs-dev.firebaseapp.com/guide/observable) that you can use to get the current authenticated state.
 
 The `OktaAuth` service has methods for sign-in and sign-out actions.
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Link to RxJS Observable is down; updated to https://rxjs-dev.firebaseapp.com/guide/observable in this guide: https://developer.okta.com/docs/guides/sign-into-spa-redirect/angular/main/#redirect-to-the-sign-in-page
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-940225](https://oktainc.atlassian.net/browse/OKTA-940225)
