### PR TITLE
Validate access tokens (Java): add note about verifier limitations

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/validate-access-tokens/main/java/accesstoken.md
+++ b/packages/@okta/vuepress-site/docs/guides/validate-access-tokens/main/java/accesstoken.md
@@ -1,6 +1,6 @@
 See the instructions for the [Okta JSON Web Token (JWT) Verifier for Java](https://github.com/okta/okta-jwt-verifier-java).
 
-> **Note:** Use the JWT Verifier for Java on a resource server that runs an API Service. Don't use the verifier as part of a mobile app. Minor network delays could trigger the one second default timeout.
+> **Note:** Use the Okta JWT Verifier for Java on a resource server that runs an API Service. Don't use the verifier as part of a mobile app. Minor network delays could trigger the one second default timeout.
 
 ### Required libraries
 
@@ -23,7 +23,10 @@ Include the following lines in your Maven `pom.xml`:
 </dependency>
 ```
 
-> **Note:** Replace `{okta-jwt.version}` in your Maven `pom.xml` with the latest version from the [Maven central repository](https://search.maven.org/search?q=a:okta-jwt-verifier).
+> **Notes:**
+>
+> * Replace `{okta-jwt.version}` in your Maven `pom.xml` with the latest version from the [Maven central repository](https://search.maven.org/search?q=a:okta-jwt-verifier).
+> * Use the Okta JWT Verifier for Java on a resource server that runs an API Service. Don't use the verifier as part of a mobile app. Minor network delays could trigger the one second default timeout.
 
 ### Validate access token
 

--- a/packages/@okta/vuepress-site/docs/guides/validate-access-tokens/main/java/accesstoken.md
+++ b/packages/@okta/vuepress-site/docs/guides/validate-access-tokens/main/java/accesstoken.md
@@ -1,5 +1,7 @@
 See the instructions for the [Okta JSON Web Token (JWT) Verifier for Java](https://github.com/okta/okta-jwt-verifier-java).
 
+> **Note:** Use the JWT Verifier for Java on a resource server that runs an API Service. Don't use the verifier as part of a mobile app. Minor network delays could trigger the one second default timeout.
+
 ### Required libraries
 
 To validate a JWT, you need the Okta JWT Verifier for Java library.


### PR DESCRIPTION
## Description:
- **What's changed?** Adds a note describing how best to use the Okta JWT Verifier for Java library.
- **Is this PR related to a Monolith release?** No.

### Resolves:

* [OKTA-694703](https://oktainc.atlassian.net/browse/OKTA-694703)
