### PR TITLE
Logs missing snippets

### DIFF
--- a/packages/@okta/vuepress-theme-prose/util/guides.js
+++ b/packages/@okta/vuepress-theme-prose/util/guides.js
@@ -3,7 +3,7 @@ import { commonify, fancify, iconify, cssForIcon } from './frameworks';
 const PATH_LIKE = '(?:([^\/]*)\/?)';
 const FILE_LIKE = '(?:([^\.\/]*)\.?[^\.\/]*$)';
 const FRAGMENTS = '/docs/guides/';
-const DEFAULT_FRAMEWORK = '-'; 
+const DEFAULT_FRAMEWORK = '-';
 const DEFAULT_SECTION = '';
 
 export const guideFromPath = path => {
@@ -11,7 +11,7 @@ export const guideFromPath = path => {
   let framework;
   let sectionName;
   [, guideName, sectionName ] = path.match(`${FRAGMENTS}${PATH_LIKE}${PATH_LIKE}$`) || [];
-  if( !sectionName ) { 
+  if( !sectionName ) {
     [, guideName, framework, sectionName ] = path.match(`${FRAGMENTS}${PATH_LIKE}${PATH_LIKE}${PATH_LIKE}`) || [];
   }
   framework = framework === DEFAULT_FRAMEWORK ? '' : framework; // Drop useless default
@@ -28,22 +28,22 @@ export const makeGuidePath = ({ guideName, framework, sectionName }) => {
 
 export const alphaSort = (a,b) => a > b ? 1 : a < b ? -1 : 0;
 
-const recordGuidesMeta = ({ guidesInfo, page }) => { 
+const recordGuidesMeta = ({ guidesInfo, page }) => {
   guidesInfo.order = page.frontmatter.guides || [];
   guidesInfo.featured = page.frontmatter.featured || [];
 };
 
-const recordGuideMeta = ({ guide, page, guideName, framework }) => { 
+const recordGuideMeta = ({ guide, page, guideName, framework }) => {
   guide.order = page.frontmatter.sections || [];
   guide.makeLink =  framework => makeGuidePath({ guideName, framework, sectionName: guide.order[0] });
   guide.excerpt = page.frontmatter.excerpt || '';
   guide.title = page.frontmatter.title || guideName;
-  guide.name = guideName; 
+  guide.name = guideName;
   guide.page = page;
   guide.componentKey = page.key;
 };
 
-const recordSectionMeta = ({ section, page, guideName, sectionName }) => { 
+const recordSectionMeta = ({ section, page, guideName, sectionName }) => {
   section.name = sectionName;
   section.page = page;
   section.componentKey = page.key;
@@ -53,27 +53,27 @@ const recordSectionMeta = ({ section, page, guideName, sectionName }) => {
   section.makeLink = framework => makeGuidePath({ guideName, framework, sectionName });
 };
 
-const recordSnippetMeta = ({ section, page, framework, guideName, sectionName, snippet }) => { 
+const recordSnippetMeta = ({ section, page, framework, guideName, sectionName, snippet }) => {
   const name = commonify(framework);
   const title = fancify(name);
   section.frameworkByName = section.frameworkByName || {};
   section.frameworkByName[framework] = section.frameworkByName[framework] || {};
-  section.frameworkByName[framework][snippet] = { 
+  section.frameworkByName[framework][snippet] = {
     framework,
     snippet,
-    name, 
+    name,
     title,
     label: title,
     css: cssForIcon(name),
     link: makeGuidePath({ guideName, framework, sectionName }),
-    page, 
+    page,
     componentKey: page.key,
   };
   section.snippetByName = section.snippetByName || {};
   section.snippetByName[snippet] = section.snippetByName[snippet] || {};
 };
 
-const recordMeta = ({ guidesInfo, page }) => { 
+const recordMeta = ({ guidesInfo, page }) => {
   const guideParts = new RegExp(`^${FRAGMENTS}${PATH_LIKE}${PATH_LIKE}${PATH_LIKE}${FILE_LIKE}`);
   const [,guideName, sectionName, framework, snippet] = page.regularPath.match(guideParts);
   const isGuidesMeta = !guideName;
@@ -99,25 +99,25 @@ const recordMeta = ({ guidesInfo, page }) => {
   return recordSnippetMeta({ section, page, framework, guideName, sectionName, snippet });
 };
 
-const collectFrameworksFromSections = ({ sections }) => { 
-  const includedFrameworks = sections.reduce( (all, section) => { 
+const collectFrameworksFromSections = ({ sections }) => {
+  const includedFrameworks = sections.reduce( (all, section) => {
     Object.keys(section.frameworkByName).forEach( framework => all[framework] = true );
     return all;
   }, {});
   return Object.keys(includedFrameworks).sort(alphaSort);
 };
 
-const updateDerivedMeta = ({ guidesInfo }) => { 
+const updateDerivedMeta = ({ guidesInfo }) => {
   // List of guides in order
   guidesInfo.guides = guidesInfo.order.map( guideName => guidesInfo.byName[guideName] );
 
   // Each guide gets a list of sections in order
-  guidesInfo.guides.forEach( guide => { 
+  guidesInfo.guides.forEach( guide => {
     guide.sections = guide.order.map( sectionName => guide.sectionByName[sectionName]);
   });
   // Each guide assigns:
-  guidesInfo.guides.forEach( guide => { 
-    guide.sections.forEach( section => { 
+  guidesInfo.guides.forEach( guide => {
+    guide.sections.forEach( section => {
       // ...each section a list of frameworks in order
       section.frameworks = Object.keys(section.frameworkByName).sort(alphaSort);
       // ...each section a mainFramework
@@ -126,7 +126,13 @@ const updateDerivedMeta = ({ guidesInfo }) => {
       );
       // ...each snippet within each section a list of frameworks in order
       Object.entries(section.snippetByName).forEach( ([snippetName, snippet]) => {
-        snippet.frameworks = section.frameworks.map( framework => section.frameworkByName[framework][snippetName] );
+        snippet.frameworks = section.frameworks.map( framework => {
+            if (!section.frameworkByName[framework][snippetName]) {
+                console.warn(`Guide: ${guide.name}  Snippet: /${framework}/${snippetName}.htm is missing`);
+                // throw new Error(`Guide: ${guide.name}  Snippet: /${framework}/${snippetName}.htm is missing`);
+            }
+            return section.frameworkByName[framework][snippetName];
+        });
       });
       // ...each guide a mainFramework from the sections
       guide.mainFramework = guide.mainFramework || section.mainFramework;
@@ -136,7 +142,7 @@ const updateDerivedMeta = ({ guidesInfo }) => {
   });
 };
 
-export const buildGuidesInfo = ({ pages }) => { 
+export const buildGuidesInfo = ({ pages }) => {
   const guidesInfo = { byName: {} };
   const withinGuides = new RegExp(`^${FRAGMENTS}`);
 
@@ -148,6 +154,6 @@ export const buildGuidesInfo = ({ pages }) => {
 };
 
 let guidesInfo; // singleton for getGuideInfo()
-export const getGuidesInfo = ({ pages }) => { 
+export const getGuidesInfo = ({ pages }) => {
   return guidesInfo || (guidesInfo = buildGuidesInfo({ pages }));
 }


### PR DESCRIPTION
### Changes
- Missing or unused snippets in framework folders may cause build failures. Detecting those and print to console will help to get rid of those.

### Resolves:
* [OKTA-953348](https://oktainc.atlassian.net/browse/OKTA-953348)
