### PR TITLE
Removes /reference/api/ pages from sitemap

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/config.js
+++ b/packages/@okta/vuepress-site/.vuepress/config.js
@@ -402,6 +402,12 @@ module.exports = ctx => ({
     // add redir url for main guide pages
     let found = guidesInfo.guideInfo[path];
 
+    if (path.startsWith('/docs/reference/api/')) {
+        frontmatter.sitemap = {
+          exclude: true
+        };
+    }
+
     if (path.endsWith('/main/')) {
       // For paths such as /docs/guides/{guide-name}/main/ where the guide has stack selector/frameworks
       let mainPagePath = path.slice(0, -'main/'.length);;


### PR DESCRIPTION
## Description:
- Removes `/reference/api/` stub pages from a sitemap so they won't appear in google search results.
- https://preview-5513--reverent-murdock-829d24.netlify.app/docs-sitemap.xml does not have `/reference/api/` pages
 
### Resolves:
* [OKTA-954355](https://oktainc.atlassian.net/browse/OKTA-954355)
