### PR TITLE
Aj okta 978585 spa redirect doc updates (#5589)

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/configmid.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/configmid.md
@@ -2,14 +2,20 @@ The Okta Angular SDK requires an instance of an `OktaAuth` object with configura
 
 Make the following changes to `src/app/app.config.ts`:
 
-1. Add the following import lines to the code to pull in the dependencies:
+1. Update the import from `@angular/core` by adding `importProvidersFrom`:
+
+   ```typescript
+   import { ApplicationConfig, importProvidersFrom, /* other imports */ } from '@angular/core';
+   ```
+
+2. Add the following import lines to the code to pull in the dependencies:
 
    ```ts
    import { OktaAuthModule } from '@okta/okta-angular';
    import { OktaAuth } from '@okta/okta-auth-js';
    ```
 
-2. Add an `OktaAuth` object before the `appConfig` as follows, replacing the placeholder values with your own values (see [Find your config values](/docs/guides/sign-into-spa-redirect/angular/main/#find-your-config-values)):
+3. Add an `OktaAuth` object before the `appConfig` as follows, replacing the placeholder values with your own values (see [Find your config values](/docs/guides/sign-into-spa-redirect/angular/main/#find-your-config-values)):
 
    ```ts
    const oktaAuth = new OktaAuth({
@@ -20,12 +26,12 @@ Make the following changes to `src/app/app.config.ts`:
    });
    ```
 
-3. Add the Okta configuration to the `OktaAuthModule` static `forRoot` method in the `ApplicationConfig` object using the `importProvidersFrom` function:
+4. Add the Okta configuration to the `OktaAuthModule` static `forRoot` method in the `ApplicationConfig` object using the `importProvidersFrom` function:
 
    ```ts
    export const appConfig: ApplicationConfig = {
     providers: [
-      // other providers as required
+      // add other providers as required
       importProvidersFrom(
            OktaAuthModule.forRoot({ oktaAuth })
       )

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/createproject.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/createproject.md
@@ -1,10 +1,10 @@
 
 You need recent versions of [Node](https://nodejs.org/en/) and [npm](https://www.npmjs.com/). Okta also recommends installing the [Angular CLI](https://angular.dev/tools/cli).
 
-Create an Angular app named **okta-angular-quickstart** using the following command. Choose any style sheet format you want when it asks you which format you want to use.
+Create an Angular app named **okta-angular-quickstart** using the following command.
 
 ```shell
-npx @angular/cli@19 new okta-angular-quickstart --ssr=false
+npx @angular/cli@19 new okta-angular-quickstart --ssr=false --style=css
 ```
 
 This creates an Angular app using version 19 regardless of the version of the Angular CLI installed on your system.

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/getuserinfo.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/getuserinfo.md
@@ -39,7 +39,7 @@ The `authState$` subject in `OktaAuthStateService` contains an `idToken` that co
     import { ProfileComponent } from './profile/profile.component';
     ```
 
-4. Add the following to the `routes` array:
+4. Add the following to the `routes` array if it's not there:
 
     ```typescript
     { path: 'profile', component: ProfileComponent }

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/loginredirect.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/loginredirect.md
@@ -2,7 +2,7 @@ The `OktaAuthStateService` and `OktaAuth` services are used together to support 
 
 The `OktaAuth` service has methods for sign-in and sign-out actions.
 
-1. Add buttons, to support sign-in and sign-out actions, to the component template (`app.component.html`), just inside the `<main class="main"></main>` so that they’re visible. Display either the sign-in or sign-out button based on the current authenticated state.
+1. Update the component template `app.component.html` to add buttons, to support sign-in and sign-out actions, just inside the `<main class="main"></main>` so that they’re visible. Either the sign-in or sign-out button displays based on the current authenticated state.
 
    ```html
    @if (isAuthenticated$ | async) {

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/redirectvalues.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/redirectvalues.md
@@ -1,2 +1,2 @@
-* **Redirect URI**: `http://localhost:4200/login/callback`
-* **Post Logout Redirect URI(s)**: select the default option, `http://localhost:4200`
+* **Sign-in Redirect URIs**: `http://localhost:4200/login/callback`
+* **Sign-out Redirect URIs**: `http://localhost:4200`

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/index.md
@@ -44,22 +44,24 @@ An app integration represents your app in your Okta org. The integration configu
 
 To create your app integration in Okta using the Admin Console:
 
-1. [Sign in to your Okta organization](https://developer.okta.com/login) with your administrator account.
+1. [Sign in to your Okta org](https://developer.okta.com/login) with your administrator account.
 1. Click **Admin** in the upper-right corner of the page.
 1. Open the Applications page by selecting **Applications** > **Applications**.
 1. Click **Create App Integration**.
 1. Select a **Sign-in method** of **OIDC - OpenID Connect**.
 1. Select an **Application type** of **Single-Page Application**, then click **Next**.
    > **Note:** If you choose an inappropriate app type, it can break the sign-in or sign-out flows by requiring the verification of a client secret. Public clients don't have a client secret.
-1. Enter an **App integration name**.
+1. Enter an **App integration name**. For example, "My SPA".
 1. Select **Authorization Code** and **Refresh Token** as the **Grant type**. This enables the Authorization Code flow with PKCE for your app. It also can refresh the access token when it expires without prompting the user to reauthenticate.
 1. Enter the **Sign-in redirect URIs** and **Sign-out redirect URIs** for both local development, such as `http://localhost:xxxx/login/callback`, and for production, such as `https://app.example.com/login/callback`:<br>
 
     <StackSnippet snippet="redirectvalues" />
+
+   > **Note:** The values suggested here are those used in the sample app.
 1. Select the type of **Controlled access** for your app in the **Assignments** section. You can allow all users to have access or limit access to individuals and groups. See the [Assign app integrations](https://help.okta.com/okta_help.htm?type=oie&id=ext-lcm-user-app-assign) topic in the Okta product documentation.
 1. Click **Save** to create the app integration and open its configuration page. Keep this page open as you need to copy some values in later steps when configuring your app.
 1. On the **General** tab, scroll to **General Settings** and click **Edit**.
-1. Verify that the **Refresh Token** is selected as a **Grant type**. In the **Refresh Token** section, [refresh token rotation](/docs/guides/refresh-tokens/main/#refresh-token-rotation) is automatically set as the default refresh token behavior.
+1. Verify that the **Refresh Token** is selected as a **Grant type**. In the **Refresh Token** section, **Rotate token after every use**  is automatically set as the default refresh token behavior. See [Refresh token rotation](/docs/guides/refresh-tokens/main/#refresh-token-rotation).
    > **Note:** By default, the **Grace period for token rotation** is set to 30 seconds. You can [change the rotation period](/docs/guides/refresh-tokens/main/#enable-refresh-token-rotation) to between 0 and 60 seconds. After the refresh token is rotated, the previous token remains valid for this amount of time to allow clients to get the new token. Using a value of 0 indicates that there's no grace period. However, a grace period of 0 doesn't necessarily mean that the previous refresh token is immediately invalidated. That token is invalidated after the new one is generated and returned in the response.
 1. In the **Login** section, specify an **Initiate login URI** to have Okta initiate the sign-in flow. When Okta redirects to this URI (for example, `https://example.com:xxxx/login`), the client is triggered to send an authorize request. This URI is also used when users reset their passwords while signing in to the app. Okta redirects the user back to this URI after the password is reset so that the user can continue to sign in.
 1. Click **Save**.

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/react/loginredirect.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/react/loginredirect.md
@@ -10,7 +10,7 @@ const signin = async () => await oktaAuth.signInWithRedirect();
 const signout = async () => await oktaAuth.signOut();
 ```
 
-Add the buttons to support sign-in and sign-out actions. You can display either the sign-in or sign-out button based on the current authenticated state. Replace the `{/* Add sign in and sign out buttons */}`.
+Add the buttons to support sign-in and sign-out actions. You can display either the sign-in or sign-out button based on the current authenticated state. Replace the `{/* Add sign in and sign out buttons */}` with the following.
 
 ```jsx
 <div>

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/react/redirectvalues.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/react/redirectvalues.md
@@ -1,2 +1,2 @@
-* **Redirect URI**: `http://localhost:5173/login/callback`
-* **Post Logout Redirect URI(s)** select the default option, `http://localhost:5173`
+* **Sign-in Redirect URIs**: `http://localhost:5173/login/callback`
+* **Sign-out Redirect URIs**: `http://localhost:5173`

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/vue/createproject.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/vue/createproject.md
@@ -6,12 +6,12 @@ You need recent versions of [Node](https://nodejs.org/en/) and [npm](https://www
    npm create vue@3.11.2
    ```
 
-1. You're asked to name the project and manually select features. Name the project `okta-vue-quickstart` and:
-
-    * Select **No** for TypeScript.
-    * Select **No** for JSX Support.
-    * Select **Y** to add Vue Router for SPA development.
-    * Select the defaults for the other options.
+1. You're asked to name the project and manually select features:
+   * Name the project `okta-vue-quickstart`.
+   * Select **No** for TypeScript.
+   * Select **No** for JSX Support.
+   * Select **Yes** to add Vue Router for SPA development.
+   * Select the defaults for the other options.
 
 1. Go into your app's root app directory to view the created files and install dependencies:
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/vue/getuserinfo.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/vue/getuserinfo.md
@@ -84,13 +84,13 @@
    import ProfileView from '../views/ProfileView.vue'
    ```
 
-6. Add a new route to the `index.js` `routes` array:
+6. In the same `index.js` file, add a new route to the top of the `routes` array in the same file:
 
    ```ts
    {
      path: '/profile',
      component: ProfileView,
-   }
+   },
    ```
 
 This component is available at a `/profile` route and displays the user their profile info.

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/vue/handlecallback.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/vue/handlecallback.md
@@ -6,7 +6,7 @@ The Okta Vue SDK provides the [LoginCallback](https://github.com/okta/okta-vue#u
    import { LoginCallback, navigationGuard } from '@okta/okta-vue'
    ```
 
-2. Add a new route for the callback to the `routes` array. The path should match the path provided in the `redirectUri` property inside the `src/config.js` file.
+2. Add a new route for the callback to `routes` array. The path should match the path provided in the `redirectUri` property inside the `src/config.js` file.
 
    ```js
    {

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/vue/loginredirect.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/vue/loginredirect.md
@@ -17,7 +17,7 @@
      .mount('#app')
    ```
 
-2. Add buttons to support sign-in and sign-out actions inside the `src/components/HelloWorld.vue` component `<template>` element. Display either the sign-in or sign-out button based on the current authenticated state.
+2. Add buttons to support sign-in and sign-out actions inside the `src/components/HelloWorld.vue` component `<template>` element. Either the sign-in or sign-out button displays based on the current authenticated state.
 
    ```html
    <div>

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/vue/redirectvalues.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/vue/redirectvalues.md
@@ -1,2 +1,2 @@
-* **Redirect URI**: `http://localhost:5173/login/callback`
-* **Post Logout Redirect URI(s)** select `http://localhost:5173`
+* **Sign-in Redirect URIs**: `http://localhost:5173/login/callback`
+* **Sign-out Redirect URIs**: `http://localhost:5173`


### PR DESCRIPTION

Recreating the PR because I merged it into the wrong PR.

## Description:
- **What's changed?** <!-- Describe your changes. This will most likely be a copy-paste of your commit message(s), which should be descriptive and informative. -->
   * Initial minor changes to docs

  * A few more tweaks for Angular version of doc
  
  * Update packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/configmid.md
  
  * Matching the UI
  
  * Apply suggestions from code review
  
  * Update packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/vue/handlecallback.md
  
  * Update packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/createproject.md
  
  * Update packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/createproject.md
  
  * More feedback from Alisa
  
  * Update packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/configmid.md

- **Is this PR related to a Monolith release?** <!-- If so, which one? --> N/A

### Resolves:

* [OKTA-978585](https://oktainc.atlassian.net/browse/OKTA-978585)
