### PR TITLE
Fixes framework

### DIFF
--- a/packages/@okta/vuepress-theme-prose/const/navbar.const.js
+++ b/packages/@okta/vuepress-theme-prose/const/navbar.const.js
@@ -748,7 +748,7 @@ export const guides = [
           },
           {
             title: "Express Configuration",
-            path: "/docs/guides/express-configuration/main",
+            path: "/docs/guides/express-configuration/main/",
             subLinks: [
               {
                 title: "Enable Express Configuration",

--- a/packages/@okta/vuepress-theme-prose/util/contentBuilder.js
+++ b/packages/@okta/vuepress-theme-prose/util/contentBuilder.js
@@ -35,6 +35,9 @@ function createContentInfo({
       [, name, framework, sectionName] = path.match(`${fragment}${PATH_LIKE}${PATH_LIKE}${PATH_LIKE}`) || [];
     }
     framework = framework === DEFAULT_FRAMEWORK ? '' : framework;
+    if (framework) {
+        framework = framework.toLowerCase();
+    }
     sectionName = sectionName || DEFAULT_SECTION;
     return { [`${type}Name`]: name, framework, sectionName };
   };
@@ -107,7 +110,7 @@ function createContentInfo({
     info[listKey].forEach(content => {
       content.sections.forEach(section => {
         section.frameworks = Object.keys(section.frameworkByName).sort(alphaSort);
-        section.mainFramework = section.frameworks.length && section.frameworks.reduce((min, next) => min < next ? min : next);
+        section.mainFramework = section.frameworks.length && section.frameworks[0];
 
         Object.entries(section.snippetByName).forEach(([snippetName, snippet]) => {
           snippet.frameworks = section.frameworks.map(framework => {


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- fixing breadcrumbs by correcting topic path in navbar constants
- fixing default framework.
  - Needed to lower case SCIM to correctly find it in frameworks map.
  - Simply taking first framework from alphabetically sorted list. I'm not sure why `.reduce` call was needed there.

### Resolves:
* [OKTA-1011936](https://oktainc.atlassian.net/browse/OKTA-1011936)

### Reviewer:
- @paulwallace-okta 
