### PR TITLE
Update Role typo in index.md (#1)

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/scim-with-entitlements/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/scim-with-entitlements/main/index.md
@@ -114,7 +114,7 @@ See [Custom entitlement with extensions](#custom-entitlement-with-extensions) fo
 
 #### Roles schema
 
-The `urn:okta:scim:schemas:core:1.0:Entitlement` schema contains the following information:
+The `urn:okta:scim:schemas:core:1.0:Role` schema contains the following information:
 
 |Parameter | Type | Description | Notes |
 |---|---|---|---|


### PR DESCRIPTION
## Description:
- **What's changed?** 
Updated text typo that fixes`urn:okta:scim:schemas:core:1.0:Entitlement` to `urn:okta:scim:schemas:core:1.0:Role` in the docs