### PR TITLE
OKTA-1071410: Fixed robots.txt file

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/scripts/build.sh
+++ b/packages/@okta/vuepress-site/.vuepress/scripts/build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 cp .vuepress/scripts/updateBuildScript.js ../../../node_modules/@vuepress/core/lib/node/build/index.js
 cp .vuepress/scripts/addWorkerScript.js ../../../node_modules/@vuepress/core/lib/node/build/worker.js
-vuepress build . && cp conductor.yml dist/conductor.yml
+vuepress build . && cp conductor.yml dist/conductor.yml && node .vuepress/scripts/fix-robots.js

--- a/packages/@okta/vuepress-site/.vuepress/scripts/fix-robots.js
+++ b/packages/@okta/vuepress-site/.vuepress/scripts/fix-robots.js
@@ -1,0 +1,21 @@
+/* To fix: https://oktainc.atlassian.net/browse/OKTA-1071410 */
+const fs = require("fs");
+const path = require('path');
+const robotsPath = path.resolve(__dirname, '../../dist/robots.txt');
+
+if (!fs.existsSync(robotsPath)) {
+  console.warn(`robots.txt not found at: ${robotsPath}`);
+  return;
+}
+
+const content = fs.readFileSync(robotsPath, "utf8");
+
+const fixedContent = content.replace(
+  /Sitemap:\s*https:\/developer\.okta\.com\/sitemap_index\.xml/g,
+  "Sitemap: https://developer.okta.com/sitemap_index.xml"
+);
+
+fs.writeFileSync(robotsPath, fixedContent, "utf8");
+
+console.log("robots.txt sitemap URL fixed successfully");
+


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** There is a bug in the vuepress robots plugin (https://github.com/HiYue/vuepress-plugin-robots/issues/5) which sets wrong sitemap url in robots.txt. Since we can't change the plugin, I've added a script to change the sitemap url in robots.txt using a script.
- **Is this PR related to a Monolith release?** <!-- If so, which one? -->

### Resolves:

* [OKTA-1071410](https://oktainc.atlassian.net/browse/OKTA-1071410)
