### PR TITLE
OKTA-1091206 - Fix copyright year substitution

### DIFF
--- a/packages/@okta/vuepress-site/copyright/index.md
+++ b/packages/@okta/vuepress-site/copyright/index.md
@@ -8,68 +8,65 @@ title: Copyright and Trademarks
 
 showBreadcrumb: False
 
-sections:
-
-- Copyright © {{ year }} Okta. All rights reserved.
-
-- Okta has made all efforts to ensure that this guide is accurate.
-
-- Okta Headquarters North America<br>
-  100 First Street<br>
-  San Francisco<br>
-  CA 94105<br>
-  USA
-
-- Okta®, Auth0®, and the Okta® and Auth0® Logos are registered trademarks of Okta, Inc. in the U.S. and other countries.
-
-- See <a href="https://www.okta.com/terms-of-service/" target="_blank">Okta's Terms of Service</a> for its Intellectual Property.
-
-- <hr />
-
-- Microsoft, .NET, and Azure Active Directory are trademarks of the Microsoft group of companies.
-
-- Google, Android™ platform, and Angular are trademarks or registered trademarks of Google LLC.
-
-- Amazon is a trademark or registered trademark of Amazon LLC.
-
-- Apple, the Apple logo, and iOS are trademarks of Apple Inc., registered in the United States and other countries.
-
-- Java is a registered trademark of Oracle.
-
-- Python is a registered trademark of the PSF. The Python logos (in several variants) are trademarks of the PSF as well.
-
-- Facebook, React, and React Native are trademarks of META PLATFORMS, INC.
-
-- Discord is a trademark of Discord Inc.
-
-- GITHUB®, the GITHUB® logo design, the INVERTOCAT logo design, OCTOCAT®, and the OCTOCAT® logo design are trademarks of GitHub, Inc.
-
-- Gitlab and the Gitlab logos (in several variants) are trademarks of Gitlab Inc.
-
-- LinkedIn, the LinkedIn logo, the IN logo, and InMail are registered trademarks or trademarks of LinkedIn Corporation and its affiliates in the United States and/or other countries.
-
-- Node.js and its wordmarks in plain text or logo form are registered trademarks or trademarks of the Node.js community.
-
-- OpenID® is a trademark (registered in numerous countries) of the OpenID Foundation.
-
-- Paypal and the Paypal logo are registered trademarks or trademarks of Paypal, Inc.
-
-- The PHP logo is available under a Creative Commons Attribution-Share Alike 4.0 International license.
-
-- Salesforce and the Salesforce logos (in various forms) are trademarks of salesforce.com, Inc.
-
-- OASIS, SAML, and Security Assertion Markup Language are trademarks of OASIS, the open standards consortium where the SAML specification is owned and developed. SAML is a copyrighted © work of OASIS Open. All rights reserved.
-
-- Spotify and the Spotify logos (in several variants) are registered trademarks or trademarks of Spotify AB.
-
-- Vue.js and the Vue.js logo are trademarks or registered trademarks of Evan You.
-
-- Xero and the Xero logo are registered trademarks of Xero Limited.
-
-- Yahoo! and the Yahoo! Logo are trademarks or registered trademarks of YAHOO INC.
-
-- The Login.gov service is provided by the U.S. General Services Administration.
-
-- All other product and service names mentioned herein are registered trademarks or trademarks of their respective companies.
-
 ---
+Copyright © {{ new Date().getFullYear() }} Okta. All rights reserved.
+
+Okta has made all efforts to ensure that this guide is accurate.
+
+Okta Headquarters North America<br>
+100 First Street<br>
+San Francisco<br>
+CA 94105<br>
+USA
+
+Okta®, Auth0®, and the Okta® and Auth0® Logos are registered trademarks of Okta, Inc. in the U.S. and other countries.
+
+See <a href="https://www.okta.com/terms-of-service/" target="_blank">Okta's Terms of Service</a> for its Intellectual Property.
+
+<hr />
+
+Microsoft, .NET, and Azure Active Directory are trademarks of the Microsoft group of companies.
+
+Google, Android™ platform, and Angular are trademarks or registered trademarks of Google LLC.
+
+Amazon is a trademark or registered trademark of Amazon LLC.
+
+Apple, the Apple logo, and iOS are trademarks of Apple Inc., registered in the United States and other countries.
+
+Java is a registered trademark of Oracle.
+
+Python is a registered trademark of the PSF. The Python logos (in several variants) are trademarks of the PSF as well.
+
+Facebook, React, and React Native are trademarks of META PLATFORMS, INC.
+
+Discord is a trademark of Discord Inc.
+
+GITHUB®, the GITHUB® logo design, the INVERTOCAT logo design, OCTOCAT®, and the OCTOCAT® logo design are trademarks of GitHub, Inc.
+
+Gitlab and the Gitlab logos (in several variants) are trademarks of Gitlab Inc.
+
+LinkedIn, the LinkedIn logo, the IN logo, and InMail are registered trademarks or trademarks of LinkedIn Corporation and its affiliates in the United States and/or other countries.
+
+Node.js and its wordmarks in plain text or logo form are registered trademarks or trademarks of the Node.js community.
+
+OpenID® is a trademark (registered in numerous countries) of the OpenID Foundation.
+
+Paypal and the Paypal logo are registered trademarks or trademarks of Paypal, Inc.
+
+The PHP logo is available under a Creative Commons Attribution-Share Alike 4.0 International license.
+
+Salesforce and the Salesforce logos (in various forms) are trademarks of salesforce.com, Inc.
+
+OASIS, SAML, and Security Assertion Markup Language are trademarks of OASIS, the open standards consortium where the SAML specification is owned and developed. SAML is a copyrighted © work of OASIS Open. All rights reserved.
+
+Spotify and the Spotify logos (in several variants) are registered trademarks or trademarks of Spotify AB.
+
+Vue.js and the Vue.js logo are trademarks or registered trademarks of Evan You.
+
+Xero and the Xero logo are registered trademarks of Xero Limited.
+
+Yahoo! and the Yahoo! Logo are trademarks or registered trademarks of YAHOO INC.
+
+The Login.gov service is provided by the U.S. General Services Administration.
+
+All other product and service names mentioned herein are registered trademarks or trademarks of their respective companies.

--- a/packages/@okta/vuepress-theme-prose/components/Copyright.vue
+++ b/packages/@okta/vuepress-theme-prose/components/Copyright.vue
@@ -9,30 +9,12 @@
         </div>
       </div>
       <div class="copyright--container">
-        <div class="copyright--text">
-          <p
-            v-for="(section, sectionIdx) in processedSections"
-            :key="sectionIdx"
-            class="copyright--section-paragraph"
-            v-html="section"
-          />
-        </div>
+        <Content class="copyright--text" />
       </div>
     </section>
   </div>
 </template>
 
 <script>
-export default {
-  computed: {
-    year () {
-      return new Date().getFullYear();
-    },
-    processedSections () {
-      return this.$page.frontmatter.sections.map(section => 
-        section.replace(/\{\{\s*year\s*\}\}/g, this.year)
-      );
-    }
-  }
-}
+export default {};
 </script>


### PR DESCRIPTION
## Description:
- **What's changed?** Fix the copyright year substitution & move the text from frontmatter to page content
- **Is this PR related to a Monolith release?**

### Resolves:

* [OKTA-1091206](https://oktainc.atlassian.net/browse/OKTA-1091206)
