### PR TITLE
OKTA-1141841 - Aerial 2026.04.0 RN

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/public/rss/aerial.xml
+++ b/packages/@okta/vuepress-site/.vuepress/public/rss/aerial.xml
@@ -4,8 +4,17 @@
   <title>Okta Aerial API release notes</title>
   <link>https://developer.okta.com/docs/release-notes/2026-okta-aerial/</link>
   <description>Recent release notes for Okta Aerial</description>
-  <pubDate>Thu, 05 Mar 2026 12:00:00 GMT</pubDate>
+  <pubDate>Tue, 31 Mar 2026 12:00:00 GMT</pubDate>
   
+    <item>
+      <title>Monthly release</title>
+      <link>https://developer.okta.com/docs/release-notes/2026-okta-aerial/#monthly-release</link>
+      <guid>https://developer.okta.com/docs/release-notes/2026-okta-aerial/#monthly-release</guid>
+      <pubDate>Tue, 31 Mar 2026 12:00:00 GMT</pubDate>
+      <description><![CDATA[<a href="https://developer.okta.com/docs/release-notes/2026-okta-aerial/#bug-fixed-in-weekly-release">Bug fixed in weekly release</a>]]></description>
+    </item>
+  
+
     <item>
       <title>Monthly release</title>
       <link>https://developer.okta.com/docs/release-notes/2026-okta-aerial/#monthly-release</link>

--- a/packages/@okta/vuepress-site/docs/release-notes/2026-okta-aerial/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2026-okta-aerial/index.md
@@ -20,10 +20,10 @@ See also [Introduction to the Okta Aerial API](https://developer.okta.com/docs/a
 ## April
 
 ### Monthly release
-<!-- Published on: 2026-04-xxT12:00:00Z -->
+<!-- Published on: 2026-03-31T12:00:00Z -->
 | Change | Expected in Aerial services preview | Expected in Aerial services production |
 |--------|-----------------------------| -----------------------------|
-| [Bug fixed in weekly release](#bug-fixed-in-weekly-release)| March 25, 2026  | March 30, 2026   |
+| [Bug fixed in weekly release](#bug-fixed-in-weekly-release)| March 31, 2026  | April 6, 2026   |
 
 #### Bug fixed in weekly release
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2026-okta-aerial/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2026-okta-aerial/index.md
@@ -27,7 +27,7 @@ See also [Introduction to the Okta Aerial API](https://developer.okta.com/docs/a
 
 #### Bug fixed in weekly release
 
-The Aerial Console sometimes contained incorrect data on a client's associated orgs. (OKTA-112607)
+The Aerial Console sometimes contained incorrect data on a client's associated orgs. (OKTA-1126071)
 
 ### Monthly release
 <!-- Published on: 2026-03-05T12:00:00Z -->

--- a/packages/@okta/vuepress-site/docs/release-notes/2026-okta-aerial/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2026-okta-aerial/index.md
@@ -17,10 +17,10 @@ These release notes list customer-visible changes to the Okta Aerial API. Okta A
 
 See also [Introduction to the Okta Aerial API](https://developer.okta.com/docs/api/openapi/aerial/guides/overview/).
 
-## March
+## April
 
-### Weekly release
-<!-- Published on: 2026-03-25T12:00:00Z -->
+### Monthly release
+<!-- Published on: 2026-04-xxT12:00:00Z -->
 | Change | Expected in Aerial services preview | Expected in Aerial services production |
 |--------|-----------------------------| -----------------------------|
 | [Bug fixed in weekly release](#bug-fixed-in-weekly-release)| March 25, 2026  | March 30, 2026   |

--- a/packages/@okta/vuepress-site/docs/release-notes/2026-okta-aerial/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2026-okta-aerial/index.md
@@ -19,6 +19,16 @@ See also [Introduction to the Okta Aerial API](https://developer.okta.com/docs/a
 
 ## March
 
+### Weekly release
+<!-- Published on: 2026-03-25T12:00:00Z -->
+| Change | Expected in Aerial services preview | Expected in Aerial services production |
+|--------|-----------------------------| -----------------------------|
+| [Bug fixed in weekly release](#bug-fixed-in-weekly-release)| March 25, 2026  | March 30, 2026   |
+
+#### Bug fixed in weekly release
+
+The Aerial Console sometimes contained incorrect data on a client's associated orgs. (OKTA-112607)
+
 ### Monthly release
 <!-- Published on: 2026-03-05T12:00:00Z -->
 | Change | Expected in Aerial services preview | Expected in Aerial services production |


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Adding a release note for the Aerial 3/31 preview release
- **Is this PR related to a Monolith release?** kinda

### Resolves:

* [OKTA-1141841](https://oktainc.atlassian.net/browse/OKTA-1141841)

### Netlify Preview Link:

[Preview](https://bd-okta-1141841-aerial-2026-04-0-rn--dev-docs-preview.netlify.app/docs/release-notes/2026-okta-aerial/)
