### PR TITLE
okta developer tools release notes tab

### DIFF
--- a/packages/@okta/vuepress-site/.vuepress/public/rss/dev-tools.xml
+++ b/packages/@okta/vuepress-site/.vuepress/public/rss/dev-tools.xml
@@ -4,22 +4,13 @@
   <title>Okta Developer Tools release notes</title>
   <link>https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/</link>
   <description>Recent release notes for Okta Developer Tools</description>
-  <pubDate>Wed, 06 May 2026 12:00:00 GMT</pubDate>
+  <pubDate>Thu, 14 May 2026 12:00:00 GMT</pubDate>
   
-    <item>
-      <title>Monthly release 2026.06.0</title>
-      <link>https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#monthly-release-2026-06-0</link>
-      <guid>https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#monthly-release-2026-06-0</guid>
-      <pubDate>Wed, 06 May 2026 12:00:00 GMT</pubDate>
-      <description><![CDATA[<a href="https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#terraform-guide-for-zoom">Terraform guide for Zoom</a>]]></description>
-    </item>
-  
-
     <item>
       <title>Weekly release 2026.04.3</title>
       <link>https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#weekly-release-2026-04-3</link>
       <guid>https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#weekly-release-2026-04-3</guid>
-      <pubDate>Wed, 29 Apr 2026 12:00:00 GMT</pubDate>
+      <pubDate>Thu, 14 May 2026 12:00:00 GMT</pubDate>
       <description><![CDATA[<a href="https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#identity-threat-protection-with-okta-ai-managed-with-terraform">Identity Threat Protection with Okta AI managed with Terraform</a>]]></description>
     </item>
   

--- a/packages/@okta/vuepress-site/.vuepress/public/rss/dev-tools.xml
+++ b/packages/@okta/vuepress-site/.vuepress/public/rss/dev-tools.xml
@@ -4,13 +4,13 @@
   <title>Okta Developer Tools release notes</title>
   <link>https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/</link>
   <description>Recent release notes for Okta Developer Tools</description>
-  <pubDate>Thu, 14 May 2026 12:00:00 GMT</pubDate>
+  <pubDate>Wed, 29 Apr 2026 12:00:00 GMT</pubDate>
   
     <item>
       <title>Weekly release 2026.04.3</title>
       <link>https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#weekly-release-2026-04-3</link>
       <guid>https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#weekly-release-2026-04-3</guid>
-      <pubDate>Thu, 14 May 2026 12:00:00 GMT</pubDate>
+      <pubDate>Wed, 29 Apr 2026 12:00:00 GMT</pubDate>
       <description><![CDATA[<a href="https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#identity-threat-protection-with-okta-ai-managed-with-terraform">Identity Threat Protection with Okta AI managed with Terraform</a>]]></description>
     </item>
   

--- a/packages/@okta/vuepress-site/.vuepress/public/rss/dev-tools.xml
+++ b/packages/@okta/vuepress-site/.vuepress/public/rss/dev-tools.xml
@@ -11,7 +11,16 @@
       <link>https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#monthly-release-2026-06-0</link>
       <guid>https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#monthly-release-2026-06-0</guid>
       <pubDate>Wed, 06 May 2026 12:00:00 GMT</pubDate>
-      <description><![CDATA[<a href="https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#update-to-python-sdk">Update to Python SDK</a><br><a href="https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#update-to-terraform-provider-for-okta">Update to Terraform Provider for Okta</a>]]></description>
+      <description><![CDATA[<a href="https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#terraform-guide-for-zoom">Terraform guide for Zoom</a>]]></description>
+    </item>
+  
+
+    <item>
+      <title>Weekly release 2026.04.3</title>
+      <link>https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#weekly-release-2026-04-3</link>
+      <guid>https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#weekly-release-2026-04-3</guid>
+      <pubDate>Wed, 29 Apr 2026 12:00:00 GMT</pubDate>
+      <description><![CDATA[<a href="https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#identity-threat-protection-with-okta-ai-managed-with-terraform">Identity Threat Protection with Okta AI managed with Terraform</a>]]></description>
     </item>
   
 </channel>

--- a/packages/@okta/vuepress-site/.vuepress/public/rss/dev-tools.xml
+++ b/packages/@okta/vuepress-site/.vuepress/public/rss/dev-tools.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+<channel>
+  <title>Okta Developer Tools release notes</title>
+  <link>https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/</link>
+  <description>Recent release notes for Okta Developer Tools</description>
+  <pubDate>Wed, 06 May 2026 12:00:00 GMT</pubDate>
+  
+    <item>
+      <title>Monthly release 2026.06.0</title>
+      <link>https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#monthly-release-2026-06-0</link>
+      <guid>https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#monthly-release-2026-06-0</guid>
+      <pubDate>Wed, 06 May 2026 12:00:00 GMT</pubDate>
+      <description><![CDATA[<a href="https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#update-to-python-sdk">Update to Python SDK</a><br><a href="https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/#update-to-terraform-provider-for-okta">Update to Terraform Provider for Okta</a>]]></description>
+    </item>
+  
+</channel>
+</rss>

--- a/packages/@okta/vuepress-site/.vuepress/scripts/generate-rss.js
+++ b/packages/@okta/vuepress-site/.vuepress/scripts/generate-rss.js
@@ -225,3 +225,12 @@ generateRssFromMarkdown(
   'https://developer.okta.com/docs/release-notes/2026-okta-mcp-server/',
   path.join(__dirname, '../public/rss/mcp.xml')
 );
+
+// Okta Developer Tools Release Notes
+generateRssFromMarkdown(
+  path.join(__dirname, '../../docs/release-notes/2026-okta-dev-tools/index.md'),
+  'Okta Developer Tools release notes',
+  'Recent release notes for Okta Developer Tools',
+  'https://developer.okta.com/docs/release-notes/2026-okta-dev-tools/',
+  path.join(__dirname, '../public/rss/dev-tools.xml')
+);

--- a/packages/@okta/vuepress-site/docs/release-notes/2026-okta-dev-tools/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2026-okta-dev-tools/index.md
@@ -13,13 +13,21 @@ These release notes list customer-visible changes to the Developer Tools. The Ok
 
 | Change | Expected in Preview Orgs |
 |--------|--------------------------|
-| [Update to Python SDK](#update-to-python-sdk)      | May 6, 2026            |
-| [Update to Terraform Provider for Okta](#update-to-terraform-provider-for-okta)       | May 6 2026            |
+| [Terraform guide for Zoom](#terraform-guide-for-zoom) | June 6, 2026            |
 
-#### Update to Python SDK
+#### Terraform guide for Zoom
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+To be added later during the June monthly release.
 
-#### Update to Terraform Provider for Okta
+## April
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+### Weekly release 2026.04.3
+<!-- Published on: 2026-04-29T12:00:00Z -->
+
+| Change | Expected in Preview Orgs |
+| ------ | ------------------------ |
+| [Identity Threat Protection with Okta AI managed with Terraform](#identity-threat-protection-with-okta-ai-managed-with-terraform) | April 29, 2026 |
+
+#### Identity Threat Protection with Okta AI managed with Terraform
+
+You can now manage Okta Identity Threat Protection (ITP) with Okta AI using the Okta Terraform Provider. This allows admins to manage their entire threat protection surface using an Infrastructure-as-Code (IaC) approach, ensuring consistent, repeatable, and scalable security configurations. See [Manage Identity Threat Protection with Okta AI resources using Terraform](/docs/guides/terraform-manage-itp/main/). <!-- OKTA-1122778 -->

--- a/packages/@okta/vuepress-site/docs/release-notes/2026-okta-dev-tools/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2026-okta-dev-tools/index.md
@@ -9,7 +9,7 @@ title: Okta Developer Tools API release notes 2026
   Subscribe to RSS
 </a><br><br>
 
-These release notes list customer-visible changes to the Developer Tools. The Okta's developer tooling ecosystem includes Terraform, SDKs, CLI, and other libraries.
+These release notes list customer-visible changes to the Developer Tools. The Okta's developer tooling ecosystem includes Terraform, SDKs, and CLI.
 
 ## April
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2026-okta-dev-tools/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2026-okta-dev-tools/index.md
@@ -9,7 +9,7 @@ These release notes list customer-visible changes to the Developer Tools. The Ok
 ## June
 
 ### Monthly release 2026.06.0
-<!-- Published on: 2026-05-09T12:00:00Z -->
+<!-- Published on: 2026-05-06T12:00:00Z -->
 
 | Change | Expected in Preview Orgs |
 |--------|--------------------------|

--- a/packages/@okta/vuepress-site/docs/release-notes/2026-okta-dev-tools/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2026-okta-dev-tools/index.md
@@ -7,14 +7,14 @@ title: Okta Developer Tools API release notes 2026
 <a href="/rss/dev-tools.xml">
   <img src="/img/icons/Feed-icon.svg" alt="RSS" width="20" height="20" />
   Subscribe to RSS
-</a>
+</a><br><br>
 
 These release notes list customer-visible changes to the Developer Tools. The Okta's developer tooling ecosystem includes Terraform, SDKs, CLI, and other libraries.
 
 ## April
 
 ### Weekly release 2026.04.3
-<!-- Published on: 2026-05-14T12:00:00Z -->
+<!-- Published on: 2026-04-29T12:00:00Z -->
 
 | Change | Expected in Preview Orgs |
 | ------ | ------------------------ |

--- a/packages/@okta/vuepress-site/docs/release-notes/2026-okta-dev-tools/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2026-okta-dev-tools/index.md
@@ -4,20 +4,7 @@ title: Okta Developer Tools API release notes 2026
 
 # Developer Tools release notes (2026)
 
-These release notes list customer-visible changes to the Developer Tools. The Okta's developer tooling ecosystem includes Terraform, SDKs, CLI, token validators, and other libraries.
-
-## June
-
-### Monthly release 2026.06.0
-<!-- Published on: 2026-05-06T12:00:00Z -->
-
-| Change | Expected in Preview Orgs |
-|--------|--------------------------|
-| [Terraform guide for Zoom](#terraform-guide-for-zoom) | June 6, 2026            |
-
-#### Terraform guide for Zoom
-
-To be added later during the June monthly release.
+These release notes list customer-visible changes to the Developer Tools. The Okta's developer tooling ecosystem includes Terraform, SDKs, CLI, and other libraries.
 
 ## April
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2026-okta-dev-tools/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2026-okta-dev-tools/index.md
@@ -2,18 +2,24 @@
 title: Okta Developer Tools API release notes 2026
 ---
 
-# ODeveloper Tools release notes (2026)
+# Developer Tools release notes (2026)
 
 These release notes list customer-visible changes to the Developer Tools. The Okta's developer tooling ecosystem includes Terraform, SDKs, CLI, token validators, and other libraries.
 
 ## June
 
 ### Monthly release 2026.06.0
+<!-- Published on: 2026-05-09T12:00:00Z -->
 
 | Change | Expected in Preview Orgs |
 |--------|--------------------------|
-| | March 4, 2026 |
-| | March 4, 2026 |
+| [Update to Python SDK](#update-to-python-sdk)      | May 6, 2026            |
+| [Update to Terraform Provider for Okta](#update-to-terraform-provider-for-okta)       | May 6 2026            |
 
-#### test
+#### Update to Python SDK
 
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+#### Update to Terraform Provider for Okta
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/packages/@okta/vuepress-site/docs/release-notes/2026-okta-dev-tools/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2026-okta-dev-tools/index.md
@@ -2,10 +2,9 @@
 title: Okta Developer Tools API release notes 2026
 ---
 
-# Okta Developer Tools (2026)
+# ODeveloper Tools release notes (2026)
 
-
-These release notes list customer-visible changes to the Okta Developer Tools.
+These release notes list customer-visible changes to the Developer Tools. The Okta's developer tooling ecosystem includes Terraform, SDKs, CLI, token validators, and other libraries.
 
 ## June
 
@@ -14,7 +13,7 @@ These release notes list customer-visible changes to the Okta Developer Tools.
 | Change | Expected in Preview Orgs |
 |--------|--------------------------|
 | | March 4, 2026 |
-| ] | March 4, 2026 |
+| | March 4, 2026 |
 
 #### test
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2026-okta-dev-tools/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2026-okta-dev-tools/index.md
@@ -1,0 +1,20 @@
+---
+title: Okta Developer Tools API release notes 2026
+---
+
+# Okta Developer Tools (2026)
+
+
+These release notes list customer-visible changes to the Okta Developer Tools.
+
+## June
+
+### Monthly release 2026.06.0
+
+| Change | Expected in Preview Orgs |
+|--------|--------------------------|
+| | March 4, 2026 |
+| ] | March 4, 2026 |
+
+#### test
+

--- a/packages/@okta/vuepress-site/docs/release-notes/2026-okta-dev-tools/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2026-okta-dev-tools/index.md
@@ -4,12 +4,17 @@ title: Okta Developer Tools API release notes 2026
 
 # Developer Tools release notes (2026)
 
+<a href="/rss/dev-tools.xml">
+  <img src="/img/icons/Feed-icon.svg" alt="RSS" width="20" height="20" />
+  Subscribe to RSS
+</a>
+
 These release notes list customer-visible changes to the Developer Tools. The Okta's developer tooling ecosystem includes Terraform, SDKs, CLI, and other libraries.
 
 ## April
 
 ### Weekly release 2026.04.3
-<!-- Published on: 2026-04-29T12:00:00Z -->
+<!-- Published on: 2026-05-14T12:00:00Z -->
 
 | Change | Expected in Preview Orgs |
 | ------ | ------------------------ |

--- a/packages/@okta/vuepress-site/docs/release-notes/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/index.md
@@ -5,7 +5,7 @@ meta:
     content: List of changes to the Okta API and related API...
 ---
 
-# Okta API Release Notes
+# Okta Developer Doc Release Notes
 
 Each month, Okta releases API-specific features, enhancements, bug fixes, and Okta Integration Network updates. The monthly release includes Generally Available (GA) and Early Access (EA) features. Following the monthly release, bug fixes and stability improvements are deployed weekly for the remainder of the month.
 
@@ -24,6 +24,10 @@ Learn about features and fixes deployed to the following Okta products:
 * [Okta Access Gateway 2026](/docs/release-notes/2026-okta-access-gateway/)
 
 * [Okta Aerial 2026](/docs/release-notes/2026-okta-aerial)
+
+* [Okta MCP Server 2026](/docs/release-notes/2026-okta-mcp-server/)
+
+* [Okta Developer Tools 2026](/docs/release-notes/2026-okta-dev-tools)
 
 You can find older release notes in the [Archive](/docs/release-notes/archive) section.
 

--- a/packages/@okta/vuepress-theme-prose/const/navbar.const.js
+++ b/packages/@okta/vuepress-theme-prose/const/navbar.const.js
@@ -1367,6 +1367,10 @@ export const releaseNotes = [
         path: "/docs/release-notes/2026-okta-mcp-server/",
       },
       {
+        title: "2026 - Developer Tools",
+        path: "/docs/release-notes/2026-okta-dev-tools/",
+      },
+      {
         title: "Archive",
         path: "/docs/release-notes/archive",
         subLinks: [


### PR DESCRIPTION

## Description:
- **What's changed?** Added a new release note tab entry as "Okta Developer Tools release notes (2026)
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-1170439](https://oktainc.atlassian.net/browse/OKTA-1170439)

### Netlify Preview Link:
https://sj-okta-1170439-dev-tools--dev-docs-preview.netlify.app/docs/release-notes/2026-okta-dev-tools/
