### PR TITLE
Update Angular docs for new SDK version

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/addconfigpkg.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/addconfigpkg.md
@@ -2,5 +2,5 @@ Use Okta's Angular SDK and Okta's JavaScript SDK in your Angular app. Add the np
 
 ```shell
 cd okta-angular-quickstart
-npm install @okta/okta-angular@6.4 @okta/okta-auth-js@7.8
+npm install @okta/okta-angular@8.0 @okta/okta-auth-js@8.0
 ```

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/configmid.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/configmid.md
@@ -7,7 +7,7 @@ Make the following changes to `src/app/app.config.ts`:
 1. Add the following import lines to the code to pull in the dependencies:
 
    ```ts
-   import { OktaAuthModule } from '@okta/okta-angular';
+   import { provideOktaAuth, withOktaConfig } from '@okta/okta-angular';
    import { OktaAuth } from '@okta/okta-auth-js';
    ```
 
@@ -28,9 +28,9 @@ Make the following changes to `src/app/app.config.ts`:
    export const appConfig: ApplicationConfig = {
     providers: [
       // other providers as required
-      importProvidersFrom(
-           OktaAuthModule.forRoot({ oktaAuth })
-      )
+      provideOktaAuth(
+        withOktaConfig({ oktaAuth })
+      ),
     ]
    };
    ```

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/createproject.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/createproject.md
@@ -4,11 +4,11 @@ You need recent versions of [Node](https://nodejs.org/en/) and [npm](https://www
 Create an Angular app named **okta-angular-quickstart** using the following command. Choose any style sheet format you want when it asks you which format you want to use.
 
 ```shell
-npx @angular/cli@19 new okta-angular-quickstart --ssr=false
+npx @angular/cli@21 new okta-angular-quickstart --ssr=false
 ```
 
-This creates an Angular app using version 19 regardless of the version of the Angular CLI installed on your system.
+This creates an Angular app using version 21 regardless of the version of the Angular CLI installed on your system.
 
-> **Note**: This guide uses Angular CLI v19, okta-angular v6.4.0, and Okta Auth JavaScript SDK v7.8.0.
+> **Note**: This guide uses Angular CLI v21, okta-angular v8.0.0, and Okta Auth JavaScript SDK v8.0.1.
 
 > **Note**: This quickstart uses the basic Angular CLI output, as it's easier to understand the Okta-specific additions if you work through them yourself.

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/reqautheverything.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/reqautheverything.md
@@ -1,11 +1,11 @@
-The Okta Angular SDK has a guard to check for the authenticated state that you can add to protected routes. It's common in Angular to use feature modules and protect the route to the feature so that all child routes are also guarded.
+The Okta Angular SDK has a guards to check for the authenticated state that you can add to protected routes. It's common in Angular to use feature modules and protect the route to the feature so that all child routes are also guarded.
 
-In `app.routes.ts`, add the `OktaAuthGuard` to protect the route accessing a lazy loaded feature module using the `canActivate` property.
+In `app.routes.ts`, add the `canActivateAuthGuard` functional guard to protect the route accessing a lazy loaded feature module using the `canActivate` property.
 
 1. Update the Okta import statement to:
 
    ```ts
-   import { OktaAuthGuard, OktaCallbackComponent } from '@okta/okta-angular';
+   import { canActivateAuthGuard, OktaCallbackComponent } from '@okta/okta-angular';
    ```
 
 2. Add the following route to the `routes` array:
@@ -13,7 +13,7 @@ In `app.routes.ts`, add the `OktaAuthGuard` to protect the route accessing a laz
    ```ts
    {
      path: 'protected',
-     loadChildren: () => import('./protected/routes').then(m => m.PROTECTED_FEATURE_ROUTES), canActivate: [OktaAuthGuard]
+     loadChildren: () => import('./protected/routes').then(m => m.PROTECTED_FEATURE_ROUTES), canActivate: [canActivateAuthGuard]
    },
    ```
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/reqauthspecific.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/reqauthspecific.md
@@ -1,9 +1,9 @@
-The `OktaAuthGuard` can protect a route to a single component as well with `canActivate` property.
+The `canActivateAuthGuard` functional guard can protect a route to a single component as well with `canActivate` property.
 
 1. Add the `canActivate` property to the `routes` array in `app.routes.ts`:
 
    ```ts
-   { path: 'profile', component: ProfileComponent, canActivate: [OktaAuthGuard] }
+   { path: 'profile', component: ProfileComponent, canActivate: [canActivateAuthGuard] }
    ```
 
 The single `/profile` route is protected directly. If you're not authenticated and go to this page, you must click **Sign in** before being routed to the `ProfileComponent`.


### PR DESCRIPTION
## Description:
- **What's changed?** 
Updates Angular redirect getting started guide with the latest version of Okta Angular SDK. The new SDK no longer relies on outdated NgModules architecture. The changes here matches the changes I'm adding to sample code.

- **Is this PR related to a Monolith release?** 
No

