### PR TITLE
Update Angular docs for new SDK version

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/addconfigpkg.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/addconfigpkg.md
@@ -2,5 +2,5 @@ Use Okta's Angular SDK and Okta's JavaScript SDK in your Angular app. Add the np
 
 ```shell
 cd okta-angular-quickstart
-npm install @okta/okta-angular@6.4 @okta/okta-auth-js@7.8
+npm install @okta/okta-angular@8.0 @okta/okta-auth-js@8.0
 ```

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/configmid.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/configmid.md
@@ -7,7 +7,7 @@ Make the following changes to `src/app/app.config.ts`:
 1. Add the following import lines to the code to pull in the dependencies:
 
    ```ts
-   import { OktaAuthModule } from '@okta/okta-angular';
+   import { provideOktaAuth, withOktaConfig } from '@okta/okta-angular';
    import { OktaAuth } from '@okta/okta-auth-js';
    ```
 
@@ -28,9 +28,9 @@ Make the following changes to `src/app/app.config.ts`:
    export const appConfig: ApplicationConfig = {
     providers: [
       // other providers as required
-      importProvidersFrom(
-           OktaAuthModule.forRoot({ oktaAuth })
-      )
+      provideOktaAuth(
+        withOktaConfig({ oktaAuth })
+      ),
     ]
    };
    ```

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/createproject.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/createproject.md
@@ -1,13 +1,13 @@
 
-Start with the basics. You need recent versions of [Node](https://nodejs.org/en/) and [npm](https://www.npmjs.com/), and Okta also recommends installing the [Angular CLI](https://angular.dev/tools/cli).
+Start with the basics. You need recent versions of [Node](https://nodejs.org/en/) and [npm](https://www.npmjs.com/). Okta also recommends installing the [Angular CLI](https://angular.dev/tools/cli).
 
-Create an Angular app named **okta-angular-quickstart** using the following command. When the CLI prompts you for a style sheet format, choose whichever one you prefer.
+Create an Angular app named **okta-angular-quickstart** using the following command. When the CLI prompts you for a style sheet format, choose whichever one you prefer&mdash;it doesn't affect the Okta integration.
 
 ```shell
 npx @angular/cli@21 new okta-angular-quickstart --ssr=false
 ```
 
-This creates the app using Angular version 21 regardless of which version of the Angular CLI you've installed on your system.
+This creates the app using Angular 21, no matter which CLI version you installed.
 
 > **Note**: This guide uses Angular CLI v21, okta-angular v8.0.0, and Okta Auth JavaScript SDK v8.0.1.
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/createproject.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/createproject.md
@@ -1,13 +1,13 @@
 
-You need recent versions of [Node](https://nodejs.org/en/) and [npm](https://www.npmjs.com/). Okta also recommends installing the [Angular CLI](https://angular.dev/tools/cli).
+Start with the basics. You need recent versions of [Node](https://nodejs.org/en/) and [npm](https://www.npmjs.com/), and Okta also recommends installing the [Angular CLI](https://angular.dev/tools/cli).
 
-Create an Angular app named **okta-angular-quickstart** using the following command. Choose any style sheet format you want when it asks you which format you want to use.
+Create an Angular app named **okta-angular-quickstart** using the following command. When the CLI prompts you for a style sheet format, choose whichever one you prefer.
 
 ```shell
 npx @angular/cli@21 new okta-angular-quickstart --ssr=false
 ```
 
-This creates an Angular app using version 21 regardless of the version of the Angular CLI installed on your system.
+This creates the app using Angular version 21 regardless of which version of the Angular CLI you've installed on your system.
 
 > **Note**: This guide uses Angular CLI v21, okta-angular v8.0.0, and Okta Auth JavaScript SDK v8.0.1.
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/createproject.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/createproject.md
@@ -4,11 +4,11 @@ You need recent versions of [Node](https://nodejs.org/en/) and [npm](https://www
 Create an Angular app named **okta-angular-quickstart** using the following command. Choose any style sheet format you want when it asks you which format you want to use.
 
 ```shell
-npx @angular/cli@19 new okta-angular-quickstart --ssr=false
+npx @angular/cli@21 new okta-angular-quickstart --ssr=false
 ```
 
-This creates an Angular app using version 19 regardless of the version of the Angular CLI installed on your system.
+This creates an Angular app using version 21 regardless of the version of the Angular CLI installed on your system.
 
-> **Note**: This guide uses Angular CLI v19, okta-angular v6.4.0, and Okta Auth JavaScript SDK v7.8.0.
+> **Note**: This guide uses Angular CLI v21, okta-angular v8.0.0, and Okta Auth JavaScript SDK v8.0.1.
 
 > **Note**: This quickstart uses the basic Angular CLI output, as it's easier to understand the Okta-specific additions if you work through them yourself.

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/reqautheverything.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/reqautheverything.md
@@ -1,6 +1,6 @@
-The Okta Angular SDK has a guards to check for the authenticated state that you can add to protected routes. It's common in Angular to use feature modules and protect the route to the feature so that all child routes are also guarded.
+The Okta Angular SDK has a guard to check for the authenticated state that you can add to protected routes. It's common in Angular to use feature modules and protect the route to the feature so that all child routes are also guarded.
 
-In `app.routes.ts`, add the `canActivateAuthGuard` functional guard to protect the route accessing a lazy loaded feature module using the `canActivate` property.
+In `app.routes.ts`, add the `canActivateAuthGuard` functional guard to protect the route accessing a lazy-loaded feature module using the `canActivate` property.
 
 1. Update the Okta import statement to:
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/reqautheverything.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/reqautheverything.md
@@ -1,11 +1,11 @@
-The Okta Angular SDK has a guard to check for the authenticated state that you can add to protected routes. It's common in Angular to use feature modules and protect the route to the feature so that all child routes are also guarded.
+The Okta Angular SDK has a guards to check for the authenticated state that you can add to protected routes. It's common in Angular to use feature modules and protect the route to the feature so that all child routes are also guarded.
 
-In `app.routes.ts`, add the `OktaAuthGuard` to protect the route accessing a lazy loaded feature module using the `canActivate` property.
+In `app.routes.ts`, add the `canActivateAuthGuard` functional guard to protect the route accessing a lazy loaded feature module using the `canActivate` property.
 
 1. Update the Okta import statement to:
 
    ```ts
-   import { OktaAuthGuard, OktaCallbackComponent } from '@okta/okta-angular';
+   import { canActivateAuthGuard, OktaCallbackComponent } from '@okta/okta-angular';
    ```
 
 2. Add the following route to the `routes` array:
@@ -13,7 +13,7 @@ In `app.routes.ts`, add the `OktaAuthGuard` to protect the route accessing a laz
    ```ts
    {
      path: 'protected',
-     loadChildren: () => import('./protected/routes').then(m => m.PROTECTED_FEATURE_ROUTES), canActivate: [OktaAuthGuard]
+     loadChildren: () => import('./protected/routes').then(m => m.PROTECTED_FEATURE_ROUTES), canActivate: [canActivateAuthGuard]
    },
    ```
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/reqauthspecific.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-spa-redirect/main/angular/reqauthspecific.md
@@ -1,9 +1,9 @@
-The `OktaAuthGuard` can protect a route to a single component as well with `canActivate` property.
+The `canActivateAuthGuard` functional guard can protect a route to a single component as well with `canActivate` property.
 
 1. Add the `canActivate` property to the `routes` array in `app.routes.ts`:
 
    ```ts
-   { path: 'profile', component: ProfileComponent, canActivate: [OktaAuthGuard] }
+   { path: 'profile', component: ProfileComponent, canActivate: [canActivateAuthGuard] }
    ```
 
 The single `/profile` route is protected directly. If you're not authenticated and go to this page, you must click **Sign in** before being routed to the `ProfileComponent`.


### PR DESCRIPTION
## Description:

Updates the Angular "Sign in to SPA (redirect)" guide to the latest Okta Angular SDK and Angular tooling. The new `@okta/okta-angular` v8 drops the NgModule-based architecture in favor of Angular's standalone provider APIs, and these doc changes bring the guide in line with the updated sample app.

This reposts #6188 by @alisaduncan so it can be merged in-repo (forked PRs can't be merged). Original authorship is preserved via a `Co-authored-by` trailer.

## Changes

- **Dependency bumps:**
  - `@okta/okta-angular` `6.4` → `8.0`
  - `@okta/okta-auth-js` `7.8` → `8.0.1`
  - Angular CLI `19` → `21`
- **Standalone config** (`configmid.md`): replaces `OktaAuthModule.forRoot()` + `importProvidersFrom(...)` with `provideOktaAuth(withOktaConfig({ oktaAuth }))`.
- **Functional route guard** (`reqautheverything.md`, `reqauthspecific.md`): replaces the class-based `OktaAuthGuard` with the functional `canActivateAuthGuard`.
- **Version notes** (`createproject.md`): updates the stated CLI/SDK versions.

## Files changed

- `.../sign-into-spa-redirect/main/angular/addconfigpkg.md`
- `.../sign-into-spa-redirect/main/angular/configmid.md`
- `.../sign-into-spa-redirect/main/angular/createproject.md`
- `.../sign-into-spa-redirect/main/angular/reqautheverything.md`
- `.../sign-into-spa-redirect/main/angular/reqauthspecific.md`

## Notes

- Not tied to a Monolith release.
- Pairs with the corresponding Angular sample-app update.
- Acrolinx: `createproject.md` previously scored 69 — addressed writing-style/score issues in this PR.

### Resolves:

* [OKTA-1192767](https://oktainc.atlassian.net/browse/OKTA-1192767)

### Netlify Preview Link:

<!-- Add preview link here -->
