### PR TITLE
OKTA-1160833: Document empty profile for Okta Verify factors

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
@@ -318,6 +318,8 @@ The user must [change their expired password](#change-password) to complete the 
 
 The user is assigned to a **sign-on policy** that requires additional verification and must [select and verify](#verify-factor) a previously enrolled [Factor](#factor-object) by `id` to complete the authentication transaction.
 
+> **Note:** In unauthenticated responses, the `profile` object for any Okta Verify factor is returned as an empty object (`{}`). The `profile` is populated after the factor is verified. See the [Factor object](#factor-object) for details.
+
 ```json
 {
   "stateToken": "007ucIX7PATyn94hsHfOLVaXAmOBkKHWnOOLG43bsb",
@@ -7578,6 +7580,8 @@ A subset of [Factor properties](https://developer.okta.com/docs/api/openapi/okta
 | profile        | profile of a [supported Factor](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/UserFactor/)                       | [Factor Profile object](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/UserFactor/#tag/UserFactor/operation/listFactors!c=200&path=0/profile&t=response)         | TRUE     | FALSE  | TRUE     |
 | provider       | Factor provider                                                                                | [Provider Type](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/UserFactor/#tag/UserFactor/operation/listSupportedFactors!c=200&path=provider&t=response)                         | FALSE    | TRUE   | TRUE     |
 | vendorName     | Factor vendor name (same as provider but for On-Prem MFA it depends on administrator settings) | [Provider Type](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/UserFactor/#tag/UserFactor/operation/listSupportedFactors!c=200&path=provider&t=response)                         | FALSE    | TRUE   | TRUE     |
+
+> **Note:** For Okta Verify factors, the `profile` is returned as an empty object (`"profile": {}`) when the factor appears in an unauthenticated response &mdash; for example, when only a username is submitted to the `/api/v1/authn` endpoint and Okta returns the factors required to authenticate (as in a Factor Sequencing flow). After the factor is verified, and in authenticated flows, the `profile` is fully populated.
 
 ```json
 {


### PR DESCRIPTION
# Summary

Documents a behavior change to the Classic Engine Authentication API (`/api/v1/authn`): for **Okta Verify factors**, the factor `profile` is returned as an empty object (`{}`) in **unauthenticated** responses (for example, when only a username is submitted, as in a Factor Sequencing flow). The `profile` is re-populated after the factor is verified and in authenticated flows.

## Changes

- Added a canonical note to the **Factor object** `profile` property definition explaining the empty-`profile` behavior.
- Added a short inline note at the `MFA_REQUIRED` factor-challenge example (where Okta Verify `profile` data appears), linking back to the Factor object.

## Notes

- Wording intentionally describes only *what* changes, not the underlying rationale.

### Resolves:

* [OKTA-1160833](https://oktainc.atlassian.net/browse/OKTA-1160833)

### Netlify Preview Link:

<!-- Add preview link here -->
