### PR TITLE
OKTA-1194467 - Revert bacon queue name for production task

### DIFF
--- a/.bacon.yml
+++ b/.bacon.yml
@@ -12,4 +12,4 @@ test_suites:
     sort_order: '1'
     timeout: '50'
     criteria: MAINLINE
-    queue_name: ci-queue-productionJenga-AL2023
+    queue_name: small


### PR DESCRIPTION
## Description:
- **What's changed?** Revert bacon queue name to `small` for `publish-production` task
- **Is this PR related to a Monolith release?** n/a

### Resolves:
* [OKTA-1194467](https://oktainc.atlassian.net/browse/OKTA-1194467)

### Netlify Preview Link:
https://ad-okta-1194467-revert-bacon-queue-for-prod-t--dev-docs-preview.netlify.app/
