### PR TITLE
IDV integration guide: Add 10-minute timeout requirement for IDV authorize endpoint

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/idv-integration/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/idv-integration/main/index.md
@@ -242,7 +242,10 @@ Okta uses the `request_uri` in the IDV vendor response and constructs a `GET /oa
 
 The user's browser sends the GET request to the IDV vendor's OAuth 2.0 authorization endpoint. The IDV vendor evaluates the `request_uri` so that the IDV flow can start.
 
-> **Note:** For IDV vendors, Okta recommends renaming the authorization endpoint so that it's clear the endpoint is used for identity verification. For example, rename the endpoint to `/oauth2/idv-authorize`.
+> **Notes:**
+>
+> * For IDV vendors, Okta recommends renaming the authorization endpoint so that it's clear the endpoint is used for identity verification. For example, rename the endpoint to `/oauth2/idv-authorize`.
+> * IDV vendors must provide a user experience at their authorization endpoint that supports a user taking up to 10 minutes to complete the IDV flow.
 
 #### GET /oauth2/authorize request example
 


### PR DESCRIPTION
## Description
- **Is this PR related to a Monolith release?** No.

## Summary
Updates the [Integrate Okta with identity verification vendors](https://developer.okta.com/docs/guides/idv-integration/main/) guide to add a requirement that IDV vendors must provide a user experience at their authorization endpoint that supports a user taking up to 10 minutes to complete the IDV flow.

## Changes
- Added the 10-minute timeout requirement to the **User's browser sends GET /oauth2/authorize request to IDV vendor** section.
- Consolidated the existing endpoint-renaming note and the new requirement into a single `Notes:` bullet list, matching the repo's convention for consecutive notes.

## Jira
[OKTA-1111103](https://oktainc.atlassian.net/browse/OKTA-1111103)

## Netlify Preview Link

<!-- Add preview link here -->
