### PR TITLE
OCI journey - OIE upgrade: Identify Okta integrations and customizations

### DIFF
--- a/packages/@okta/vuepress-site/docs/concepts/oie-intro/index.md
+++ b/packages/@okta/vuepress-site/docs/concepts/oie-intro/index.md
@@ -122,4 +122,6 @@ On March 1, 2022, all new [Okta orgs](/docs/concepts/okta-organizations/) are Id
 
 If you're a Classic Engine customer who wants to upgrade their apps to use Identity Engine, go to [Identity Engine upgrade overview](/docs/guides/oie-upgrade-overview/) to review the level of effort based on your current configuration and telemetry use.
 
+To inventory every integration point that the upgrade might affect, see [Identify your Okta authentication integrations and customizations](/docs/guides/oie-upgrade-identify-integrations/).
+
 For Classic Engine customers who aren’t ready to upgrade, your existing functionality continues to work for now, including your Classic Engine org, v1 API, and SDKs.

--- a/packages/@okta/vuepress-site/docs/guides/ie-limitations/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/ie-limitations/main/index.md
@@ -7,6 +7,8 @@ excerpt: Okta Identity Engine introduces a lot of changes to the Okta platform. 
 
 Okta Identity Engine introduces many changes to the Okta platform. Some of these changes result in a lack of support for previously available features. Also, some of these changes result in Identity Engine features not supported for use with Classic Engine APIs.
 
+To find which of these features and integrations your org actually uses, see [Identify your Okta authentication integrations and customizations](/docs/guides/oie-upgrade-identify-integrations/).
+
 Are you an admin? See the Identity Engine [limitations](https://help.okta.com/okta_help.htm?type=oie&id=ext-oie-limitations) doc for admins.
 
 > **Note:** This doc is designed for people who are familiar with Classic Engine. If you're new to Okta and Identity Engine, see [Get started](https://help.okta.com/okta_help.htm?type=oie&id=ext-get-started-oie) with Identity Engine.

--- a/packages/@okta/vuepress-site/docs/guides/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/index.md
@@ -166,6 +166,7 @@ guides:
  - oie-embedded-widget-use-case-basic-sign-in
  - oie-embedded-widget-use-case-sign-in-soc-idp
  - oie-upgrade-overview
+ - oie-upgrade-identify-integrations
  - oie-upgrade-plan-embedded-upgrades
  - oie-upgrade-add-sdk-to-your-app
  - oie-upgrade-api-sdk-to-oie-sdk

--- a/packages/@okta/vuepress-site/docs/guides/oie-upgrade-identify-integrations/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-upgrade-identify-integrations/index.md
@@ -1,0 +1,9 @@
+---
+title: Identify your Okta authentication integrations and customizations
+meta:
+  - name: description
+    content: Find all Okta sign-in, customization, SDK, and API integration points so you can assess each one before upgrading to Okta Identity Engine.
+layout: Guides
+sections:
+  - main
+---

--- a/packages/@okta/vuepress-site/docs/guides/oie-upgrade-identify-integrations/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-upgrade-identify-integrations/main/index.md
@@ -7,7 +7,7 @@ meta:
 
 <ApiLifecycle access="ie" />
 
-Okta integrations can span apps, sign-in pages, custom code, SDKs, API tokens, Okta Workflows, hooks, directory agents, and log streams. Discovery helps your team decide what to test, update, replace, retire, or assign an owner before the Okta Identity Engine upgrade.
+Okta integrations can span apps, sign-in pages, custom code, SDKs, API tokens, Okta Workflows, hooks, directory agents, and log streams. Any of these can break during an upgrade. Discovery helps your team decide what to test, update, replace, retire, or assign an owner before the Okta Identity Engine upgrade.
 
 A single Okta org may run multiple deployment models at the same time. Find all of them before the upgrade so that nothing breaks unexpectedly.
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-upgrade-identify-integrations/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-upgrade-identify-integrations/main/index.md
@@ -28,7 +28,11 @@ A single Okta org may run multiple deployment models at the same time. Find all 
 
 ---
 
-## Create an integration inventory
+## Plan your discovery
+
+Set up a place to record findings, then choose where to begin.
+
+### Create an integration inventory
 
 Use this worksheet to record every integration that you find. Add a row for each app, service, script, Workflow, agent, or integration that interacts with Okta.
 
@@ -43,7 +47,7 @@ Use this worksheet to record every integration that you find. Add a row for each
 | Upgrade action | Test, update, replace, retire, validate, or investigate. |
 | Notes | Any other relevant detail. |
 
-## Decide where to start your discovery
+### Decide where to start your discovery
 
 Use this table to choose a starting point for each kind of integration.
 
@@ -60,7 +64,11 @@ Use this table to choose a starting point for each kind of integration.
 | Workflows or automations using Okta | Okta Workflows console > **Flows** | Workflows connected apps | Flow name, connections, and Okta actions |
 | Directory agents or log stream dependencies | **Directory** > **Directory Integrations** | **Reports** > **Log streaming** | Agent type, version, and connection status |
 
-## Find Okta-hosted redirect sign-in integration points
+## Find sign-in and client-side integration points
+
+Use this section to find redirect sign-in, embedded widget, custom sign-in page, and SDK integration points.
+
+### Okta-hosted redirect sign-in
 
 Use this section to find apps that redirect users to an Okta-hosted login page, especially apps with a customized login page.
 
@@ -81,7 +89,7 @@ Use this section to find apps that redirect users to an Okta-hosted login page, 
 * Whether an acknowledgement item appears in the **OIE Upgrade Hub**.
 * The location and nature of any custom code in the code editor.
 
-## Find embedded Sign-In Widget and custom sign-in page integration points
+### Embedded Sign-In Widget and custom sign-in pages
 
 Use this section to find apps that embed the Okta Sign-In Widget on an application page, or custom sign-in pages not hosted by Okta.
 
@@ -102,7 +110,7 @@ Use this section to find apps that embed the Okta Sign-In Widget on an applicati
 * Whether an embedded Sign-In Widget acknowledgement item exists in the Upgrade Hub.
 * Whether Classic Mode is in use.
 
-## Find apps that use Okta SDKs or client-side authentication
+### Okta SDKs and client-side authentication
 
 Use this section to find apps that use the Auth.js SDK, Okta client-side SDKs, or custom JavaScript authentication flows.
 
@@ -205,7 +213,11 @@ Use this section to find components that affect sign-in flows, token issuance, p
 
 For each component, record the name, type, configuration, owner, and whether it's currently active.
 
-## Validate active usage with reports and the System Log
+## Validate usage and plan upgrade actions
+
+Confirm which integration points are still in use, then assign an action to each one.
+
+### Validate active usage with reports and the System Log
 
 Use these tools to confirm which integration points are still in active use before you assign upgrade actions.
 
@@ -232,7 +244,7 @@ To find server-side API callers:
 
 For programmatic export, use the [List Log Events API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/SystemLog/).
 
-## Map owners, dependencies, and upgrade actions
+### Map owners, dependencies, and upgrade actions
 
 Review all inventory entries and assign an upgrade action to each integration.
 
@@ -252,7 +264,7 @@ Review all inventory entries and assign an upgrade action to each integration.
 | Inactive app with no recent activity | A candidate for retirement before the upgrade | Verify with the owner; retire if confirmed unused |
 | Unknown owner | You can't assign upgrade responsibility | Escalate to IT or the security team for ownership investigation |
 
-## What to assess before the upgrade
+### What to assess before the upgrade
 
 * Confirm who owns each integration.
 * Confirm that each integration is still active and in use.

--- a/packages/@okta/vuepress-site/docs/guides/oie-upgrade-identify-integrations/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-upgrade-identify-integrations/main/index.md
@@ -20,7 +20,7 @@ A single Okta org may run multiple deployment models at the same time. Find all 
 
 #### What you need
 
-* Super admin or read-only admin access to the Okta Admin Console.
+* Super admin or read-only admin access to the Admin Console.
 * A contact list for app, security, DevOps, and development team owners.
 * Access to source-code search, CI/CD configuration, and secrets managers.
 * A date range for log and report queries, such as the past 90 days.
@@ -39,7 +39,7 @@ Use this worksheet to record every integration that you find. Add a row for each
 | Column | What to record |
 | --- | --- |
 | Integration name | The name of the app, service, script, Workflow, agent, or integration. |
-| Integration type | Redirect SSO, embedded widget, custom sign-in page, SDK or Auth.js, SSWS API token, OAuth service app, custom authorization server, event hook, Workflow, directory agent, log stream, or other. |
+| Integration type | Redirect SSO, embedded widget, SDK, API token, OAuth service app, hook, Workflow, directory agent, log stream, or other. |
 | Where found | Admin Console, System Log, a report, source code, CORS trusted origins, secrets manager, or SIEM. |
 | Owner | A team, an admin, or unknown. |
 | Last observed use | A date or evidence from logs, reports, or code history. |
@@ -53,11 +53,11 @@ Use this table to choose a starting point for each kind of integration.
 
 | To find... | Start with... | Confirm with... | Record... |
 | --- | --- | --- | --- |
-| Apps using Okta SSO | **Applications** > **Applications** in the Admin Console | Application Access report | App name, type, status, and owner |
-| Apps with recent sign-in activity | Application usage report | `user.authentication.sso` events in the System Log | App name, last used, and user count |
-| Apps with user or group assignments | App integration assignments | User App Access report | Groups assigned and provisioning status |
-| Redirect apps with a customized hosted login | **OIE Upgrade Hub** acknowledgement items | **Customizations** > **Brands** > **Pages** > **Code Editor** | Custom domain and any custom CSS or JavaScript |
-| Embedded Sign-In Widget or Auth.js SDK | **OIE Upgrade Hub** acknowledgement items | **Security** > **API** > **Trusted Origins** CORS entries | URLs registered for CORS |
+| Apps using Okta SSO | **Apps** > **Apps** in the Admin Console | App access report | App name, type, status, and owner |
+| Apps with recent sign-in activity | App usage report | `user.authentication.sso` events in the System Log | App name, last used, and user count |
+| Apps with user or group assignments | App integration assignments | User App access report | Groups assigned and provisioning status |
+| Redirect apps with a customized hosted login | **OIE Upgrade Hub** acknowledgment items | **Customizations** > **Brands** > **Pages** > **Code Editor** | Custom domain and any custom CSS or JavaScript |
+| Embedded Sign-In Widget or Auth.js SDK | **OIE Upgrade Hub** acknowledgment items | **Security** > **API** > **Trusted Origins** CORS entries | URLs registered for CORS |
 | SSWS API tokens and owners | **Security** > **API** > **Tokens** | [List API tokens](/docs/guides/create-an-api-token/) | Token name, role, last used, and owner |
 | OAuth service apps calling Okta APIs | **Security** > **API** > **API service integrations** | Okta API scopes assigned to each app | App name, scopes, and owner |
 | Custom authorization servers | **Security** > **API** > **Authorization servers** | [Build authorization servers](/docs/guides/customize-authz-server/) | Server name, audience, and scopes |
@@ -75,10 +75,10 @@ Use this section to find apps that redirect users to an Okta-hosted login page, 
 **Check**
 
 * Check the URL that users visit to sign in.
-  * A `.okta.com` or `.oktapreview.com` URL means no [custom domain](/docs/guides/custom-url-domain/) is configured, so login page customizations aren't possible.
-  * A URL on your own domain means a custom domain is configured.
-* Open the **OIE Upgrade Hub** and review acknowledgement items for hosted login page customizations.
-  * Any change to the login page code editor, even a comment, triggers an acknowledgement item.
+  * A `.okta.com` or `.oktapreview.com` URL means that no [custom domain](/docs/guides/custom-url-domain/) is configured, so login page customizations aren't possible.
+  * A URL on your own domain means that a custom domain is configured.
+* Open the **OIE Upgrade Hub** and review acknowledgment items for hosted login page customizations.
+  * Any change to the login page code editor, even a comment, triggers an acknowledgment item.
 * Go to **Customizations** > **Brands**.
   * For each brand with a custom domain, open **Pages** > **Login page** > **Code Editor**.
   * Review for [deprecated Sign-In Widget methods](/docs/guides/oie-upgrade-sign-in-widget-deprecated-methods/), custom CSS, or custom JavaScript.
@@ -86,7 +86,7 @@ Use this section to find apps that redirect users to an Okta-hosted login page, 
 **Record**
 
 * Whether a custom domain is in use.
-* Whether an acknowledgement item appears in the **OIE Upgrade Hub**.
+* Whether an acknowledgment item appears in the **OIE Upgrade Hub**.
 * The location and nature of any custom code in the code editor.
 
 ### Embedded Sign-In Widget and custom sign-in pages
@@ -95,7 +95,7 @@ Use this section to find apps that embed the Okta Sign-In Widget on an applicati
 
 **Check**
 
-* Open the **OIE Upgrade Hub** and look for an acknowledgement item that indicates an embedded Okta Sign-In Widget.
+* Open the **OIE Upgrade Hub** and look for an acknowledgment item that indicates an embedded Okta Sign-In Widget.
   * This item appears when the widget is detected as embedded.
 * Go to **Security** > **API** > **Trusted Origins** and filter for entries with CORS enabled.
   * [CORS registration](/docs/guides/enable-cors/) is required for both the Sign-In Widget and the Auth.js SDK to function.
@@ -107,7 +107,7 @@ Use this section to find apps that embed the Okta Sign-In Widget on an applicati
 **Record**
 
 * Each URL registered for CORS, and whether CORS was the intended purpose.
-* Whether an embedded Sign-In Widget acknowledgement item exists in the Upgrade Hub.
+* Whether an embedded Sign-In Widget acknowledgment item exists in the Upgrade Hub.
 * Whether Classic Mode is in use.
 
 ### Okta SDKs and client-side authentication
@@ -135,10 +135,10 @@ Use this section to find all app integrations in the org, including active, inac
 
 **Check**
 
-* Go to **Applications** > **Applications** and review all app integrations by status, including active and inactive apps.
-* Use the [Applications API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Application/) to export a complete list programmatically for large orgs.
+* Go to **Apps** > **Apps** and review all app integrations by status, including active and inactive apps.
+* Use the [Apps API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Application/) to export a complete list programmatically for large orgs.
 * Review each app's sign-on method (SAML, OIDC, SWA, or bookmark), provisioning status, and last sign-in date.
-* Use the Application usage report to identify apps with no recent sign-in activity.
+* Use the app usage report to identify apps with no recent sign-in activity.
 
 **Record**
 
@@ -225,9 +225,9 @@ Use these tools to confirm which integration points are still in active use befo
 
 | Report | What it shows | Use it to |
 | --- | --- | --- |
-| Application Access report | SSO attempts across app integrations | Confirm which apps have recent SSO activity |
-| Application usage report | Sign-in counts by app over a date range | Identify stale or inactive apps |
-| User App Access report | Users and groups with access to each app | Identify ownership and dependency scope |
+| App access report | SSO attempts across app integrations | Confirm which apps have recent SSO activity |
+| App usage report | Sign-in counts by app over a date range | Identify stale or inactive apps |
+| User App access report | Users and groups with access to each app | Identify ownership and dependency scope |
 | Admin role assignments report | Admins, resource sets, and roles | Identify API token owners and possible app owners |
 
 **System Log**
@@ -251,7 +251,7 @@ Review all inventory entries and assign an upgrade action to each integration.
 | Finding | Why it matters before the upgrade | Recommended action |
 | --- | --- | --- |
 | Redirect app using a custom domain | The custom login page may use deprecated Sign-In Widget methods | Test before the upgrade |
-| **OIE Upgrade Hub** acknowledgement item | Indicates a customization or embedded component that needs review | Complete the Upgrade Hub acknowledgement process |
+| **OIE Upgrade Hub** acknowledgment item | Indicates a customization or embedded component that needs review | Complete the Upgrade Hub acknowledgment process |
 | Embedded Sign-In Widget | Widget version compatibility must be confirmed for Identity Engine | Test before upgrade; update the widget version if needed |
 | Auth.js SDK in use | The SDK version must be Identity Engine-compatible | Update the SDK version before the upgrade |
 | Server-side calls to `/api/v1/authn`, `/api/v1/sessions`, or `/api/v1/factors` | Classic-only endpoints may change behavior in Identity Engine | Identify the caller, assess impact, and update or replace |
@@ -270,13 +270,13 @@ Review all inventory entries and assign an upgrade action to each integration.
 * Confirm that each integration is still active and in use.
 * Confirm whether the integration affects sign-in, policy, API automation, provisioning, user lifecycle, logging, or security monitoring.
 * Confirm whether the integration must be tested in an Identity Engine preview or sandbox environment.
-* Complete all relevant **OIE Upgrade Hub** acknowledgement items.
+* Complete all relevant **OIE Upgrade Hub** acknowledgment items.
 * Notify downstream teams of the upgrade timeline and any expected changes.
 * Assign an upgrade action to each integration: test, update, replace, retire, validate, or investigate.
 
 ## Next steps
 
-* Complete all acknowledgement items in the **OIE Upgrade Hub** for your org.
+* Complete all acknowledgment items in the **OIE Upgrade Hub** for your org.
 * Test all embedded, SDK-based, and server-side integration points in an Identity Engine preview environment before upgrading production.
 * Replace or update Classic-only API calls with Identity Engine-supported equivalents where needed.
 * Assign integration owners and collect upgrade readiness sign-off from each team before the production upgrade.
@@ -285,7 +285,7 @@ Review all inventory entries and assign an upgrade action to each integration.
 ## Related topics
 
 * [Prepare your customizations for upgrade](https://help.okta.com/okta_help.htm?type=oie&id=ext-custom-sign-in-page)
-* [Applications API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Application/)
+* [Apps API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Application/)
 * [Create and manage API tokens](/docs/guides/create-an-api-token/)
 * [Implement OAuth for Okta service app](/docs/guides/implement-oauth-for-okta-serviceapp/)
 * [Build authorization servers](/docs/guides/customize-authz-server/)

--- a/packages/@okta/vuepress-site/docs/guides/oie-upgrade-identify-integrations/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-upgrade-identify-integrations/main/index.md
@@ -83,7 +83,7 @@ Use this section to find apps that redirect users to an Okta-hosted login page, 
   * For each brand with a custom domain, open **Pages** > **Login page** > **Code Editor**.
   * Review for [deprecated Sign-In Widget methods](/docs/guides/oie-upgrade-sign-in-widget-deprecated-methods/), custom CSS, or custom JavaScript.
 
-**Record**
+**Record:**
 
 * Whether a custom domain is in use.
 * Whether an acknowledgment item appears in the **OIE Upgrade Hub**.
@@ -91,24 +91,24 @@ Use this section to find apps that redirect users to an Okta-hosted login page, 
 
 ### Embedded Sign-In Widget and custom sign-in pages
 
-Use this section to find apps that embed the Okta Sign-In Widget on an application page, or custom sign-in pages not hosted by Okta.
+Use this section to find apps that embed the Okta Sign-In Widget on an app page, or custom sign-in pages not hosted by Okta.
 
 **Check**
 
 * Open the **OIE Upgrade Hub** and look for an acknowledgment item that indicates an embedded Okta Sign-In Widget.
-  * This item appears when the widget is detected as embedded.
+  * This item appears when the Sign-In Widget is detected as embedded.
 * Go to **Security** > **API** > **Trusted Origins** and filter for entries with CORS enabled.
   * [CORS registration](/docs/guides/enable-cors/) is required for both the Sign-In Widget and the Auth.js SDK to function.
   * Any URL registered for CORS is a potential embedded client-side authentication endpoint.
 * The Upgrade Hub doesn't detect the Auth.js (`okta-auth-js`) SDK independently.
   * Use CORS entries and source-code search to find Auth.js usage.
-* If the Sign-In Widget runs in Classic Mode, the upgrade may not require changes. Thorough testing is still required.
+* If the Sign-In Widget runs in classic mode, the upgrade may not require changes. Thorough testing is still required.
 
-**Record**
+**Record:**
 
 * Each URL registered for CORS, and whether CORS was the intended purpose.
 * Whether an embedded Sign-In Widget acknowledgment item exists in the Upgrade Hub.
-* Whether Classic Mode is in use.
+* Whether classic mode is in use.
 
 ### Okta SDKs and client-side authentication
 
@@ -123,7 +123,7 @@ Use this section to find apps that use the Auth.js SDK, Okta client-side SDKs, o
 * Reach out to development teams directly.
   * Server-side authentication patterns may not appear in the Admin Console or System Log in a traceable way.
 
-**Record**
+**Record:**
 
 * The application or repository name.
 * The SDK or library version found.
@@ -140,7 +140,7 @@ Use this section to find all app integrations in the org, including active, inac
 * Review each app's sign-on method (SAML, OIDC, SWA, or bookmark), provisioning status, and last sign-in date.
 * Use the app usage report to identify apps with no recent sign-in activity.
 
-**Record**
+**Record:**
 
 * App name, sign-on method, status, provisioning status, and the date of last observed sign-in.
 
@@ -161,7 +161,7 @@ Use this section to find SSWS API tokens, OAuth service apps, and service accoun
   * In the CSV, filter the `rawUserAgent` column for values that don't start with `Mozilla`.
   * If a log event includes `system.transaction.request.apiTokenId`, look up that token ID under **Security** > **API** > **Tokens** to find the owner.
 
-**Record**
+**Record:**
 
 * Token name, owner, associated admin role, and last-used date.
 * Which services or scripts are confirmed to use each token.
@@ -173,7 +173,7 @@ Use this section to find SSWS API tokens, OAuth service apps, and service accoun
 * Go to **Security** > **API** > **API service integrations** and review each machine-to-machine integration and its scopes.
 * Use the [Okta API scopes](/docs/guides/implement-oauth-for-okta/) reference to understand what each scope allows.
 
-**Record**
+**Record:**
 
 * Service app name, configured scopes, and owner team.
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-upgrade-identify-integrations/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-upgrade-identify-integrations/main/index.md
@@ -20,11 +20,11 @@ A single Okta org may run multiple deployment models at the same time. Find all 
 
 #### What you need
 
-* Super admin or read-only admin access to the Admin Console.
-* A contact list for app, security, DevOps, and development team owners.
-* Access to source-code search, CI/CD configuration, and secrets managers.
-* A date range for log and report queries, such as the past 90 days.
-* A spreadsheet or tracking tool to record inventory findings.
+* Super admin or read-only admin access to the Admin Console
+* A contact list for app, security, DevOps, and development team owners
+* Access to source-code search, CI/CD configuration, and secrets managers
+* A date range for log and report queries, such as the past 90 days
+* A spreadsheet or tracking tool to record inventory findings
 
 ---
 

--- a/packages/@okta/vuepress-site/docs/guides/oie-upgrade-identify-integrations/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-upgrade-identify-integrations/main/index.md
@@ -1,0 +1,282 @@
+---
+title: Identify your Okta authentication integrations and customizations
+meta:
+  - name: description
+    content: Find all Okta sign-in, customization, SDK, and API integration points so you can assess each one before upgrading to Okta Identity Engine.
+---
+
+<ApiLifecycle access="ie" />
+
+Okta integrations can span apps, sign-in pages, custom code, SDKs, API tokens, Okta Workflows, hooks, directory agents, and log streams. Discovery helps your team decide what to test, update, replace, retire, or assign an owner before the Okta Identity Engine upgrade.
+
+A single Okta org may run multiple deployment models at the same time. Find all of them before the upgrade so that nothing breaks unexpectedly.
+
+---
+
+#### Learning outcomes
+
+* Find every Okta sign-in, SDK, API, and automation integration point in your org.
+* Assess each integration and assign an upgrade action before the Identity Engine upgrade.
+
+#### What you need
+
+* Super admin or read-only admin access to the Okta Admin Console.
+* A contact list for app, security, DevOps, and development team owners.
+* Access to source-code search, CI/CD configuration, and secrets managers.
+* A date range for log and report queries, such as the past 90 days.
+* A spreadsheet or tracking tool to record inventory findings.
+
+---
+
+## Create an integration inventory
+
+Use this worksheet to record every integration that you find. Add a row for each app, service, script, Workflow, agent, or integration that interacts with Okta.
+
+| Column | What to record |
+| --- | --- |
+| Integration name | The name of the app, service, script, Workflow, agent, or integration. |
+| Integration type | Redirect SSO, embedded widget, custom sign-in page, SDK or Auth.js, SSWS API token, OAuth service app, custom authorization server, event hook, Workflow, directory agent, log stream, or other. |
+| Where found | Admin Console, System Log, a report, source code, CORS trusted origins, secrets manager, or SIEM. |
+| Owner | A team, an admin, or unknown. |
+| Last observed use | A date or evidence from logs, reports, or code history. |
+| Impact area | Sign-in, authentication, provisioning, API automation, policy, user lifecycle, logging, or security. |
+| Upgrade action | Test, update, replace, retire, validate, or investigate. |
+| Notes | Any other relevant detail. |
+
+## Decide where to start your discovery
+
+Use this table to choose a starting point for each kind of integration.
+
+| To find... | Start with... | Confirm with... | Record... |
+| --- | --- | --- | --- |
+| Apps using Okta SSO | **Applications** > **Applications** in the Admin Console | Application Access report | App name, type, status, and owner |
+| Apps with recent sign-in activity | Application usage report | `user.authentication.sso` events in the System Log | App name, last used, and user count |
+| Apps with user or group assignments | App integration assignments | User App Access report | Groups assigned and provisioning status |
+| Redirect apps with a customized hosted login | **OIE Upgrade Hub** acknowledgement items | **Customizations** > **Brands** > **Pages** > **Code Editor** | Custom domain and any custom CSS or JavaScript |
+| Embedded Sign-In Widget or Auth.js SDK | **OIE Upgrade Hub** acknowledgement items | **Security** > **API** > **Trusted Origins** CORS entries | URLs registered for CORS |
+| SSWS API tokens and owners | **Security** > **API** > **Tokens** | [List API tokens](/docs/guides/create-an-api-token/) | Token name, role, last used, and owner |
+| OAuth service apps calling Okta APIs | **Security** > **API** > **API service integrations** | Okta API scopes assigned to each app | App name, scopes, and owner |
+| Custom authorization servers | **Security** > **API** > **Authorization servers** | [Build authorization servers](/docs/guides/customize-authz-server/) | Server name, audience, and scopes |
+| Workflows or automations using Okta | Okta Workflows console > **Flows** | Workflows connected apps | Flow name, connections, and Okta actions |
+| Directory agents or log stream dependencies | **Directory** > **Directory Integrations** | **Reports** > **Log streaming** | Agent type, version, and connection status |
+
+## Find Okta-hosted redirect sign-in integration points
+
+Use this section to find apps that redirect users to an Okta-hosted login page, especially apps with a customized login page.
+
+**Check**
+
+* Check the URL that users visit to sign in.
+  * A `.okta.com` or `.oktapreview.com` URL means no [custom domain](/docs/guides/custom-url-domain/) is configured, so login page customizations aren't possible.
+  * A URL on your own domain means a custom domain is configured.
+* Open the **OIE Upgrade Hub** and review acknowledgement items for hosted login page customizations.
+  * Any change to the login page code editor, even a comment, triggers an acknowledgement item.
+* Go to **Customizations** > **Brands**.
+  * For each brand with a custom domain, open **Pages** > **Login page** > **Code Editor**.
+  * Review for [deprecated Sign-In Widget methods](/docs/guides/oie-upgrade-sign-in-widget-deprecated-methods/), custom CSS, or custom JavaScript.
+
+**Record**
+
+* Whether a custom domain is in use.
+* Whether an acknowledgement item appears in the **OIE Upgrade Hub**.
+* The location and nature of any custom code in the code editor.
+
+## Find embedded Sign-In Widget and custom sign-in page integration points
+
+Use this section to find apps that embed the Okta Sign-In Widget on an application page, or custom sign-in pages not hosted by Okta.
+
+**Check**
+
+* Open the **OIE Upgrade Hub** and look for an acknowledgement item that indicates an embedded Okta Sign-In Widget.
+  * This item appears when the widget is detected as embedded.
+* Go to **Security** > **API** > **Trusted Origins** and filter for entries with CORS enabled.
+  * [CORS registration](/docs/guides/enable-cors/) is required for both the Sign-In Widget and the Auth.js SDK to function.
+  * Any URL registered for CORS is a potential embedded client-side authentication endpoint.
+* The Upgrade Hub doesn't detect the Auth.js (`okta-auth-js`) SDK independently.
+  * Use CORS entries and source-code search to find Auth.js usage.
+* If the Sign-In Widget runs in Classic Mode, the upgrade may not require changes. Thorough testing is still required.
+
+**Record**
+
+* Each URL registered for CORS, and whether CORS was the intended purpose.
+* Whether an embedded Sign-In Widget acknowledgement item exists in the Upgrade Hub.
+* Whether Classic Mode is in use.
+
+## Find apps that use Okta SDKs or client-side authentication
+
+Use this section to find apps that use the Auth.js SDK, Okta client-side SDKs, or custom JavaScript authentication flows.
+
+**Check**
+
+* Search source-code repositories for imports or references to `@okta/okta-auth-js`, `@okta/okta-signin-widget`, `@okta/okta-react`, `@okta/okta-angular`, `@okta/okta-vue`, or `okta-sdk-*`.
+* Check package manifests, CI/CD configuration, and secrets managers for Okta client IDs, issuer URLs, or redirect URIs.
+  * Manifests include `package.json`, `pom.xml`, `requirements.txt`, and `.csproj` files.
+* Cross-reference findings with CORS Trusted Origins, which are required for client-side Okta authentication.
+* Reach out to development teams directly.
+  * Server-side authentication patterns may not appear in the Admin Console or System Log in a traceable way.
+
+**Record**
+
+* The application or repository name.
+* The SDK or library version found.
+* Whether the app also appears in CORS Trusted Origins.
+
+## Find applications configured in Okta
+
+Use this section to find all app integrations in the org, including active, inactive, and recently provisioned apps.
+
+**Check**
+
+* Go to **Applications** > **Applications** and review all app integrations by status, including active and inactive apps.
+* Use the [Applications API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Application/) to export a complete list programmatically for large orgs.
+* Review each app's sign-on method (SAML, OIDC, SWA, or bookmark), provisioning status, and last sign-in date.
+* Use the Application usage report to identify apps with no recent sign-in activity.
+
+**Record**
+
+* App name, sign-on method, status, provisioning status, and the date of last observed sign-in.
+
+## Find API tokens and service integrations that call Okta APIs
+
+Use this section to find SSWS API tokens, OAuth service apps, and service accounts that call Okta management APIs.
+
+### SSWS API tokens
+
+**Check**
+
+* Go to **Security** > **API** > **Tokens** and review each active token's name, ID, role, type, and last-used date.
+* API tokens act on behalf of the admin who created them.
+  * Tokens owned by former employees or shared accounts may need reassignment or replacement before the upgrade.
+* Use the [List API tokens](/docs/guides/create-an-api-token/) operation to export token metadata for bulk review.
+* To trace which token made specific calls, filter the System Log for `/api/v1/authn`, `/api/v1/sessions`, or `/api/v1/factors` requests.
+  * Export the results to CSV.
+  * In the CSV, filter the `rawUserAgent` column for values that don't start with `Mozilla`.
+  * If a log event includes `system.transaction.request.apiTokenId`, look up that token ID under **Security** > **API** > **Tokens** to find the owner.
+
+**Record**
+
+* Token name, owner, associated admin role, and last-used date.
+* Which services or scripts are confirmed to use each token.
+
+### OAuth service apps
+
+**Check**
+
+* Go to **Security** > **API** > **API service integrations** and review each machine-to-machine integration and its scopes.
+* Use the [Okta API scopes](/docs/guides/implement-oauth-for-okta/) reference to understand what each scope allows.
+
+**Record**
+
+* Service app name, configured scopes, and owner team.
+
+## Find authorization servers, hooks, Workflows, agents, and log streams
+
+Use this section to find components that affect sign-in flows, token issuance, provisioning, or automation.
+
+**Custom authorization servers**
+
+* Go to **Security** > **API** > **Authorization servers** and list all custom authorization servers.
+* For each server, note the audience, scopes, claims, and any attached access policies or rules.
+* See [Build authorization servers](/docs/guides/customize-authz-server/) for a configuration reference.
+
+**Event hooks and inline hooks**
+
+* Go to **Workflow** > **Event Hooks** and **Inline Hooks** in the Admin Console.
+* For each hook, record the endpoint URL, the events subscribed to, and the owner team.
+* See the [Event Hooks](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/EventHook/) and [Inline Hooks](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/InlineHook/) APIs for reference.
+
+**Okta Workflows**
+
+* Open the Workflows console and review active and inactive flows.
+* Check the Workflows connected apps and the Okta connector reference.
+* Identify flows that trigger on user lifecycle events, such as user creation, deactivation, or group membership changes.
+
+**Directory agents**
+
+* Go to **Directory** > **Directory Integrations** and list all AD, LDAP, and HR agents.
+* Record each agent's name, type, version, and connection status.
+* See your AD and LDAP integration settings for a configuration reference.
+
+**Log streams**
+
+* Go to **Reports** > **Log streaming** and review all configured log stream destinations.
+* Record each stream's destination, event type filters, and owner team.
+* See the [Log Streaming API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/LogStream/) for a configuration reference.
+
+For each component, record the name, type, configuration, owner, and whether it's currently active.
+
+## Validate active usage with reports and the System Log
+
+Use these tools to confirm which integration points are still in active use before you assign upgrade actions.
+
+**Reports**
+
+| Report | What it shows | Use it to |
+| --- | --- | --- |
+| Application Access report | SSO attempts across app integrations | Confirm which apps have recent SSO activity |
+| Application usage report | Sign-in counts by app over a date range | Identify stale or inactive apps |
+| User App Access report | Users and groups with access to each app | Identify ownership and dependency scope |
+| Admin role assignments report | Admins, resource sets, and roles | Identify API token owners and possible app owners |
+
+**System Log**
+
+* Use System Log filters to search by event type, actor, IP address, or target.
+* Use the [event types catalog](/docs/reference/api/event-types/) to identify the event types most relevant to your discovery.
+
+To find server-side API callers:
+
+1. Filter the System Log for requests to `/api/v1/authn`, `/api/v1/sessions`, or `/api/v1/factors`.
+2. Export the results to CSV.
+3. In the CSV, filter the `rawUserAgent` column for values that don't start with `Mozilla`. Non-browser user agents indicate server-side or scripted callers.
+4. If `system.transaction.request.apiTokenId` is populated, copy that token ID and search for it under **Security** > **API** > **Tokens** to find the owner.
+
+For programmatic export, use the [List Log Events API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/SystemLog/).
+
+## Map owners, dependencies, and upgrade actions
+
+Review all inventory entries and assign an upgrade action to each integration.
+
+| Finding | Why it matters before the upgrade | Recommended action |
+| --- | --- | --- |
+| Redirect app using a custom domain | The custom login page may use deprecated Sign-In Widget methods | Test before the upgrade |
+| **OIE Upgrade Hub** acknowledgement item | Indicates a customization or embedded component that needs review | Complete the Upgrade Hub acknowledgement process |
+| Embedded Sign-In Widget | Widget version compatibility must be confirmed for Identity Engine | Test before upgrade; update the widget version if needed |
+| Auth.js SDK in use | The SDK version must be Identity Engine-compatible | Update the SDK version before the upgrade |
+| Server-side calls to `/api/v1/authn`, `/api/v1/sessions`, or `/api/v1/factors` | Classic-only endpoints may change behavior in Identity Engine | Identify the caller, assess impact, and update or replace |
+| Active SSWS API token owned by a departed admin | The token may fail if the admin account is deactivated | Reassign to an active service account, or replace with an OAuth service app |
+| OAuth service app with broad scopes | Scope access may need review after the upgrade | Validate scopes and follow least privilege |
+| Custom authorization server | Identity Engine policy and rule changes may affect token issuance | Test token flows in an Identity Engine preview org |
+| Okta Workflow triggering on lifecycle events | Identity Engine policy changes may affect trigger timing or payload data | Test flows in an Identity Engine preview org |
+| Directory agent on an older version | Older agents may have compatibility issues | Update the agent to the current version before the upgrade |
+| Log stream to an external SIEM | Log format or event type changes may affect SIEM parsing | Test in a preview org; update SIEM filters if needed |
+| Inactive app with no recent activity | A candidate for retirement before the upgrade | Verify with the owner; retire if confirmed unused |
+| Unknown owner | You can't assign upgrade responsibility | Escalate to IT or the security team for ownership investigation |
+
+## What to assess before the upgrade
+
+* Confirm who owns each integration.
+* Confirm that each integration is still active and in use.
+* Confirm whether the integration affects sign-in, policy, API automation, provisioning, user lifecycle, logging, or security monitoring.
+* Confirm whether the integration must be tested in an Identity Engine preview or sandbox environment.
+* Complete all relevant **OIE Upgrade Hub** acknowledgement items.
+* Notify downstream teams of the upgrade timeline and any expected changes.
+* Assign an upgrade action to each integration: test, update, replace, retire, validate, or investigate.
+
+## Next steps
+
+* Complete all acknowledgement items in the **OIE Upgrade Hub** for your org.
+* Test all embedded, SDK-based, and server-side integration points in an Identity Engine preview environment before upgrading production.
+* Replace or update Classic-only API calls with Identity Engine-supported equivalents where needed.
+* Assign integration owners and collect upgrade readiness sign-off from each team before the production upgrade.
+* Return to the [Prepare your upgrade to Okta Identity Engine](/docs/guides/oie-upgrade-overview/) journey for planning, rollout, and timeline steps.
+
+## Related topics
+
+* [Prepare your customizations for upgrade](https://help.okta.com/okta_help.htm?type=oie&id=ext-custom-sign-in-page)
+* [Applications API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Application/)
+* [Create and manage API tokens](/docs/guides/create-an-api-token/)
+* [Implement OAuth for Okta service app](/docs/guides/implement-oauth-for-okta-serviceapp/)
+* [Build authorization servers](/docs/guides/customize-authz-server/)
+* [Enable CORS](/docs/guides/enable-cors/)
+* [Event types](/docs/reference/api/event-types/)
+* [List Log Events API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/SystemLog/)

--- a/packages/@okta/vuepress-site/docs/guides/oie-upgrade-identify-integrations/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oie-upgrade-identify-integrations/main/index.md
@@ -266,6 +266,8 @@ Review all inventory entries and assign an upgrade action to each integration.
 
 ### What to assess before the upgrade
 
+Assess each integration against this checklist:
+
 * Confirm who owns each integration.
 * Confirm that each integration is still active and in use.
 * Confirm whether the integration affects sign-in, policy, API automation, provisioning, user lifecycle, logging, or security monitoring.
@@ -275,6 +277,8 @@ Review all inventory entries and assign an upgrade action to each integration.
 * Assign an upgrade action to each integration: test, update, replace, retire, validate, or investigate.
 
 ## Next steps
+
+After you finish discovery, take these actions:
 
 * Complete all acknowledgment items in the **OIE Upgrade Hub** for your org.
 * Test all embedded, SDK-based, and server-side integration points in an Identity Engine preview environment before upgrading production.

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-overview/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-overview/main/index.md
@@ -49,6 +49,8 @@ For more background on the different deployment models, including basic flows an
 
 If you’re a Classic Engine customer who wants to upgrade their apps to use Identity Engine for authentication, go to [Identity Engine upgrade overview](/docs/guides/oie-upgrade-overview/).
 
+Before you start, [identify your Okta authentication integrations and customizations](/docs/guides/oie-upgrade-identify-integrations/) to inventory every sign-in, SDK, API, and automation point that needs testing.
+
 ## Next steps
 
 * [Add an external identity provider](/docs/guides/identity-providers/)

--- a/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/api/authn/index.md
@@ -8,6 +8,8 @@ excerpt: Control user access to Okta.
 
 The Okta Authentication API provides operations to authenticate users, perform multifactor enrollment and verification, recover forgotten passwords, and unlock accounts. It can be used as a standalone API to provide the identity layer on top of your existing application. Or it can be integrated with the Okta [Sessions API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Session/) to obtain an Okta [session cookie](/docs/guides/session-cookie/) and access apps within Okta.
 
+> **Note:** This is a Classic Engine API. Before you upgrade to Identity Engine, [identify your Okta authentication integrations and customizations](/docs/guides/oie-upgrade-identify-integrations/) to find every caller of this API in your org.
+
 The API is targeted for developers who want to build their own end-to-end sign-in experience. Developers can build their own sign-in experience to replace the built-in Okta login experience and addresses the following key scenarios:
 
 * **Primary authentication** allows you to verify the username and password credentials for a user.

--- a/packages/@okta/vuepress-theme-prose/const/navbar.const.js
+++ b/packages/@okta/vuepress-theme-prose/const/navbar.const.js
@@ -557,6 +557,10 @@ export const guides = [
         guideName: "oie-upgrade-overview/main",
         subLinks: [
           {
+            title: "Identify integrations and customizations",
+            guideName: "oie-upgrade-identify-integrations",
+          },
+          {
             title: "Plan embedded app upgrades",
             guideName: "oie-upgrade-plan-embedded-upgrades",
           },


### PR DESCRIPTION
## Description:
- **What's changed?**
  Adds a new OIE-upgrade guide, **Identify your Okta authentication integrations and customizations**, which helps customers discover and inventory every Okta integration point — redirect/hosted sign-in, embedded Sign-In Widget, custom sign-in pages, Auth.js/Okta SDKs, apps, SSWS API tokens, OAuth service apps, custom authorization servers, event/inline hooks, Okta Workflows, directory agents, and log streams — before upgrading from Classic Engine to Identity Engine. It also covers validating active usage via reports and the System Log, and mapping owners + upgrade actions.

  - **New guide:** `docs/guides/oie-upgrade-identify-integrations/` (guide + registration).
  - **Registration/navigation:** entry added to `docs/guides/index.md` and `vuepress-theme-prose/const/navbar.const.js`.
  - **Inbound cross-links** to the new guide added from `sign-in-overview`, the `oie-intro` concept, `ie-limitations`, and the `authn` API reference. No journey (`oie-upgrade-*`) docs were modified — those are owned separately.
  - **Editorial/QA:** grouped headings to shorten the "On this page" TOC; applied an Acrolinx terminology + spelling pass; reviewed all unordered lists against the InfoDev Style Guide.

  > Note: navbar placement may need revisiting as the broader journey doc structure firms up. I placed it as the first sub-link under **Okta Identity Engine upgrade** (before "Plan embedded app upgrades"), since discovery precedes planning.

- **Is this PR related to a Monolith release?**
  No. Targeting the July monthly developer docs release (code freeze June 26, 2026.07.0).

## Resolves

* [OKTA-1177823](https://oktainc.atlassian.net/browse/OKTA-1177823)

## Netlify Preview Link

[Preview link](https://tbs-okta-1177823-identify-integrations--dev-docs-preview.netlify.app/docs/guides/oie-upgrade-identify-integrations/main/)
