### PR TITLE
OKTA-1198191 - Fix header layout for desktop breakpoints

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/abstracts/_breakpoints.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/abstracts/_breakpoints.scss
@@ -2,6 +2,7 @@ $breakpoints: (
   "phone": 320px,
   "tablet": 767px,
   "desktop": 1024px,
+  "desktop-lg": 1280px,
   "desktop-xl": 1440px,
   "desktop-xx-large": 1920px,
   "bootstrap-xl": 1200px,

--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_header.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_header.scss
@@ -36,7 +36,7 @@ header.page-header .search--slideout {
   margin-left: 50px;
   max-width: 131px;
 
-  @include media(">desktop") {
+  @include media(">desktop-lg") {
     flex: 1 1 280px;
     max-width: 280px;
 
@@ -147,7 +147,7 @@ header.page-header .link {
   color: cv("body", "white");
   cursor: pointer;
 
-  @include media(">desktop") {
+  @include media(">desktop-lg") {
     color: cv("body", "white") !important;
   }
 }
@@ -244,7 +244,7 @@ header.page-header .link:focus {
   }
 }
 
-@include media("<desktop") {
+@include media("<desktop-lg") {
   header.page-header {
     padding: 0 16px;
   }

--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_headerNav.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_headerNav.scss
@@ -20,7 +20,7 @@
   white-space: nowrap;
   color: #fffefa;
 
-  @include media(">desktop") {
+  @include media(">desktop-lg") {
     &:hover {
       text-decoration: none;
       color: #b6caff !important;
@@ -33,7 +33,7 @@
 }
 
 .dark-theme .header-nav a {
-  @include media(">desktop") {
+  @include media(">desktop-lg") {
     &:hover {
       text-decoration: none;
       color: #b1e4de !important;


### PR DESCRIPTION
## Description:
- **What's changed?** Fix header layout for breakpoint `1024px` to `1280px`
- **Is this PR related to a Monolith release?** n/a

### Resolves:
* [OKTA-1198191](https://oktainc.atlassian.net/browse/OKTA-1198191)

### Netlify Preview Link:
https://ad-okta-1198191-fix-header-layout-for-desktop--dev-docs-preview.netlify.app/
