### PR TITLE
Kotlin Client SDK: Update sign-into-mobile-app-redirect guide to the 2.x SDK

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/keep-user-signed-in/main/android/related.md
+++ b/packages/@okta/vuepress-site/docs/guides/keep-user-signed-in/main/android/related.md
@@ -1,1 +1,1 @@
-[Check for a session at startup](/docs/guides/sign-into-mobile-app-redirect/android/main/#check-for-a-session-at-startup)
+[Check for a session at startup](/docs/guides/check-for-session/android/main/)

--- a/packages/@okta/vuepress-site/docs/guides/keep-user-signed-in/main/ios/related.md
+++ b/packages/@okta/vuepress-site/docs/guides/keep-user-signed-in/main/ios/related.md
@@ -1,1 +1,1 @@
-[Check for a session at startup](/docs/guides/sign-into-mobile-app-redirect/ios/main/#check-for-a-session-at-startup)
+[Check for a session at startup](/docs/guides/check-for-session/ios/main/)

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/index.md
@@ -1,5 +1,5 @@
 ---
-title: Configure the Client SDK in your app to user an Okta-hosted sign-in form
+title: Configure the Client SDK in your app to use an Okta-hosted sign-in form
 excerpt: Configure the Client SDK in your app to use an Okta-hosted sign-in form.
 layout: Guides
 sections:

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/android/addconfigpkg.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/android/addconfigpkg.md
@@ -1,4 +1,4 @@
-Add the latest [Okta Mobile Kotlin library](https://github.com/okta/okta-mobile-kotlin) to the `dependencies` block of the `app/build.gradle` file:
+Add the latest [Okta Client SDK for Kotlin](https://github.com/okta/okta-mobile-kotlin) libraries to the `dependencies` block of the `app/build.gradle` file:
 
 ```gradle
 // Ensure that all dependencies are compatible using the Bill of Materials (BOM).

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/android/addconfigpkg.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/android/addconfigpkg.md
@@ -2,9 +2,10 @@ Add the latest [Okta Mobile Kotlin library](https://github.com/okta/okta-mobile-
 
 ```gradle
 // Ensure that all dependencies are compatible using the Bill of Materials (BOM).
-implementation(platform('com.okta.kotlin:bom:1.0.0'))
+implementation(platform('com.okta.kotlin:bom:2.0.3'))
 
-// Add the web-authentication-ui SDK to the project.
-implementation('com.okta.kotlin:auth-foundation-bootstrap')
+// Add the SDK libraries used in this guide to the project.
+implementation('com.okta.kotlin:auth-foundation')
+implementation('com.okta.kotlin:oauth2')
 implementation('com.okta.kotlin:web-authentication-ui')
 ```

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/android/configmid.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/android/configmid.md
@@ -10,14 +10,14 @@ The app uses information from the Okta integration that you created earlier to c
 1. Add the configuration values that your app uses to interact with the Okta org. Replace the placeholders in the following code with the values from the Okta app that you created in [Create an Okta integration for your app](#create-an-okta-integration-for-your-app).
 
    Properties:
-      `discoveryUrl`=<DISCOVERY_URL>
+      `issuer`=<ISSUER>
       `clientId`=<CLIENT_ID>
       `signInRedirectUri`=<SIGN_IN_URI>
       `signOutRedirectUri`=<SIGN_OUT_REDIRECT_URI>
 
    | Placeholder               | Value                                                                                                                                                        |
    |---------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
-   | `<DISCOVERY_URL>`         | The domain of your registered Okta org followed by `/oauth2/default/.well-known/openid-configuration`, such as `https://integrator-1234567.okta.com/oauth2/default/.well-known/openid-configuration` |
+   | `<ISSUER>`                | The domain of your registered Okta org followed by `/oauth2/default`, such as `https://integrator-1234567.okta.com/oauth2/default`                            |
    | `<CLIENT_ID>`             | The client ID from the app integration that you created, such as `0ux3rutxocxFX9xyz3t9`                                                                      |
    | `<SIGN_IN_URI>`           | The sign-in redirect URI from the app integration that you created, such as `com.okta.integrator-1234567:/callback`                                                 |
    | `<SIGN_OUT_REDIRECT_URI>` | The sign-out redirect URI from the app integration that you created, such as `com.okta.integrator-1234567:/logout`                                                        |
@@ -29,7 +29,7 @@ The app uses information from the Okta integration that you created earlier to c
     def oktaProperties = new Properties()
     rootProject.file("okta.properties").withInputStream { oktaProperties.load(it) }
     android.defaultConfig {
-        buildConfigField "String", 'DISCOVERY_URL', "\"${oktaProperties.getProperty('discoveryUrl')}\""
+        buildConfigField "String", 'ISSUER', "\"${oktaProperties.getProperty('issuer')}\""
         buildConfigField "String", 'CLIENT_ID', "\"${oktaProperties.getProperty('clientId')}\""
         buildConfigField "String", 'SIGN_IN_REDIRECT_URI', "\"${oktaProperties.getProperty('signInRedirectUri')}\""
         buildConfigField "String", 'SIGN_OUT_REDIRECT_URI', "\"${oktaProperties.getProperty('signOutRedirectUri')}\""

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/android/getuserinfo.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/android/getuserinfo.md
@@ -3,7 +3,7 @@ To find information about the user, use the `idToken` method. The `Jwt` object c
 Print the users preferred username by creating the function `showPreferredUsername`:
 ```kotlin
 suspend fun showPreferredUsername() {
-    val idToken: Jwt = CredentialBootstrap.defaultCredential().idToken() ?: return
+    val idToken: Jwt = Credential.getDefaultAsync()?.idToken() ?: return
     println(idToken.preferredUsername)
 }
 ```

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/android/opensignin.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/android/opensignin.md
@@ -134,7 +134,7 @@
                 val result = WebAuthentication().logoutOfBrowser(
                     context = context,
                     redirectUrl = BuildConfig.SIGN_OUT_REDIRECT_URI,
-                    idToken = credential?.token?.idToken ?: "",
+                    idToken = credential.token.idToken ?: return@launch
                 )
                 when (result) {
                     is OAuth2ClientResult.Error -> {

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/android/opensignin.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/android/opensignin.md
@@ -6,17 +6,13 @@
     class BrowserSignInApplication : Application() {
         override fun onCreate() {
             super.onCreate()
-            // Initializes Auth Foundation and Credential Bootstrap classes.
-            AuthFoundationDefaults.cache = SharedPreferencesCache.create(this)
-            val oidcConfiguration = OidcConfiguration(
+            // Initialize AuthFoundation and set the default OidcConfiguration for the app.
+            AuthFoundation.initializeAndroidContext(this)
+            OidcConfiguration.default = OidcConfiguration(
                 clientId = BuildConfig.CLIENT_ID,
                 defaultScope = "openid email profile offline_access",
+                issuer = BuildConfig.ISSUER,
             )
-            val client = OidcClient.createFromDiscoveryUrl(
-                oidcConfiguration,
-                BuildConfig.DISCOVERY_URL.toHttpUrl(),
-            )
-            CredentialBootstrap.initialize(client.createCredentialDataSource(this))
         }
     }
     ```
@@ -112,18 +108,18 @@
             viewModelScope.launch {
                 _state.value = BrowserState.Loading
 
-                val result = CredentialBootstrap.oidcClient.createWebAuthenticationClient().login(
+                val result = WebAuthentication().login(
                     context = context,
                     redirectUrl = BuildConfig.SIGN_IN_REDIRECT_URI,
                 )
                 when (result) {
-                    is OidcClientResult.Error -> {
+                    is OAuth2ClientResult.Error -> {
                         Timber.e(result.exception, "Failed to login.")
                         _state.value = BrowserState.currentCredentialState("Failed to login.")
                     }
-                    is OidcClientResult.Success -> {
-                        val credential = CredentialBootstrap.defaultCredential()
-                        credential.storeToken(token = result.result)
+                    is OAuth2ClientResult.Success -> {
+                        val credential = Credential.store(token = result.result)
+                        Credential.setDefaultAsync(credential)
                         _state.value = BrowserState.LoggedIn.create()
                     }
                 }
@@ -134,18 +130,19 @@
             viewModelScope.launch {
                 _state.value = BrowserState.Loading
 
-                val result = CredentialBootstrap.oidcClient.createWebAuthenticationClient().logoutOfBrowser(
+                val credential = Credential.getDefaultAsync()
+                val result = WebAuthentication().logoutOfBrowser(
                     context = context,
                     redirectUrl = BuildConfig.SIGN_OUT_REDIRECT_URI,
-                    CredentialBootstrap.defaultCredential().token?.idToken ?: "",
+                    idToken = credential?.token?.idToken ?: "",
                 )
                 when (result) {
-                    is OidcClientResult.Error -> {
+                    is OAuth2ClientResult.Error -> {
                         Timber.e(result.exception, "Failed to logout.")
                         _state.value = BrowserState.currentCredentialState("Failed to logout.")
                     }
-                    is OidcClientResult.Success -> {
-                        CredentialBootstrap.defaultCredential().delete()
+                    is OAuth2ClientResult.Success -> {
+                        credential?.delete()
                         _state.value = BrowserState.LoggedOut()
                     }
                 }
@@ -165,11 +162,11 @@
         ) : BrowserState() {
             companion object {
                 /**
-                 * Creates the [LoggedIn] state using the [CredentialBootstrap.defaultCredential]s ID Token name claim.
+                 * Creates the [LoggedIn] state using the default [Credential]'s ID token name claim.
                  */
                 suspend fun create(errorMessage: String? = null): BrowserState {
-                    val credential = CredentialBootstrap.defaultCredential()
-                    val name = credential.idToken()?.name ?: ""
+                    val credential = Credential.getDefaultAsync()
+                    val name = credential?.idToken()?.name ?: ""
                     return LoggedIn(name, errorMessage)
                 }
             }
@@ -177,13 +174,12 @@
 
         companion object {
             /**
-             * Creates the [BrowserState] given the [CredentialBootstrap.defaultCredential]s presence of a token.
+             * Creates the [BrowserState] based on whether a default [Credential] exists.
              *
              * @return Either [LoggedIn] or [LoggedOut].
              */
             suspend fun currentCredentialState(errorMessage: String? = null): BrowserState {
-                val credential = CredentialBootstrap.defaultCredential()
-                return if (credential.token == null) {
+                return if (Credential.getDefaultAsync() == null) {
                     LoggedOut(errorMessage)
                 } else {
                     LoggedIn.create(errorMessage)

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/android/samplecode.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/android/samplecode.md
@@ -1,1 +1,1 @@
-[Android sample app](https://github.com/okta/okta-mobile-kotlin/tree/master/app) that includes browser sign-in, device authorization, and token exchange
+[Android sample app](https://github.com/okta/okta-mobile-kotlin/tree/master/app) that includes browser sign-in, device authorization, and token exchange examples.

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/android/samplecode.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/android/samplecode.md
@@ -1,1 +1,1 @@
-[Quickstart sample app](https://github.com/okta-samples/okta-android-kotlin-sample)
+[Android sample app](https://github.com/okta/okta-mobile-kotlin/tree/master/app) that includes browser sign-in, device authorization, and token exchange

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/android/sdkname.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/android/sdkname.md
@@ -1,0 +1,1 @@
+Okta Client SDK for Kotlin

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/android/usetoken.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/android/usetoken.md
@@ -2,7 +2,7 @@ To make authenticated requests to your resource server, add the access token int
 
 ```kotlin
 private suspend fun callResourceServer() {
-    val accessTokenInterceptor = CredentialBootstrap.defaultCredential().accessTokenInterceptor()
+    val accessTokenInterceptor = Credential.getDefaultAsync()?.accessTokenInterceptor() ?: return
     val okHttpClient = OkHttpClient.Builder().addInterceptor(accessTokenInterceptor).build()
     val request = Request.Builder().url("https://${resourceUrl}").build()
     okHttpClient.newCall(request).enqueue(object : Callback {

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/index.md
@@ -65,7 +65,7 @@ In this section you create a sample mobile app and add redirect authentication u
 
 ### Add packages
 
-Add the required dependencies for using the Okta SDK with your app.
+Add the required dependencies for using the <StackSnippet snippet="sdkname" inline /> with your app.
 
 <StackSnippet snippet="addconfigpkg" />
 
@@ -79,13 +79,13 @@ To sign users in, your app opens a browser and displays an Okta-hosted sign-in p
 
 In mobile apps, use a custom scheme similar to `your-app:/callback` so that your app can switch back into the foreground after the user is done signing in through the browser. This should be the same value that you used for the sign-in and sign-out redirect URIs.
 
-Your mobile app is responsible for parsing the information Okta sends to the callback route. The Okta SDKs can help you with this task (covered later in the [Open the sign-in page](#open-the-sign-in-page) section). For now, define the route itself.
+Your mobile app is responsible for parsing the information Okta sends to the callback route. The <StackSnippet snippet="sdkname" inline /> can help you with this task (covered later in the [Open the sign-in page](#open-the-sign-in-page) section). For now, define the route itself.
 
 <StackSnippet snippet="definecallback" />
 
 ## Open the sign-in page
 
-The SDK signs in the user by opening an Okta-hosted web page. The app can send the SDK sign-in request when the following occurs:
+The <StackSnippet snippet="sdkname" inline /> signs in the user by opening an Okta-hosted web page. The app can send the SDK sign-in request when the following occurs:
 
 * A user visits a protected route.
 * A user taps a button.

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/index.md
@@ -1,5 +1,5 @@
 ---
-title: Configure the Client SDK in your app to user an Okta-hosted sign-in form
+title: Configure the Client SDK in your app to use an Okta-hosted sign-in form
 excerpt: Configure the Client SDK in your app to use an Okta-hosted sign-in form.
 layout: Guides
 ---

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/ios/addconfigpkg.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/ios/addconfigpkg.md
@@ -1,4 +1,4 @@
-Add the latest Okta OIDC package to your project:
+Add the latest Okta Client SDK for Swift package to your project:
 
 1. Choose **File** > **Add Package Dependencies**. The Swift Package Manager opens.
 1. Enter the URL for the package in the search field:

--- a/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/ios/sdkname.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-into-mobile-app-redirect/main/ios/sdkname.md
@@ -1,0 +1,1 @@
+Okta Client SDK for Swift

--- a/packages/@okta/vuepress-site/docs/journeys/OCI-mobile/main/index.md
+++ b/packages/@okta/vuepress-site/docs/journeys/OCI-mobile/main/index.md
@@ -56,7 +56,7 @@ The Okta-recommended way to sign users in to your portal is to redirect them to 
 
 * [Learn about the Okta Sign-In Widget](/docs/concepts/sign-in-widget/)
 * [Configure the Swift SDK for an Okta-hosted sign-in form](/docs/guides/mobile-swift-configure-redirect/main/)
-* Sign users into your mobile app by redirecting them to an Okta sign-in page using the Okta Client SDK for [Swift](/docs/guides/sign-into-mobile-app-redirect/ios/main/) or [Kotlin](/docs/guides/sign-into-mobile-app-redirect/android/main/)
+* Sign users into your mobile app by redirecting them to an Okta sign-in page using the Okta Client SDK for [Swift](/docs/guides/sign-into-mobile-app-redirect/ios/main/) or [Kotlin](/docs/guides/sign-into-mobile-app-redirect/android/main/).
 
 Learn how to [customize the Sign-In Widget to match your app's theme or your company's brand](/docs/journeys/OCI-branding/main/).
 

--- a/packages/@okta/vuepress-site/docs/journeys/OCI-mobile/main/index.md
+++ b/packages/@okta/vuepress-site/docs/journeys/OCI-mobile/main/index.md
@@ -56,7 +56,7 @@ The Okta-recommended way to sign users in to your portal is to redirect them to 
 
 * [Learn about the Okta Sign-In Widget](/docs/concepts/sign-in-widget/)
 * [Configure the Swift SDK for an Okta-hosted sign-in form](/docs/guides/mobile-swift-configure-redirect/main/)
-* [Sign users into your mobile app by redirecting them to an Okta sign-in page](/docs/guides/sign-into-mobile-app-redirect/ios/main/)
+* Sign users into your mobile app by redirecting them to an Okta sign-in page using the Okta Client SDK for [Swift](/docs/guides/sign-into-mobile-app-redirect/ios/main/) or [Kotlin](/docs/guides/sign-into-mobile-app-redirect/android/main/)
 
 Learn how to [customize the Sign-In Widget to match your app's theme or your company's brand](/docs/journeys/OCI-branding/main/).
 

--- a/packages/@okta/vuepress-site/docs/journeys/OCI-mobile/main/index.md
+++ b/packages/@okta/vuepress-site/docs/journeys/OCI-mobile/main/index.md
@@ -54,8 +54,8 @@ The Okta platform offers various deployment models to integrate a sign-in form i
 
 The Okta-recommended way to sign users in to your portal is to redirect them to an Okta-hosted sign-in page. This page displays the Okta Sign-In Widget, which you can customize to reflect your brand.
 
-* [Learn about the Okta Sign-In Widget](/docs/concepts/sign-in-widget/)
-* [Configure the Swift SDK for an Okta-hosted sign-in form](/docs/guides/mobile-swift-configure-redirect/main/)
+* [Learn about the Okta Sign-In Widget](/docs/concepts/sign-in-widget/).
+* [Configure the Swift SDK for an Okta-hosted sign-in form](/docs/guides/mobile-swift-configure-redirect/main/).
 * Sign users into your mobile app by redirecting them to an Okta sign-in page using the Okta Client SDK for [Swift](/docs/guides/sign-into-mobile-app-redirect/ios/main/) or [Kotlin](/docs/guides/sign-into-mobile-app-redirect/android/main/).
 
 Learn how to [customize the Sign-In Widget to match your app's theme or your company's brand](/docs/journeys/OCI-branding/main/).

--- a/packages/@okta/vuepress-site/docs/journeys/OCI-secure-your-first-web-app/main/index.md
+++ b/packages/@okta/vuepress-site/docs/journeys/OCI-secure-your-first-web-app/main/index.md
@@ -77,7 +77,7 @@ Congratulations, your app now uses Okta to provide its sign-in services.
 
 Learn how to secure other types of apps:
 
-* [Sign users in to a mobile app by redirecting them to an Okta-hosted sign-in form](/docs/guides/sign-into-mobile-app-redirect/ios/main/).
+* [Sign users in to a mobile app by redirecting them to an Okta-hosted sign-in form](/docs/guides/sign-into-mobile-app-redirect/).
 * [Sign users in to a mobile app using a self-hosted sign-in form](/docs/guides/sign-into-mobile-app-embedded/main/).
 
 After a user signs in, Okta returns tokens to identify the user and the user's access levels. See [Understand the token lifecycle](/docs/concepts/token-lifecycles/index.md).


### PR DESCRIPTION
## Description:
- **What's changed?**

 ### 1. Update the Android (Kotlin) guide to the 2.x SDK

  Updates the Android (Kotlin) version of the "Sign into mobile app redirect" guide to the current `okta-mobile-kotlin` **2.x** SDK (BOM `2.0.3`). This is the Kotlin counterpart to the Swift refresh in #5953. The guide previously targeted the **1.x** SDK (`CredentialBootstrap`, `OidcClient`, `OidcClientResult`), which was removed or renamed in 2.x and no longer compiles against today's SDK.

  - **addconfigpkg:** BOM `1.0.0` → `2.0.3`; `auth-foundation-bootstrap` → `auth-foundation` + `oauth2` (kept `web-authentication-ui`).
  - **configmid:** `discoveryUrl`/`DISCOVERY_URL` → `issuer`/`ISSUER` in the properties list, placeholder table, and `buildConfigField` block; dropped the `/.well-known/openid-configuration` suffix (2.x derives this automatically).
  - **opensignin:** SDK init now uses `AuthFoundation.initializeAndroidContext(this)` + `OidcConfiguration.default`; sign-in/sign-out use `WebAuthentication()`, `OAuth2ClientResult`, and `Credential.store`/`setDefaultAsync`/`getDefaultAsync`/`delete`. Sign-in state is now a null-check on the default credential (a `Credential` can no longer hold a null token in 2.x).
  - **getuserinfo, usetoken:** `CredentialBootstrap.defaultCredential()` → `Credential.getDefaultAsync()`.
  - **samplecode:** repointed to the SDK repo's own sample (`okta-mobile-kotlin/tree/master/app`), mirroring the Swift PR.
  - **index (shared):** fixed the `to user an` → `to use an` title typo introduced in #5953 (also corrects the iOS page, since the title is shared).

  Every code snippet was verified against the `okta-mobile-kotlin@master` sample app (`SampleApplication.kt`, `BrowserViewModel.kt`, `DashboardViewModel.kt`) and the `Credential` source.

  ### 2. Cross-link cleanup (related to the above)

  - **Journeys:** the mobile-redirect bullets in the **OCI-mobile** and **OCI-secure-your-first-web-app** journeys linked only to the iOS guide. Repointed them to the framework-neutral guide path so the updated Kotlin/Android version is surfaced too.
  - **Stale anchor fix:** `keep-user-signed-in` related links (android + ios) pointed to a `#check-for-a-session-at-startup` anchor that no longer exists in the redirect guide. Repointed to the standalone `check-for-session` guide, matching how the redirect guide now references it.
  
  ### 3. Inline naming StackSnippet

What's changed?

  - Names the platform SDK per framework in the Sign into a mobile app using the redirect model guide, so readers see their own platform's SDK named in the prose rather than a generic "Okta SDK."
  - Adds an inline sdkname StackSnippet that resolves to Okta Client SDK for Swift (iOS) / Okta Client SDK for Kotlin (Android).
  - Wires that snippet into the three generic SDK references in the shared main/index.md (Add packages, Define a callback route, Open the sign-in page).
  - Names the SDK explicitly in the per-framework dependency snippets (addconfigpkg.md): "Okta Mobile Kotlin library" → "Okta Client SDK for Kotlin"; "Okta OIDC package" → "Okta Client SDK for Swift package". This matches the dominant "Okta Client SDK for <lang>" phrasing already used across the docs, and mirrors the same change made to the sign-users-in-mobile-self-hosted guide.

- **Is this PR related to a Monolith release?** No.

### Resolves:

* [OKTA-1089674](https://oktainc.atlassian.net/browse/OKTA-1089674)

### Netlify Preview Link:

[Preview link](https://tbs-okta-1089674-update-configure-kotlin-redi--dev-docs-preview.netlify.app/docs/guides/sign-into-mobile-app-redirect/android/main/)

