### PR TITLE
GA device assurance posture checks and custom remediation guide

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/device-assurance-posture-checks-and-remediation/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/device-assurance-posture-checks-and-remediation/main/index.md
@@ -11,7 +11,7 @@ This guide describes how to use the [Device Posture Checks API](https://develope
 > **Notes:**
 >
 > * This document is only for Okta Identity Engine. See [Identify your Okta solution](https://help.okta.com/okta_help.htm?type=oie&id=ext-oie-version) to determine your Okta version.
-> * Advanced posture checks require the Okta Device Access (ODA) SKU. Contact your Okta account team to add this SKU to your subscription.
+> * Advanced posture checks require an Okta org that's subscribed to Okta Device Access (ODA). See your Okta account team to enable the feature.
 
 ---
 

--- a/packages/@okta/vuepress-site/docs/guides/device-assurance-posture-checks-and-remediation/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/device-assurance-posture-checks-and-remediation/main/index.md
@@ -11,7 +11,7 @@ This guide describes how to use the [Device Posture Checks API](https://develope
 > **Notes:**
 >
 > * This document is only for Okta Identity Engine. See [Identify your Okta solution](https://help.okta.com/okta_help.htm?type=oie&id=ext-oie-version) to determine your Okta version.
-> * Advanced posture checks require the Okta Device Access (ODA) SKU. Contact your Okta account team to enable this feature.
+> * Advanced posture checks require the Okta Device Access (ODA) SKU. Contact your Okta account team to add this SKU to your subscription.
 
 ---
 

--- a/packages/@okta/vuepress-site/docs/guides/device-assurance-posture-checks-and-remediation/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/device-assurance-posture-checks-and-remediation/main/index.md
@@ -8,9 +8,10 @@ layout: Guides
 
 This guide describes how to use the [Device Posture Checks API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/DevicePostureCheck/) to enforce custom device checks. It also shows how to add custom remediation instructions, and then enforce the checks with the [Device Assurance Policies API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/DeviceAssurance/).
 
-> **Note:** This document is only for Okta Identity Engine. See [Identify your Okta solution](https://help.okta.com/okta_help.htm?type=oie&id=ext-oie-version) to determine your Okta version.
-
-> **Note:** Advanced posture checks require the Okta Device Access (ODA) SKU. Contact your Okta account team to enable this feature.
+> **Notes:**
+>
+> * This document is only for Okta Identity Engine. See [Identify your Okta solution](https://help.okta.com/okta_help.htm?type=oie&id=ext-oie-version) to determine your Okta version.
+> * Advanced posture checks require the Okta Device Access (ODA) SKU. Contact your Okta account team to enable this feature.
 
 ---
 

--- a/packages/@okta/vuepress-site/docs/guides/device-assurance-posture-checks-and-remediation/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/device-assurance-posture-checks-and-remediation/main/index.md
@@ -4,7 +4,7 @@ excerpt: How to use the Device Posture Checks API to enforce custom osquery chec
 layout: Guides
 ---
 
-<ApiLifecycle access="ie" /></br><ApiLifecycle access="ea" />
+<ApiLifecycle access="ie" />
 
 This guide describes how to use the [Device Posture Checks API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/DevicePostureCheck/) to enforce custom device checks. It also shows how to add custom remediation instructions, and then enforce the checks with the [Device Assurance Policies API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/DeviceAssurance/).
 

--- a/packages/@okta/vuepress-site/docs/guides/device-assurance-posture-checks-and-remediation/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/device-assurance-posture-checks-and-remediation/main/index.md
@@ -10,6 +10,8 @@ This guide describes how to use the [Device Posture Checks API](https://develope
 
 > **Note:** This document is only for Okta Identity Engine. See [Identify your Okta solution](https://help.okta.com/okta_help.htm?type=oie&id=ext-oie-version) to determine your Okta version.
 
+> **Note:** Advanced posture checks require the Okta Device Access (ODA) SKU. Contact your Okta account team to enable this feature.
+
 ---
 
 #### What you need


### PR DESCRIPTION
## Description
Promotes the device assurance posture checks and custom remediation guide from Early Access (EA) to Generally Available (GA) for the 2026.07.0 release.

### Changes:
- Removes the <ApiLifecycle access="ea" /> tag, leaving only the <ApiLifecycle access="ie" /> tag
- Converts the single blockquote note into a multi-item notes block
- Adds a new note that advanced posture checks require the Okta Device Access (ODA) SKU

Is this PR related to a Monolith release? Yes — 2026.07.0

## Resolves
[OKTA-1202064](https://oktainc.atlassian.net/browse/OKTA-1202064)

## Netlify Preview Link

[Netlify link](https://tbs-okta-1202064-remove-ea-tag-posture-checks--dev-docs-preview.netlify.app/docs/guides/device-assurance-posture-checks-and-remediation/main/)
