### PR TITLE
OKTA-1207170 - Update release notes link styles and remove button styles

### DIFF
--- a/packages/@okta/vuepress-theme-prose/assets/css/components/_releaseNotes.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/components/_releaseNotes.scss
@@ -3,10 +3,6 @@
   --release-notes-card-background-color: var(--c-gray-050);
   --release-notes-title-color: var(--c-gray-950);
   --release-notes-description-color: var(--c-gray-750);
-  --release-notes-button-background-color: var(--c-black);
-  --release-notes-button-hover-background-color: var(--c-blue-550);
-  --release-notes-button-text-color: var(--c-white);
-  --release-notes-button-hover-text-color: var(--c-white);
   --release-notes-newest-releases-label-color: var(--c-gray-750);
   --release-notes-newest-releases-link-color: var(--c-gray-950);
 }
@@ -81,38 +77,6 @@
   color: var(--release-notes-description-color);
 }
 
-.release-notes__button {
-  display: inline-flex;
-  justify-content: flex-start;
-  align-items: center;
-
-  padding: 12px 96px 12px 32px;
-
-  border-radius: 4px;
-
-  background-color: var(--release-notes-button-background-color);
-
-  font-weight: 400;
-  font-size: 16px;
-  line-height: 24px;
-  letter-spacing: -0.16px;
-  text-decoration: none;
-
-  color: var(--release-notes-button-text-color);
-
-  &:hover {
-    background-color: var(--release-notes-button-hover-background-color);
-
-    text-decoration: none;
-
-    color: var(--release-notes-button-hover-text-color);
-  }
-
-  &:visited {
-    color: var(--release-notes-button-text-color);
-  }
-}
-
 .release-notes__newest-releases {
   display: flex;
   flex-direction: column;
@@ -146,7 +110,7 @@
   list-style: none;
 }
 
-.release-notes__newest-releases-link {
+.release-notes__link {
   font-weight: 400;
   font-size: 16px;
   line-height: 24px;

--- a/packages/@okta/vuepress-theme-prose/assets/css/themes/dark/_releaseNotes.scss
+++ b/packages/@okta/vuepress-theme-prose/assets/css/themes/dark/_releaseNotes.scss
@@ -3,16 +3,6 @@
   --release-notes-card-background-color: #1e1e1e;
   --release-notes-title-color: var(--c-gray-350);
   --release-notes-description-color: var(--c-gray-350);
-  --release-notes-button-background-color: var(--c-white);
-  --release-notes-button-hover-background-color: var(--c-green-300);
-  --release-notes-button-text-color: var(--c-gray-950);
-  --release-notes-button-hover-text-color: var(--c-gray-950);
   --release-notes-newest-releases-label-color: var(--c-gray-350);
   --release-notes-newest-releases-link-color: var(--c-gray-350);
-}
-
-.release-notes__button {
-  &:hover {
-    color: var(--release-notes-button-hover-text-color) !important;
-  }
 }

--- a/packages/@okta/vuepress-theme-prose/components/ReleaseNotes.vue
+++ b/packages/@okta/vuepress-theme-prose/components/ReleaseNotes.vue
@@ -12,10 +12,10 @@
             features, plus weekly bug fixes.
           </p>
           <a
-            class="release-notes__button dont-break-out"
+            class="release-notes__link dont-break-out"
             href="/docs/release-notes/"
           >
-            Go to release notes →
+            Go to release notes
           </a>
         </div>
         <div class="release-notes__newest-releases">
@@ -29,7 +29,7 @@
               class="release-notes__newest-releases-item"
             >
               <a
-                class="release-notes__newest-releases-link dont-break-out"
+                class="release-notes__link dont-break-out"
                 :href="release.link"
               >
                 {{ release.title }}


### PR DESCRIPTION
## Description:
- **What's changed?** Update release notes button to follow link styles
- **Is this PR related to a Monolith release?** n/a

### Resolves:
* [OKTA-1207170](https://oktainc.atlassian.net/browse/OKTA-1207170)

### Netlify Preview Link:
https://ad-okta-1207170-update-release-notes-link-sty--dev-docs-preview.netlify.app/
