### PR TITLE
Device assurance guide: Add OV configurations note

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/device-assurance-policies/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/device-assurance-policies/main/index.md
@@ -53,6 +53,8 @@ You can configure OS version compliance by using device assurance. However, you 
 
 To use Dynamic OS version compliance, you need to define the `dynamicVersionRequirement` object. See [Example POST request](#example-post-request).
 
+> **Note:** To see the OS versions that Okta currently recognizes as latest and supported, send a GET request to `https://{yourOktaDomain}.okta.com/.well-known/ov-configurations`.
+
 ### Example POST request
 
 Send a POST request to the `/api/v1/device-assurances` endpoint. Include the following:


### PR DESCRIPTION
## Description

What's changed? Adds a note to the "About Dynamic OS version compliance" section of the Device Assurance Policies guide informing developers that they can query `https://{yourOktaDomain}.okta.com/.well-known/ov-configurations` to see the OS versions Okta currently recognizes as latest and supported.

Is this PR related to a Monolith release? No

### Resolves

[OKTA-1210022](https://oktainc.atlassian.net/browse/OKTA-1210022)

### Netlify Preview Link

<!-- Add preview link here -->