### PR TITLE
SIW Gen2 and Gen3: Add BYOL sections

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -315,7 +315,7 @@ new OktaSignIn({
 By default, the Sign-In Widget ships with English text only and loads other language files from the Okta CDN. To serve language files from your own host, use `assets.baseUrl` and `assets.languages`.
 
 * `assets.baseUrl`: The base path is where your language files are served. The Sign-In Widget loads `labels/json/login_{lang}.json` and `country_{lang}.json` relative to this URL.
-* `assets.languages`: The list of language codes you're hosting. This replaces the default supported-languages list. If a requested language isn't in the list, the Sign-In Widget falls back to `en`.
+* `assets.languages`: The list of language codes that you're hosting. This replaces the default supported-languages list. If a requested language isn't in the list, the Sign-In Widget falls back to `en`.
 
 ```javascript
 new OktaSignIn({

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -270,6 +270,67 @@ The following is a list of available design tokens with default values. See [Cus
 }
 ```
 
+## Language customization
+
+By default, the widget loads English text and fetches other languages on demand from the Okta CDN. Use the following options in the code editor to control language behavior.
+
+### Set the language
+
+Use the `language` option to set a specific language for the widget. Pass a language code as a string, or a callback function that receives the supported and user-preferred languages and returns a language code.
+
+```javascript
+new OktaSignIn({
+  // Simple string form
+  language: 'ja',
+
+  // Or use a callback to choose dynamically
+  language: (supportedLanguages, userLanguages) => {
+    // supportedLanguages: array of codes the widget supports, e.g. ['en', 'ja', 'fr', ...]
+    // userLanguages: array of codes from the user's browser preferences
+    return supportedLanguages.find(lang => userLanguages.includes(lang)) || 'en';
+  }
+});
+```
+
+### Override individual strings
+
+Use the `i18n` option to replace specific strings in any language. Keys come from [login.properties](https://github.com/okta/okta-signin-widget/blob/master/packages/@okta/i18n/src/properties/login.properties) and [country.properties](https://github.com/okta/okta-signin-widget/blob/master/packages/@okta/i18n/src/properties/country.properties) (prefix country keys with `country.`).
+
+```javascript
+new OktaSignIn({
+  i18n: {
+    en: {
+      'primaryauth.title': 'Sign in to Acme',
+      'primaryauth.username.placeholder': 'Your Acme ID',
+    },
+    ja: {
+      'primaryauth.title': 'Acme にサインイン',
+    }
+  }
+});
+```
+
+### Host your own language files
+
+By default, the widget ships with English text only and loads other language files from the Okta CDN. To serve language files from your own host, use `assets.baseUrl` and `assets.languages`.
+
+* `assets.baseUrl`: The base path where your language files are served. The widget loads `labels/json/login_{lang}.json` and `country_{lang}.json` relative to this URL.
+* `assets.languages`: The list of language codes you're hosting. This replaces the default supported-languages list. If a requested language isn't in the list, the widget falls back to `en`.
+
+```javascript
+new OktaSignIn({
+  assets: {
+    baseUrl: 'https://acme.com/assets/dist',
+    languages: ['en', 'ja', 'fr'],
+  }
+});
+```
+
+> **Notes:**
+>
+> * The language JSON source files are in the `dist/labels/json` folder of the [`@okta/okta-signin-widget` npm package](https://www.npmjs.com/package/@okta/okta-signin-widget).
+> * Hosting your own language files is also supported in the embedded Gen2 Sign-In Widget. See [Style the sign-in page](/docs/guides/custom-widget/main/).
+
 ## Customization examples
 
 The following examples illustrate the impact of basic changes:

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget-gen3/main/index.md
@@ -272,11 +272,11 @@ The following is a list of available design tokens with default values. See [Cus
 
 ## Language customization
 
-By default, the widget loads English text and fetches other languages on demand from the Okta CDN. Use the following options in the code editor to control language behavior.
+By default, the Sign-In Widget loads English text and fetches other languages on demand from the Okta CDN. Use the following options in the code editor to control language behavior.
 
 ### Set the language
 
-Use the `language` option to set a specific language for the widget. Pass a language code as a string, or a callback function that receives the supported and user-preferred languages and returns a language code.
+Use the `language` option to set a specific language for the Sign-In Widget. Pass a language code as a string, or a callback function that receives the supported and user-preferred languages and returns a language code.
 
 ```javascript
 new OktaSignIn({
@@ -312,10 +312,10 @@ new OktaSignIn({
 
 ### Host your own language files
 
-By default, the widget ships with English text only and loads other language files from the Okta CDN. To serve language files from your own host, use `assets.baseUrl` and `assets.languages`.
+By default, the Sign-In Widget ships with English text only and loads other language files from the Okta CDN. To serve language files from your own host, use `assets.baseUrl` and `assets.languages`.
 
-* `assets.baseUrl`: The base path where your language files are served. The widget loads `labels/json/login_{lang}.json` and `country_{lang}.json` relative to this URL.
-* `assets.languages`: The list of language codes you're hosting. This replaces the default supported-languages list. If a requested language isn't in the list, the widget falls back to `en`.
+* `assets.baseUrl`: The base path is where your language files are served. The Sign-In Widget loads `labels/json/login_{lang}.json` and `country_{lang}.json` relative to this URL.
+* `assets.languages`: The list of language codes you're hosting. This replaces the default supported-languages list. If a requested language isn't in the list, the Sign-In Widget falls back to `en`.
 
 ```javascript
 new OktaSignIn({

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget/main/index.md
@@ -606,6 +606,30 @@ var config = {
 };
 ```
 
+### Host your own language files
+
+The `i18n` option lets you override specific strings in languages Sign-In Widget already supports. If you need to support a language not in the default list, or want to serve language files from your own server instead of the Okta CDN, use `assets.baseUrl` and `assets.languages`.
+
+* `assets.baseUrl`: The base URL where your language files are served. The Sign-In Widget loads `labels/json/login_{lang}.json` and `country_{lang}.json` relative to this path.
+* `assets.languages`: The list of language codes you're hosting. This replaces Sign-In Widget's default supported-languages list. If a requested language isn't in the list, Sign-In Widget falls back to `en`.
+
+```javascript
+var config = {
+  baseUrl: 'https://{yourOktaDomain}',
+  assets: {
+    baseUrl: 'https://acme.com/assets/dist',
+    languages: ['en', 'ja', 'fr'],
+  },
+};
+
+var signIn = new OktaSignIn(config);
+```
+
+> **Notes:**
+>
+> * The language JSON source files are in the `dist/labels/json` folder of the [`@okta/okta-signin-widget` npm package](https://www.npmjs.com/package/@okta/okta-signin-widget).
+> * Hosting your own language files is also supported in the Gen3 Sign-In Widget used with redirect authentication. See [Style the Sign-In Widget (third generation)](/docs/guides/custom-widget-gen3/main/).
+
 ## Customization examples
 
 Use the following examples to help you customize the sign-in page with your own CSS, scripts, and per-application branding.

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget/main/index.md
@@ -611,7 +611,7 @@ var config = {
 The `i18n` option lets you override specific strings in languages that Sign-In Widget already supports. If you need to support a language not in the default list, or want to serve language files from your own server instead of the Okta CDN, use `assets.baseUrl` and `assets.languages`.
 
 * `assets.baseUrl`: The base URL where your language files are served. The Sign-In Widget loads `labels/json/login_{lang}.json` and `country_{lang}.json` relative to this path.
-* `assets.languages`: The list of language codes you're hosting. This replaces Sign-In Widget's default supported-languages list. If a requested language isn't in the list, Sign-In Widget falls back to `en`.
+* `assets.languages`: The list of language codes that you're hosting. This replaces Sign-In Widget's default supported-languages list. If a requested language isn't in the list, Sign-In Widget falls back to `en`.
 
 ```javascript
 var config = {

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget/main/index.md
@@ -608,7 +608,7 @@ var config = {
 
 ### Host your own language files
 
-The `i18n` option lets you override specific strings in languages Sign-In Widget already supports. If you need to support a language not in the default list, or want to serve language files from your own server instead of the Okta CDN, use `assets.baseUrl` and `assets.languages`.
+The `i18n` option lets you override specific strings in languages that Sign-In Widget already supports. If you need to support a language not in the default list, or want to serve language files from your own server instead of the Okta CDN, use `assets.baseUrl` and `assets.languages`.
 
 * `assets.baseUrl`: The base URL where your language files are served. The Sign-In Widget loads `labels/json/login_{lang}.json` and `country_{lang}.json` relative to this path.
 * `assets.languages`: The list of language codes you're hosting. This replaces Sign-In Widget's default supported-languages list. If a requested language isn't in the list, Sign-In Widget falls back to `en`.


### PR DESCRIPTION
## Description
What's changed? Adds a new "Language customization" section to the Gen3 Sign-In Widget styling guide covering the language, i18n, and BYOL (assets.baseUrl + assets.languages) options. Adds a new "Host your own language files" subsection to the Gen2 Sign-In Widget styling guide covering the same BYOL options for embedded use. Both sections cross-reference each other.

Is this PR related to a Monolith release? No

## Resolves
[OKTA-700610](https://oktainc.atlassian.net/browse/OKTA-700610)

## Netlify Preview Link
- [Gen2](https://tbs-okta-700610-byol-siw-language-customizati--dev-docs-preview.netlify.app/docs/guides/custom-widget/main/#host-your-own-language-files)
- [Gen3](https://tbs-okta-700610-byol-siw-language-customizati--dev-docs-preview.netlify.app/docs/guides/custom-widget-gen3/main/#language-customization)
