### PR TITLE
SIW Gen2: document enabling features

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/custom-widget/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget/main/index.md
@@ -730,7 +730,8 @@ To enable or disable a feature, use the `OktaUtil.getSignInWidgetConfig()` metho
 ```javascript
 var config = OktaUtil.getSignInWidgetConfig();
 config['features.registration'] = true;
-OktaUtil.renderSignInWidgetToEl('okta-login-container', config);
+// or: config.features.registration = true;
+// Then pass config to OktaSignIn as usual
 ```
 
 > **Caution:** **Don’t** override the entire `config.features` object. Assigning a new object to `config.features` (for example, `config.features = { registration: true }`) removes all of Okta's default feature settings and can break flows such as the password-reset email link. Always set individual feature flags as shown earlier.

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget/main/index.md
@@ -733,7 +733,7 @@ config['features.registration'] = true;
 OktaUtil.renderSignInWidgetToEl('okta-login-container', config);
 ```
 
-> **Caution:** Do **not** override the entire `config.features` object. Assigning a new object to `config.features` (for example, `config.features = { registration: true }`) removes all of Okta's default feature settings and can break flows such as the password-reset email link. Always set individual feature flags as shown above.
+> **Caution:** **Don’t** override the entire `config.features` object. Assigning a new object to `config.features` (for example, `config.features = { registration: true }`) removes all of Okta's default feature settings and can break flows such as the password-reset email link. Always set individual feature flags as shown earlier.
 
 ### About the Sign-In Widget version
 

--- a/packages/@okta/vuepress-site/docs/guides/custom-widget/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/custom-widget/main/index.md
@@ -721,6 +721,20 @@ Using this method, inspect the app ID and modify the widget configuration or app
 </script>
 ```
 
+### Enable Sign-In Widget features on the Okta-hosted sign-in page
+
+The Okta-hosted sign-in page sets default [feature flags](https://github.com/okta/okta-signin-widget#feature-flags) on the Sign-In Widget that are required for certain flows to work correctly. For example, the password-reset email link flow depends on default feature settings that Okta configures at runtime.
+
+To enable or disable a feature, use the `OktaUtil.getSignInWidgetConfig()` method to retrieve the existing config object, then set the individual feature property on it. Use the bracket notation (`config['features.featureName']`) or dot notation (`config.features.featureName`) to target a single flag:
+
+```javascript
+var config = OktaUtil.getSignInWidgetConfig();
+config['features.registration'] = true;
+OktaUtil.renderSignInWidgetToEl('okta-login-container', config);
+```
+
+> **Caution:** Do **not** override the entire `config.features` object. Assigning a new object to `config.features` (for example, `config.features = { registration: true }`) removes all of Okta's default feature settings and can break flows such as the password-reset email link. Always set individual feature flags as shown above.
+
 ### About the Sign-In Widget version
 
 The Okta-hosted sign-in page uses the [Sign-In Widget](https://github.com/okta/okta-signin-widget#okta-hosted-sign-in-page-default) component to interact with the user.


### PR DESCRIPTION
## Description
What's changed? Adds a new "Enable Sign-In Widget features on the Okta-hosted sign-in page" section to the Gen2 custom-widget guide. Documents the correct way to enable or disable Sign-In Widget feature flags (config['features.featureName'] = true) and warns against overriding the entire config.features object, which removes Okta's runtime defaults and can break flows such as the password-reset email link.

Is this PR related to a Monolith release? No

## Resolves
[OKTA-415479](https://oktainc.atlassian.net/browse/OKTA-415479)

## Netlify Preview Link:
[Preview link](https://bs-okta-415479-custom-sign-in-features--dev-docs-preview.netlify.app/docs/guides/custom-widget/main/)
