### PR TITLE
update catalog info only

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/update-oin-app/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/update-oin-app/main/index.md
@@ -40,42 +40,20 @@ The OIN Wizard currently supports updates for integrations that use the followin
 
 > **Note:** You can use the [OIN Wizard](/docs/guides/update-oin-app/) to update OIDC, SAML 2.0, SCIM 2.0, and API service integrations that were originally submitted through the [OIN Manager](/docs/guides/submit-app/).
 
-If you need to update only catalog information, such as your app name, description, logo, or support contact information, click the **Edit** button on the **Home** page. This streamlined option skips configuration and testing, allowing you to submit minor branding updates directly to the OIN Ops team for review without requiring functional testing or backward-compatibility verification.
+If you need to update only catalog information, such as your app name, description, logo, or support contact information, click **Edit** on the **Home** page. This streamlined option skips configuration and testing, allowing you to submit minor branding updates directly to the OIN Ops team for review without requiring functional testing or backward-compatibility verification. See [Update catalog information only](#update-catalog-information-only).
 
-When you edit a published OIN integration, test both the updated version and the published version for backward-compatibility. The integration version that was previously installed in your customer's org will not include new settings from your update. Testing the published version ensures that your integration still works for customers who have already installed it. See [Update integration considerations](#update-integration-considerations) before you edit your published integration.
+If you need to edit more than the catalog information for your published OIN integration, test both the updated version and the published version for backward-compatibility. The integration version that was previously installed in your customer's org doesn't include new settings from your update. Testing the published version ensures that your integration still works for customers who have already installed it. See [Update integration considerations](#update-integration-considerations) before you edit your published integration.
 
 After you successfully test the updated and published versions of your integration, resubmit your integration to the OIN team. Your integration goes through a [submission review process](/docs/guides/submit-app-overview/#understand-the-submission-review-process) before the updated version is published in the OIN catalog.
 
 ## Update integration considerations
 
-### Update catalog information only
-
-Update catalog information independently to keep your listing accurate without requiring engineering resources.
-
-To edit the catalog information directly, go to the **Home** page, locate the **Your apps** section, click **Edit** next to the app you want to modify, and select **Catalog Info**. Use this streamlined workflow to update the following catalog fields:
-
-- App name
-- Logo
-- App description
-- Contact information
-
-When you modify only the preceding catalog fields on a published integration, the OIN Wizard bypasses configuration and testing. A confirmation dialog appears for you to submit your changes. Your submission goes directly to the OIN team. Your app displays an in-review status in **Your apps** section. Your changes are tracked through an automated operations ticket and deployed upon OIN Ops team approval. The live version remains active in the public OIN catalog during this review.
-
-If your update includes changes to functional configurations such as SAML settings, SCIM provisioning, or URLs, you must select the **Edit** >  **Integration** option instead of **Edit** > **Catalog Info** and complete the full end-to-end testing Workflow.
-
-### Functional configuration considerations
-
-To update functional settings for your published app, you can use either of the following navigation paths:
-
-- Go to the **Home** page, locate the **Your apps** section, click **Edit** next to the app, and select **Integration**.
-- Go to **Applications > Your OIN Integrations**, click your published integration, and select the standard editing option.
-
-Review the following guidelines before you edit and resubmit your configurations:
-
 > **Note:** Some considerations on this page are specifically for the **<StackSnippet snippet="protocol-name" inline/>**. <br>
 > If you want to change the instructions that you see on this page, select a different option from the **Instructions for** dropdown list.
 
-When you update an integration that's already published, be mindful to preserve backward compatibility for customer that have installed your integration before your latest update.
+When you update an integration that's already published, preserve backward compatibility for customer that have installed your integration before your latest update.
+
+Review the following guidelines before you edit and resubmit your configurations:
 
 * If you modify the **Name** (`name`) property of your [tenant settings](/docs/guides/submit-oin-app/openidconnect/main/#tenant-settings), Okta removes the original variable and creates a variable with your updated name. This action negatively impacts your existing customers if you use the original variable in your integration dynamic properties.
 
@@ -87,23 +65,51 @@ When you update an integration that's already published, be mindful to preserve 
 
 ## Update your integration
 
-> **Notes:**
->- This section applies only to functional updates. For updating catalog information only, see, [Update catalog information only](#update-catalog-information-only).<br>
->- When you edit your published OIN integration, your previous PUBLISHED status and date are overwritten with the DRAFT status and current date.
-</br><StackSnippet snippet="express-submission-note" inline/>
+### Update catalog information only
 
-To update a previously published OIN integration:
+Update catalog information independently to keep your listing accurate without requiring engineering resources or going through the full testing workflow.
 
-1. Sign in to your Integrator Free Plan org as a user with either app admin or super admin roles.
-   > **Note:** Edit your integration from an Okta account that has your company domain in the email address. You can't use an account with a personal email address. The OIN team doesn't review submission edits from a personal email account.
+To update only your app's catalog listing:
 
 1. In the Admin Console, go to **Applications** > **Your OIN Integrations**.
+
+2. Locate your published integration in the **Your apps** section.
+
+3. Click **Edit** next to the app, and then select **Catalog Info**.
+
+Use this streamlined workflow to update the following catalog fields:
+
+- App name
+- Logo
+- App description
+- Contact information
+
+When you modify only these catalog fields on a published integration, the OIN Wizard bypasses configuration and testing. A confirmation dialog appears for you to submit your changes. Your submission goes directly to the OIN team. Your app displays an in-review status in **Your apps** section. Your changes are tracked through an automated operations ticket and deployed upon OIN Ops team approval. The live version remains active in the public OIN catalog during this review.
+
+> **Important:** If your update includes changes to functional configurations such as SAML settings, SCIM provisioning, or URLs, you must select **Edit** > **Integration** instead and complete the full end-to-end testing workflow described in the **Update functional configuration** section below.
+
+### Update functional configuration
+
+> **Notes:**</br>
+> This section applies to updates that include functional configuration changes such as SAML settings, SCIM provisioning, or URLs.</br>
+> When you edit your published OIN integration, your previous PUBLISHED status and date are overwritten with the DRAFT status and current date.
+</br><StackSnippet snippet="express-submission-note" inline/>
+
+1. Sign in to your Integrator Free Plan org as a user with either app admin or super admin roles.
+
+   > **Note:** Edit your integration from an Okta account that has your company domain in the email address. You can't use an account with a personal email address. The OIN team doesn't review submission edits from a personal email account.
+
+1. Go to your published integration using one of the following paths:
+
+    - Go to the **Home** page, locate the **Your apps** section, click **Edit** next to the app, and select **Integration**.
+    - Go to **Applications > Your OIN Integrations**, click your published integration, and select the standard editing option.
 
    > **Note:** If you have a draft submission and want to go straight to testing, see [Navigate directly to test your integration](/docs/guides/submit-oin-app/openidconnect/main/#navigate-directly-to-test-your-integration).
 
 1. Click your published integration to update from the dashboard. Your published OIN submission appears in read-only mode.
 
 1. From the **This integration is read-only** information box, click **Edit integration**. The **Add integration capabilities** page appears.
+
     > **Note:** You can skip this step if your submission is in draft status. The **Edit integration** option isn't available for submissions in draft status because it's not in read-only mode.
 
     <StackSnippet snippet="detect-old-instance" />

--- a/packages/@okta/vuepress-site/docs/guides/update-oin-app/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/update-oin-app/main/index.md
@@ -86,8 +86,6 @@ Use this streamlined workflow to update the following catalog fields:
 
 When you modify only these catalog fields on a published integration, the OIN Wizard bypasses configuration and testing. A confirmation dialog appears for you to submit your changes. Your submission goes directly to the OIN team. Your app displays an in-review status in **Your apps** section. Your changes are tracked through an automated operations ticket and deployed upon OIN Ops team approval. The live version remains active in the public OIN catalog during this review.
 
-> **Important:** If your update includes changes to functional configurations such as SAML settings, SCIM provisioning, or URLs, you must select **Edit** > **Integration** instead and complete the full end-to-end testing workflow described in the **Update functional configuration** section below.
-
 ### Update functional configuration
 
 > **Notes:**</br>

--- a/packages/@okta/vuepress-site/docs/guides/update-oin-app/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/update-oin-app/main/index.md
@@ -40,16 +40,42 @@ The OIN Wizard currently supports updates for integrations that use the followin
 
 > **Note:** You can use the [OIN Wizard](/docs/guides/update-oin-app/) to update OIDC, SAML 2.0, SCIM 2.0, and API service integrations that were originally submitted through the [OIN Manager](/docs/guides/submit-app/).
 
-When you edit a published OIN integration, you need to test the flows for the updated version and the published version for backwards compatibility. The integration version that was previously installed in your customer's org won't contain new settings from the updated version. Testing the published version for backwards compatibility ensures that your integration still works for customers who have already installed it. See [Update integration considerations](#update-integration-considerations) before you edit your published integration.
+If you need to update only catalog information, such as your app name, description, logo, or support contact information, click the **Edit** button on the **Home** page. This streamlined option skips configuration and testing, allowing you to submit minor branding updates directly to the OIN Ops team for review without requiring functional testing or backward-compatibility verification.
+
+When you edit a published OIN integration, test both the updated version and the published version for backward-compatibility. The integration version that was previously installed in your customer's org will not include new settings from your update. Testing the published version ensures that your integration still works for customers who have already installed it. See [Update integration considerations](#update-integration-considerations) before you edit your published integration.
 
 After you successfully test the updated and published versions of your integration, resubmit your integration to the OIN team. Your integration goes through a [submission review process](/docs/guides/submit-app-overview/#understand-the-submission-review-process) before the updated version is published in the OIN catalog.
 
 ## Update integration considerations
 
-> **Note:** Some considerations on this page are specifically for the **<StackSnippet snippet="protocol-name" inline/>** . <br>
+### Update catalog information only
+
+Update catalog information independently to keep your listing accurate without requiring engineering resources.
+
+To edit the catalog information directly, go to the **Home** page, locate the **Your apps** section, click **Edit** next to the app you want to modify, and select **Catalog Info**. Use this streamlined workflow to update the following catalog fields:
+
+- App name
+- Logo
+- App description
+- Contact information
+
+When you modify only the preceding catalog fields on a published integration, the OIN Wizard bypasses configuration and testing. A confirmation dialog appears for you to submit your changes. Your submission goes directly to the OIN team. Your app displays an in-review status in **Your apps** section. Your changes are tracked through an automated operations ticket and deployed upon OIN Ops team approval. The live version remains active in the public OIN catalog during this review.
+
+If your update includes changes to functional configurations such as SAML settings, SCIM provisioning, or URLs, you must select the **Edit** >  **Integration** option instead of **Edit** > **Catalog Info** and complete the full end-to-end testing Workflow.
+
+### Functional configuration considerations
+
+To update functional settings for your published app, you can use either of the following navigation paths:
+
+- Go to the **Home** page, locate the **Your apps** section, click **Edit** next to the app, and select **Integration**.
+- Go to **Applications > Your OIN Integrations**, click your published integration, and select the standard editing option.
+
+Review the following guidelines before you edit and resubmit your configurations:
+
+> **Note:** Some considerations on this page are specifically for the **<StackSnippet snippet="protocol-name" inline/>**. <br>
 > If you want to change the instructions that you see on this page, select a different option from the **Instructions for** dropdown list.
 
-When you update an integration that's already published, be mindful to preserve backwards compatibility for customer that have installed your integration before your latest update.
+When you update an integration that's already published, be mindful to preserve backward compatibility for customer that have installed your integration before your latest update.
 
 * If you modify the **Name** (`name`) property of your [tenant settings](/docs/guides/submit-oin-app/openidconnect/main/#tenant-settings), Okta removes the original variable and creates a variable with your updated name. This action negatively impacts your existing customers if you use the original variable in your integration dynamic properties.
 
@@ -61,7 +87,9 @@ When you update an integration that's already published, be mindful to preserve 
 
 ## Update your integration
 
-> **Notes:** When you edit your published OIN integration, your previous PUBLISHED status and date are overwritten with the DRAFT status and current date.
+> **Notes:**
+>- This section applies only to functional updates. For updating catalog information only, see, [Update catalog information only](#update-catalog-information-only).<br>
+>- When you edit your published OIN integration, your previous PUBLISHED status and date are overwritten with the DRAFT status and current date.
 </br><StackSnippet snippet="express-submission-note" inline/>
 
 To update a previously published OIN integration:
@@ -90,6 +118,8 @@ To update a previously published OIN integration:
 
 ## Test integration updates
 
+>**Note:** This section applies only to functional updates. When updating catalog information only, the OIN Wizard bypasses testing and proceeds directly to submission.
+
 The OIN Wizard journey includes the **Test integration** experience page to help you configure and test your updated integration within the same org before submission. These are the tasks that you need to complete:
 
 <StackSnippet snippet="test-steps" />
@@ -97,7 +127,7 @@ The OIN Wizard journey includes the **Test integration** experience page to help
 
 See [Submit your updated integration](#submit-your-updates) after all required tests are successful.
 
-> **Note:** Test steps on this page are specifically for the **<StackSnippet snippet="protocol-name" inline/>**. <br>
+> **Note:** Test steps on this page are specifically for the **<StackSnippet snippet="protocol-name" inline/>**.<br>
 > If you want to change the instructions that you see on this page, select a different option from the **Instructions for** dropdown list.
 
 ### Generate instances for testing
@@ -117,6 +147,8 @@ Generate instances for testing your updates directly from the OIN Wizard. See [R
 <StackSnippet snippet="test-instance" />
 
 ## Submit your updates
+
+>**Note:** This section applies only to functional updates. Catalog information only updates are submitted directly without configuration or testing.
 
 After you successfully test your updated integration, you're ready to submit.
 

--- a/packages/@okta/vuepress-site/docs/guides/update-oin-app/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/update-oin-app/main/index.md
@@ -40,9 +40,11 @@ The OIN Wizard currently supports updates for integrations that use the followin
 
 > **Note:** You can use the [OIN Wizard](/docs/guides/update-oin-app/) to update OIDC, SAML 2.0, SCIM 2.0, and API service integrations that were originally submitted through the [OIN Manager](/docs/guides/submit-app/).
 
-If you need to update only catalog information, such as your app name, description, logo, or support contact information, click **Edit** on the **Home** page. This streamlined option skips configuration and testing, allowing you to submit minor branding updates directly to the OIN Ops team for review without requiring functional testing or backward-compatibility verification. See [Update catalog information only](#update-catalog-information-only).
+There are two types of updates you can make to a published OIN integration:
 
-If you need to edit more than the catalog information for your published OIN integration, test both the updated version and the published version for backward-compatibility. The integration version that was previously installed in your customer's org doesn't include new settings from your update. Testing the published version ensures that your integration still works for customers who have already installed it. See [Update integration considerations](#update-integration-considerations) before you edit your published integration.
+* Catalog information only - Update your app listing details such as name, logo, description, or contact information without requiring functional configuration changes or testing.
+
+* Functional configuration - Update functional settings such as SAML configurations, SCIM provisioning, URLs, or other integration capabilities. This update type requires testing and backward compatibility verification.
 
 After you successfully test the updated and published versions of your integration, resubmit your integration to the OIN team. Your integration goes through a [submission review process](/docs/guides/submit-app-overview/#understand-the-submission-review-process) before the updated version is published in the OIN catalog.
 
@@ -51,7 +53,7 @@ After you successfully test the updated and published versions of your integrati
 > **Note:** Some considerations on this page are specifically for the **<StackSnippet snippet="protocol-name" inline/>**. <br>
 > If you want to change the instructions that you see on this page, select a different option from the **Instructions for** dropdown list.
 
-When you update an integration that's already published, preserve backward compatibility for customer that have installed your integration before your latest update.
+When you update an integration that's already published, test both the updated version and the published version for backward compatibility. The integration version that was previously installed in your customer's org doesn't include new settings from your update. Testing the published version ensures that your integration still works for customers who have already installed it.
 
 Review the following guidelines before you edit and resubmit your configurations:
 
@@ -89,7 +91,6 @@ When you modify only these catalog fields on a published integration, the OIN Wi
 ### Update functional configuration
 
 > **Notes:**</br>
-> This section applies to updates that include functional configuration changes such as SAML settings, SCIM provisioning, or URLs.</br>
 > When you edit your published OIN integration, your previous PUBLISHED status and date are overwritten with the DRAFT status and current date.
 </br><StackSnippet snippet="express-submission-note" inline/>
 
@@ -103,8 +104,6 @@ When you modify only these catalog fields on a published integration, the OIN Wi
     - Go to **Applications > Your OIN Integrations**, click your published integration, and select the standard editing option.
 
    > **Note:** If you have a draft submission and want to go straight to testing, see [Navigate directly to test your integration](/docs/guides/submit-oin-app/openidconnect/main/#navigate-directly-to-test-your-integration).
-
-1. Click your published integration to update from the dashboard. Your published OIN submission appears in read-only mode.
 
 1. From the **This integration is read-only** information box, click **Edit integration**. The **Add integration capabilities** page appears.
 


### PR DESCRIPTION


## Description:
- **What's changed?** Changes to accommodate catalog info only
- **Is this PR related to a Monolith release?**2026.07.0 - Publish after prod live

### Resolves:

* [OKTA-1135303](https://oktainc.atlassian.net/browse/OKTA-1135303)

### Netlify Preview Link:

[Preview](https://sj-fastpth-okta-1135303--dev-docs-preview.netlify.app/docs/guides/update-oin-app/openidconnect/main/#update-catalog-information-only)
