### PR TITLE
OKTA-1209196 - Trim trailing hyphens from preview branch name

### DIFF
--- a/scripts/build-preview.sh
+++ b/scripts/build-preview.sh
@@ -40,6 +40,9 @@ if [ -n "$BRANCH" ]; then
     echo "Branch name exceeds Netlify subdomain length limit. Using trimmed alias: ${NETLIFY_ALIAS}"
   fi
 
+  # Ensure the alias does not end with a hyphen after trimming.
+  NETLIFY_ALIAS="${NETLIFY_ALIAS%-}"
+
   echo "Deploying preview to Netlify..."
   npx netlify-cli@17.23.5 deploy --alias="${NETLIFY_ALIAS}" --filter @okta/vuepress-site --dir ../packages/@okta/vuepress-site/dist
 


### PR DESCRIPTION
## Description:
- **What's changed?** Remove trailing hyphens from the branch name used in preview URLs
- **Is this PR related to a Monolith release?** n/a

### Resolves:
* [OKTA-1209196](https://oktainc.atlassian.net/browse/OKTA-1209196)

### Netlify Preview Link:
https://ad-okta-1209196-trim-trailing-hyphens-in-prev--dev-docs-preview.netlify.app/
