### PR TITLE
OKTA-1219089 - Add doc action RN for editable group rule targets

### DIFF
--- a/packages/@okta/vuepress-site/docs/release-notes/2026-okta-identity-engine/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2026-okta-identity-engine/index.md
@@ -86,7 +86,7 @@ The [Delete a group push mapping](https://developer.okta.com/docs/api/openapi/ok
 
 #### Replace a Group Rule API can now update assigned groups
 
- The [Replace a group rule](https://developer.okta.com/docs/api/openapi/okta-management/management/tags/grouprule/other/replacegrouprule) endpoint now supports updating the `actions` object to modify the groups assigned to a group rule. <!-- OKTA-1128862 FF EDITABLE_GROUP_RULE_TARGETS to GA Preview July 1, 2026 -->
+The [Replace a group rule](https://developer.okta.com/docs/api/openapi/okta-management/management/tags/grouprule/other/replacegrouprule) endpoint now supports updating the `actions` object to modify the groups assigned to a group rule. <!-- OKTA-1128862 FF EDITABLE_GROUP_RULE_TARGETS to GA Preview July 1, 2026 -->
 
 #### Native to Web SSO is GA in Production
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2026-okta-identity-engine/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2026-okta-identity-engine/index.md
@@ -28,6 +28,7 @@ title: Okta Identity Engine API release notes 2026
 | [Clear Managed Chrome Profile Browsing Data is GA in Production](#clear-managed-chrome-profile-browsing-data-is-ga-in-production) | June 3, 2026 |
 | [Group push support in API Integration Actions apps](#group-push-support-in-api-integration-actions-apps) | July 1, 2026 |
 | [Delete group push mappings in ERROR state](#delete-group-push-mappings-in-error-state) | July 1, 2026 |
+| [Replace a Group Rule API can now update assigned groups](#replace-a-group-rule-api-can-now-update-assigned-groups) | July 1, 2026 |
 | [Native to Web SSO is GA in Production](#native-to-web-sso-is-ga-in-production) | January 7, 2026 |
 | [Removal of Cross App Access as a self-service feature](#removal-of-cross-app-access-as-a-self-service-feature) | July 1, 2026 |
 | [Spec-compliant client ID claims for AI agent tokens](#spec-compliant-client-id-claims-for-ai-agent-tokens) | Jun 11, 2026 |
@@ -82,6 +83,10 @@ Apps that use API Integration Actions to perform provisioning can now use the [G
 #### Delete group push mappings in ERROR state
 
 The [Delete a group push mapping](https://developer.okta.com/docs/api/openapi/okta-management/management/tags/grouppushmapping/other/deletegrouppushmapping) endpoint now supports deleting group push mappings in the `ERROR` state, alongside the `INACTIVE` state. <!-- OKTA-1210326 -->
+
+#### Replace a Group Rule API can now update assigned groups
+
+ The [Replace a group rule](https://developer.okta.com/docs/api/openapi/okta-management/management/tags/grouprule/other/replacegrouprule) endpoint now supports updating the `actions` object to modify the groups assigned to a group rule. <!-- OKTA-1128862 FF EDITABLE_GROUP_RULE_TARGETS to GA Preview July 1, 2026 -->
 
 #### Native to Web SSO is GA in Production
 

--- a/packages/@okta/vuepress-site/docs/release-notes/2026/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2026/index.md
@@ -20,6 +20,7 @@ title: Okta Classic Engine API release notes 2026
 | [Improved group member search functionality is GA in Production](#improved-group-member-search-functionality-is-ga-in-production) | July 1, 2026 |
 | [Group push support in API Integration Actions apps](#group-push-support-in-api-integration-actions-apps) | July 1, 2026 |
 | [Delete group push mappings in ERROR state](#delete-group-push-mappings-in-error-state) | July 1, 2026 |
+| [Replace a Group Rule API can now update assigned groups](#replace-a-group-rule-api-can-now-update-assigned-groups) | July 1, 2026 |
 | [Developer documentation updates in 2026.07.0](#developer-documentation-updates-in-2026-07-0) | July 1, 2026 |
 
 #### New IP Service available for enhanced dynamic network zones
@@ -38,6 +39,10 @@ Apps that use API Integration Actions to perform provisioning can now use the [G
 #### Delete group push mappings in ERROR state
 
 The [Delete a group push mapping](https://developer.okta.com/docs/api/openapi/okta-management/management/tags/grouppushmapping/other/deletegrouppushmapping) endpoint now supports deleting group push mappings in the `ERROR` state, alongside the `INACTIVE` state. <!-- OKTA-1210326 -->
+
+#### Replace a Group Rule API can now update assigned groups
+
+The [Replace a group rule](https://developer.okta.com/docs/api/openapi/okta-management/management/tags/grouprule/other/replacegrouprule) endpoint now supports updating the `actions` object to modify the groups assigned to a group rule. <!-- OKTA-1128862 FF EDITABLE_GROUP_RULE_TARGETS to GA Preview July 1, 2026 -->
 
 #### Developer documentation updates in 2026.07.0
 


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Added RN to OIE and Classic for the editable group rule targets feature released in the July 2026 monthly.
- **Is this PR related to a Monolith release?** `2026.07.0`

### Resolves:

* [OKTA-1219089](https://oktainc.atlassian.net/browse/OKTA-1219089)

### Netlify Preview Link:

<!-- Add preview link here -->
