### PR TITLE
AuthJS SDK: Sign in to SPA - update React examples

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/basic-sign-in.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/basic-sign-in.md
@@ -20,18 +20,11 @@ export default {
   issuer: ISSUER,
   redirectUri: REDIRECT_URI,
   scopes: ['openid', 'offline_access', 'profile', 'email'],
-  pkce: true,
-  idx: {
-    // Okta Auth JS 8.x defaults idx.proceed() to Step Mode, which requires every
-    // call to name a step or action. This guide uses the older, generic
-    // remediation-driven pattern below instead (calling idx.proceed() with just
-    // the form values), so Legacy Mode is enabled here to keep that working.
-    enableLegacyMode: true
-  }
+  pkce: true
 };
 ```
 
-> **Note:** Legacy Mode is on a deprecation path in Okta Auth JS but is still fully supported. It's what lets the generic, response-driven form pattern in this guide work without hardcoding every remediation step by name. See [Step Mode vs Legacy Mode](https://github.com/okta/okta-auth-js/blob/master/docs/idx.md#step-mode-vs-legacy-mode) in the Auth JS SDK docs if you want to build against the newer, explicit-step approach instead.
+> **Note:** Okta Auth JS 8.x requires every `idx.proceed()` call to name the remediation step it's submitting. This guide uses that Step Mode pattern throughout. See [Step Mode vs Legacy Mode](https://github.com/okta/okta-auth-js/blob/master/docs/idx.md#step-mode-vs-legacy-mode) in the Auth JS SDK docs if you're migrating an older app that relies on the deprecated, generic remediation-driven pattern.
 
 ### Instantiate the Okta Auth JS client
 
@@ -91,15 +84,67 @@ Pass `transaction.nextStep` into `formTransformer` (see [Basic sign-in flow](#ba
 
 ### Handle the password authentication
 
-Review the `app.js` file for details on handling a successful password authentication by receiving the `SUCCESS` status and storing the returned tokens:
+Name the step you're submitting on every `idx.proceed()` call — `transaction.nextStep.name` holds the value, and it's the same step the form already rendered against. For this password-only use case, the step name is `identify`. Review the `app.js` file for details on handling a successful password authentication by receiving the `SUCCESS` status and storing the returned tokens:
 
 ```JavaScript
-....
-
 const handleSubmit = async e => {
+  e.preventDefault();
+
+  const newTransaction = await oktaAuth.idx.proceed({ step: 'identify', ...inputValues }); // inputValues = username, password
+  console.log('Transaction:', newTransaction);
+
+  setInputValues({});
+  if (newTransaction.status === IdxStatus.SUCCESS) {
+    oktaAuth.tokenManager.setTokens(newTransaction.tokens);
+  } else {
+    setTransaction(newTransaction);
+  }
+};
+```
+
+### The full sign-in component code
+
+With the pieces above in place, here's the complete `App.jsx` for the password-only sign-in flow, with everything shown together:
+
+```JavaScript
+import { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { OktaAuth, IdxStatus, urlParamsToObject } from '@okta/okta-auth-js';
+import { Security } from '@okta/okta-react';
+import { formTransformer } from './formTransformer';
+import oidcConfig from './config';
+import './App.css';
+
+function createOktaAuthInstance() {
+  const { state } = urlParamsToObject(window.location.search);
+  return new OktaAuth(Object.assign({}, oidcConfig, {
+    state
+  }));
+}
+
+const oktaAuth = createOktaAuthInstance();
+const restoreOriginalUri = () => {};
+
+function SignInForm() {
+  const [transaction, setTransaction] = useState(null);
+  const [inputValues, setInputValues] = useState({});
+
+  useEffect(() => {
+    const startTransaction = async () => {
+      const newTransaction = await oktaAuth.idx.authenticate();
+      setTransaction(newTransaction);
+    };
+    startTransaction();
+  }, []);
+
+  const handleChange = ({ target: { name, value } }) => {
+    setInputValues({ ...inputValues, [name]: value });
+  };
+
+  const handleSubmit = async e => {
     e.preventDefault();
 
-    const newTransaction = await oktaAuth.idx.proceed(inputValues); // inputValues = username, password
+    const newTransaction = await oktaAuth.idx.proceed({ step: 'identify', ...inputValues });
     console.log('Transaction:', newTransaction);
 
     setInputValues({});
@@ -110,5 +155,40 @@ const handleSubmit = async e => {
     }
   };
 
-  ...
-  ```
+  if (!transaction?.nextStep) {
+    return null;
+  }
+
+  const { inputs } = formTransformer(transaction.nextStep)({});
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {inputs.map(({ label, name, type, required }) => (
+        <label key={name}>
+          {label}
+          <input
+            name={name}
+            type={type}
+            required={required}
+            value={inputValues[name] || ''}
+            onChange={handleChange}
+          />
+        </label>
+      ))}
+      <button type="submit">Sign in</button>
+    </form>
+  );
+}
+
+function App() {
+  const history = useHistory();
+
+  return (
+    <Security oktaAuth={oktaAuth} restoreOriginalUri={restoreOriginalUri}>
+      <SignInForm />
+    </Security>
+  );
+}
+
+export default App;
+```

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/basic-sign-in.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/basic-sign-in.md
@@ -3,7 +3,7 @@ Review the simple password-only sign-in use case from the sample app.
 <!-- The sequence diagram below is out of date with the Step Mode rework in this
 guide (it shows a single idx.authenticate(username,password) call, not the
 two-call authenticate()-then-proceed({ step }) flow). Commented out until the
-updated diagram is ready — see OKTA-1220702 for the design request tracking
+updated diagram is ready — see the design request ticket (TBD) for tracking
 this.
 <div class="full">
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/basic-sign-in.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/basic-sign-in.md
@@ -2,9 +2,9 @@ Review the simple password-only sign-in use case from the sample app.
 
 <!-- The sequence diagram below is out of date with the Step Mode rework in this
 guide (it shows a single idx.authenticate(username,password) call, not the
-two-call authenticate()-then-proceed({ step }) flow). Commented out until the
-updated diagram is ready — see OKTA-1220704 for the design request tracking
-this.
+multi-call proceed({ step }) flow, which primes then submits each remediation
+step in turn). Commented out until the updated diagram is ready — see
+OKTA-1220704 for the design request tracking this.
 <div class="full">
 
 ![Sequence diagram that displays the interactions between the resource owner, SDK, authorization server, and resource server for a basic SPA password sign-in flow.](/img/oie-embedded-sdk/password-only-spa-authjs-flow.svg)
@@ -74,41 +74,46 @@ function App() {
 
 ### Start the sign-in transaction
 
-Before you can render a sign-in form, you need an in-progress IDX transaction to drive it. Start one when your component mounts by calling `idx.start()` with no arguments — the response's `nextStep.inputs` tells you which fields to render. For this password-only use case, that's `username` and `password`:
+Before you can render a sign-in form, you need an in-progress IDX transaction to drive it. Start one when your component mounts by calling `idx.start()`. `idx.start()` begins the transaction, but doesn't resolve a step's field data until you name that step — call `idx.proceed()` with only a `step` name and no other values to have the SDK return that step's `inputs` for rendering. For this password-only use case, the sign-in flow always begins with the `identify` step, which asks for `username`:
 
 ```JavaScript
 const [transaction, setTransaction] = useState(null);
 
 useEffect(() => {
   const startTransaction = async () => {
-    const newTransaction = await oktaAuth.idx.start();
+    await oktaAuth.idx.start();
+    const newTransaction = await oktaAuth.idx.proceed({ step: 'identify' });
     setTransaction(newTransaction);
   };
   startTransaction();
 }, []);
 ```
 
-Pass `transaction.nextStep` into `formTransformer` (see [Basic sign-in flow](#basic-sign-in-flow)) to render the form fields for the current step.
+Pass `transaction.nextStep` into `formTransformer` (see [Basic sign-in flow](#basic-sign-in-flow)) to render the form fields for the current step. Okta's Identity Engine collects the username first, then challenges for the password on a separate step, so this password-only flow renders two forms in sequence rather than one combined username-and-password form.
 
 ### Handle the password authentication
 
-Name the step you're submitting on every `idx.proceed()` call — `transaction.nextStep.name` holds the value, and it's the same step the form already rendered against. For this password-only use case, the step name is `identify`. Review the `app.js` file for details on handling a successful password authentication by receiving the `SUCCESS` status and storing the returned tokens:
+Name the step you're submitting on every `idx.proceed()` call — `transaction.nextStep.name` holds the value, and it's the same step the form already rendered against. Submitting a step's values tells you the name of the next step but not its renderable field data, so call `idx.proceed()` again with just that step name to prime the following form before you render it. Review the `app.js` file for details on handling a successful password authentication by receiving the `SUCCESS` status and storing the returned tokens:
 
 ```JavaScript
 const handleSubmit = async e => {
   e.preventDefault();
 
-  const newTransaction = await oktaAuth.idx.proceed({ step: 'identify', ...inputValues }); // inputValues = username, password
-  console.log('Transaction:', newTransaction);
-
+  const submittedTransaction = await oktaAuth.idx.proceed({ step: transaction.nextStep.name, ...inputValues });
+  console.log('Transaction:', submittedTransaction);
   setInputValues({});
-  if (newTransaction.status === IdxStatus.SUCCESS) {
-    oktaAuth.tokenManager.setTokens(newTransaction.tokens);
-  } else {
-    setTransaction(newTransaction);
+
+  if (submittedTransaction.status === IdxStatus.SUCCESS) {
+    oktaAuth.tokenManager.setTokens(submittedTransaction.tokens);
+    return;
   }
+
+  const newTransaction = await oktaAuth.idx.proceed({ step: submittedTransaction.nextStep.name });
+  setTransaction(newTransaction);
 };
 ```
+
+For this password-only use case, that's two round trips through `handleSubmit`: the first submits `username` from the `identify` step and primes the `challenge-authenticator` step; the second submits `password` from that step and reaches `IdxStatus.SUCCESS`.
 
 ### The full sign-in component code
 
@@ -138,7 +143,8 @@ function SignInForm() {
 
   useEffect(() => {
     const startTransaction = async () => {
-      const newTransaction = await oktaAuth.idx.start();
+      await oktaAuth.idx.start();
+      const newTransaction = await oktaAuth.idx.proceed({ step: 'identify' });
       setTransaction(newTransaction);
     };
     startTransaction();
@@ -151,15 +157,17 @@ function SignInForm() {
   const handleSubmit = async e => {
     e.preventDefault();
 
-    const newTransaction = await oktaAuth.idx.proceed({ step: 'identify', ...inputValues });
-    console.log('Transaction:', newTransaction);
-
+    const submittedTransaction = await oktaAuth.idx.proceed({ step: transaction.nextStep.name, ...inputValues });
+    console.log('Transaction:', submittedTransaction);
     setInputValues({});
-    if (newTransaction.status === IdxStatus.SUCCESS) {
-      oktaAuth.tokenManager.setTokens(newTransaction.tokens);
-    } else {
-      setTransaction(newTransaction);
+
+    if (submittedTransaction.status === IdxStatus.SUCCESS) {
+      oktaAuth.tokenManager.setTokens(submittedTransaction.tokens);
+      return;
     }
+
+    const newTransaction = await oktaAuth.idx.proceed({ step: submittedTransaction.nextStep.name });
+    setTransaction(newTransaction);
   };
 
   if (!transaction?.nextStep) {

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/basic-sign-in.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/basic-sign-in.md
@@ -1,10 +1,16 @@
-Review the simple password-only sign-in use case from the sample app. This use case is outlined in the following sequence diagram with your single-page app (SPA) as the client:
+Review the simple password-only sign-in use case from the sample app.
 
+<!-- The sequence diagram below is out of date with the Step Mode rework in this
+guide (it shows a single idx.authenticate(username,password) call, not the
+two-call authenticate()-then-proceed({ step }) flow). Commented out until the
+updated diagram is ready — see OKTA-1220702 for the design request tracking
+this.
 <div class="full">
 
 ![Sequence diagram that displays the interactions between the resource owner, SDK, authorization server, and resource server for a basic SPA password sign-in flow.](/img/oie-embedded-sdk/password-only-spa-authjs-flow.svg)
 
 </div>
+-->
 
 ### Set up the Okta configuration settings
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/basic-sign-in.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/basic-sign-in.md
@@ -39,20 +39,13 @@ Review the React `app.js` file that imports the required libraries and instantia
 ```JavaScript
 import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { OktaAuth, IdxStatus, urlParamsToObject, toRelativeUrl } from '@okta/okta-auth-js';
+import { OktaAuth, IdxStatus, toRelativeUrl } from '@okta/okta-auth-js';
 import { Security } from '@okta/okta-react';
 import { formTransformer } from './formTransformer';
 import oidcConfig from './config';
 import './App.css';
 
-function createOktaAuthInstance() {
-  const { state } = urlParamsToObject(window.location.search);
-  return new OktaAuth(Object.assign({}, oidcConfig, {
-    state
-  }));
-}
-
-const oktaAuth = createOktaAuthInstance();
+const oktaAuth = new OktaAuth(oidcConfig);
 
 ...
 
@@ -122,20 +115,13 @@ With the pieces above in place, here's the complete `App.jsx` for the password-o
 ```JavaScript
 import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { OktaAuth, IdxStatus, urlParamsToObject, toRelativeUrl } from '@okta/okta-auth-js';
+import { OktaAuth, IdxStatus, toRelativeUrl } from '@okta/okta-auth-js';
 import { Security } from '@okta/okta-react';
 import { formTransformer } from './formTransformer';
 import oidcConfig from './config';
 import './App.css';
 
-function createOktaAuthInstance() {
-  const { state } = urlParamsToObject(window.location.search);
-  return new OktaAuth(Object.assign({}, oidcConfig, {
-    state
-  }));
-}
-
-const oktaAuth = createOktaAuthInstance();
+const oktaAuth = new OktaAuth(oidcConfig);
 
 function SignInForm() {
   const [transaction, setTransaction] = useState(null);

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/basic-sign-in.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/basic-sign-in.md
@@ -1,10 +1,10 @@
 Review the simple password-only sign-in use case from the sample app.
 
-<!-- The sequence diagram below is out of date with the Step Mode rework in this
-guide (it shows a single idx.authenticate(username,password) call, not the
-multi-call proceed({ step }) flow, which primes then submits each remediation
-step in turn). Commented out until the updated diagram is ready — see
-OKTA-1220704 for the design request tracking this.
+<!-- The sequence diagram below is out of date. It shows the old Step Mode
+flow: a single idx.authenticate(username, password) call. The current flow
+instead primes and submits each remediation step in turn with proceed({
+step }). This comment hides the diagram until the design team updates it.
+See OKTA-1220704 for the tracking ticket.
 <div class="full">
 
 ![Sequence diagram that displays the interactions between the resource owner, SDK, authorization server, and resource server for a basic SPA password sign-in flow.](/img/oie-embedded-sdk/password-only-spa-authjs-flow.svg)
@@ -74,7 +74,7 @@ function App() {
 
 ### Start the sign-in transaction
 
-Before you can render a sign-in form, you need an in-progress IDX transaction to drive it. Start one when your component mounts by calling `idx.start()`. `idx.start()` begins the transaction, but doesn't resolve a step's field data until you name that step — call `idx.proceed()` with only a `step` name and no other values to have the SDK return that step's `inputs` for rendering. For this password-only use case, the sign-in flow always begins with the `identify` step, which asks for `username`:
+Before you can render a sign-in form, you need an in-progress IDX transaction to drive it. Start one when your component mounts by calling `idx.start()`. `idx.start()` begins the transaction. It doesn't resolve a step's field data until you name that step. Call `idx.proceed()` with only a `step` name and no other values. The SDK then returns that step's `inputs` for rendering. For this password-only use case, the sign-in flow always begins with the `identify` step, which asks for `username`:
 
 ```JavaScript
 const [transaction, setTransaction] = useState(null);
@@ -89,11 +89,11 @@ useEffect(() => {
 }, []);
 ```
 
-Pass `transaction.nextStep` into `formTransformer` (see [Basic sign-in flow](#basic-sign-in-flow)) to render the form fields for the current step. Okta's Identity Engine collects the username first, then challenges for the password on a separate step, so this password-only flow renders two forms in sequence rather than one combined username-and-password form.
+Pass `transaction.nextStep` into `formTransformer` to render the form fields for the current step. See [Basic sign-in flow](#basic-sign-in-flow) for the full form code. Okta's Identity Engine collects the username first. It then challenges for the password on a separate step. This password-only flow therefore renders two forms in sequence, not one combined form.
 
 ### Handle the password authentication
 
-Name the step you're submitting on every `idx.proceed()` call — `transaction.nextStep.name` holds the value, and it's the same step the form already rendered against. Submitting a step's values tells you the name of the next step but not its renderable field data, so call `idx.proceed()` again with just that step name to prime the following form before you render it. Review the `app.js` file for details on handling a successful password authentication by receiving the `SUCCESS` status and storing the returned tokens:
+Name the step you're submitting on every `idx.proceed()` call. `transaction.nextStep.name` holds that name. It matches the step the form already rendered. Submitting a step's values reveals the name of the next step. It does not reveal that step's renderable field data. Call `idx.proceed()` again with just the step name to prime the next form before you render it. Review the `app.js` file for details on handling a successful password authentication. It receives the `SUCCESS` status and stores the returned tokens:
 
 ```JavaScript
 const handleSubmit = async e => {
@@ -113,7 +113,7 @@ const handleSubmit = async e => {
 };
 ```
 
-For this password-only use case, that's two round trips through `handleSubmit`: the first submits `username` from the `identify` step and primes the `challenge-authenticator` step; the second submits `password` from that step and reaches `IdxStatus.SUCCESS`.
+For this password-only use case, `handleSubmit` runs twice. The first run submits `username` from the `identify` step and primes the `challenge-authenticator` step. The second run submits `password` from that step and reaches `IdxStatus.SUCCESS`.
 
 ### The full sign-in component code
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/basic-sign-in.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/basic-sign-in.md
@@ -8,30 +8,40 @@ Review the simple password-only sign-in use case from the sample app. This use c
 
 ### Set up the Okta configuration settings
 
-Review the `src/config.js` file that references the required [app integration settings](#app-integration-settings) to initialize your Okta Auth JS instance. The `config.js` file references the values that you add to the `testenv` file.
+Review the `src/config.js` file that references the required [app integration settings](#app-integration-settings) to initialize your Okta Auth JS instance. The `config.js` file references the values that you add to the `.env` file.
 
 ```JavaScript
-const CLIENT_ID = process.env.SPA_CLIENT_ID || process.env.CLIENT_ID || '{clientId}';
-const ISSUER = process.env.ISSUER || 'https://{yourOktaDomain}/oauth2/default';
-const REDIRECT_URI = `{window.location.origin}/login/callback`;
+const CLIENT_ID = import.meta.env.VITE_CLIENT_ID || '{clientId}';
+const ISSUER = import.meta.env.VITE_ISSUER || 'https://{yourOktaDomain}/oauth2/default';
+const REDIRECT_URI = `${window.location.origin}/login/callback`;
 
-// eslint-disable-next-line import/no-anonymous-default-export
 export default {
   clientId: CLIENT_ID,
   issuer: ISSUER,
   redirectUri: REDIRECT_URI,
   scopes: ['openid', 'offline_access', 'profile', 'email'],
+  pkce: true,
+  idx: {
+    // Okta Auth JS 8.x defaults idx.proceed() to Step Mode, which requires every
+    // call to name a step or action. This guide uses the older, generic
+    // remediation-driven pattern below instead (calling idx.proceed() with just
+    // the form values), so Legacy Mode is enabled here to keep that working.
+    enableLegacyMode: true
+  }
 };
 ```
 
+> **Note:** Legacy Mode is on a deprecation path in Okta Auth JS but is still fully supported. It's what lets the generic, response-driven form pattern in this guide work without hardcoding every remediation step by name. See [Step Mode vs Legacy Mode](https://github.com/okta/okta-auth-js/blob/master/docs/idx.md#step-mode-vs-legacy-mode) in the Auth JS SDK docs if you want to build against the newer, explicit-step approach instead.
+
 ### Instantiate the Okta Auth JS client
 
-Review the React `app.js` file that imports the required libraries and instantiates the Okta Auth JS client with values from the `config.js`.
+Review the React `app.js` file that imports the required libraries and instantiates the Okta Auth JS client with values from the `config.js`. Wrap your app in the `Security` component from the Okta React SDK so it can manage the Auth JS instance for you.
 
 ```JavaScript
 import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { OktaAuth, IdxStatus, urlParamsToObject, hasErrorInUrl } from '@okta/okta-auth-js';
+import { OktaAuth, IdxStatus, urlParamsToObject } from '@okta/okta-auth-js';
+import { Security } from '@okta/okta-react';
 import { formTransformer } from './formTransformer';
 import oidcConfig from './config';
 import './App.css';
@@ -44,13 +54,44 @@ function createOktaAuthInstance() {
 }
 
 const oktaAuth = createOktaAuthInstance();
+const restoreOriginalUri = () => {};
 
 ...
+
+function App() {
+  const history = useHistory();
+
+  return (
+    <Security oktaAuth={oktaAuth} restoreOriginalUri={restoreOriginalUri}>
+      ...
+    </Security>
+  );
+}
 ```
+
+> **Note:** This guide's simplified example doesn't cover redirect callbacks (for example, social IdP sign-in or email magic links). If your app needs them, see [Redirect callbacks](https://github.com/okta/okta-auth-js/blob/master/docs/idx.md#redirect-callbacks) in the Auth JS SDK docs and the `LoginCallback` component in [Okta's reference sample app](https://github.com/okta/okta-auth-js/tree/master/samples/generated/react-embedded-auth-with-sdk).
+
+### Start the sign-in transaction
+
+Before you can render a sign-in form, you need an in-progress IDX transaction to drive it. Start one when your component mounts by calling `idx.authenticate()` with no arguments — the response's `nextStep.inputs` tells you which fields to render. For this password-only use case, that's `username` and `password`:
+
+```JavaScript
+const [transaction, setTransaction] = useState(null);
+
+useEffect(() => {
+  const startTransaction = async () => {
+    const newTransaction = await oktaAuth.idx.authenticate();
+    setTransaction(newTransaction);
+  };
+  startTransaction();
+}, []);
+```
+
+Pass `transaction.nextStep` into `formTransformer` (see [Basic sign-in flow](#basic-sign-in-flow)) to render the form fields for the current step.
 
 ### Handle the password authentication
 
-Review the `apps.js` file for details on handling a successful password authentication by receiving the `SUCCESS` status and storing the returned tokens:
+Review the `app.js` file for details on handling a successful password authentication by receiving the `SUCCESS` status and storing the returned tokens:
 
 ```JavaScript
 ....

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/basic-sign-in.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/basic-sign-in.md
@@ -3,7 +3,7 @@ Review the simple password-only sign-in use case from the sample app.
 <!-- The sequence diagram below is out of date with the Step Mode rework in this
 guide (it shows a single idx.authenticate(username,password) call, not the
 two-call authenticate()-then-proceed({ step }) flow). Commented out until the
-updated diagram is ready — see the design request ticket (TBD) for tracking
+updated diagram is ready — see OKTA-1220704 for the design request tracking
 this.
 <div class="full">
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/basic-sign-in.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/basic-sign-in.md
@@ -39,7 +39,7 @@ Review the React `app.js` file that imports the required libraries and instantia
 ```JavaScript
 import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { OktaAuth, IdxStatus, urlParamsToObject } from '@okta/okta-auth-js';
+import { OktaAuth, IdxStatus, urlParamsToObject, toRelativeUrl } from '@okta/okta-auth-js';
 import { Security } from '@okta/okta-react';
 import { formTransformer } from './formTransformer';
 import oidcConfig from './config';
@@ -53,12 +53,14 @@ function createOktaAuthInstance() {
 }
 
 const oktaAuth = createOktaAuthInstance();
-const restoreOriginalUri = () => {};
 
 ...
 
 function App() {
   const history = useHistory();
+  const restoreOriginalUri = async (_oktaAuth, originalUri) => {
+    history.replace(toRelativeUrl(originalUri || '/', window.location.origin));
+  };
 
   return (
     <Security oktaAuth={oktaAuth} restoreOriginalUri={restoreOriginalUri}>
@@ -72,14 +74,14 @@ function App() {
 
 ### Start the sign-in transaction
 
-Before you can render a sign-in form, you need an in-progress IDX transaction to drive it. Start one when your component mounts by calling `idx.authenticate()` with no arguments — the response's `nextStep.inputs` tells you which fields to render. For this password-only use case, that's `username` and `password`:
+Before you can render a sign-in form, you need an in-progress IDX transaction to drive it. Start one when your component mounts by calling `idx.start()` with no arguments — the response's `nextStep.inputs` tells you which fields to render. For this password-only use case, that's `username` and `password`:
 
 ```JavaScript
 const [transaction, setTransaction] = useState(null);
 
 useEffect(() => {
   const startTransaction = async () => {
-    const newTransaction = await oktaAuth.idx.authenticate();
+    const newTransaction = await oktaAuth.idx.start();
     setTransaction(newTransaction);
   };
   startTransaction();
@@ -115,7 +117,7 @@ With the pieces above in place, here's the complete `App.jsx` for the password-o
 ```JavaScript
 import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { OktaAuth, IdxStatus, urlParamsToObject } from '@okta/okta-auth-js';
+import { OktaAuth, IdxStatus, urlParamsToObject, toRelativeUrl } from '@okta/okta-auth-js';
 import { Security } from '@okta/okta-react';
 import { formTransformer } from './formTransformer';
 import oidcConfig from './config';
@@ -129,7 +131,6 @@ function createOktaAuthInstance() {
 }
 
 const oktaAuth = createOktaAuthInstance();
-const restoreOriginalUri = () => {};
 
 function SignInForm() {
   const [transaction, setTransaction] = useState(null);
@@ -137,7 +138,7 @@ function SignInForm() {
 
   useEffect(() => {
     const startTransaction = async () => {
-      const newTransaction = await oktaAuth.idx.authenticate();
+      const newTransaction = await oktaAuth.idx.start();
       setTransaction(newTransaction);
     };
     startTransaction();
@@ -188,6 +189,9 @@ function SignInForm() {
 
 function App() {
   const history = useHistory();
+  const restoreOriginalUri = async (_oktaAuth, originalUri) => {
+    history.replace(toRelativeUrl(originalUri || '/', window.location.origin));
+  };
 
   return (
     <Security oktaAuth={oktaAuth} restoreOriginalUri={restoreOriginalUri}>

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/download-sample.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/download-sample.md
@@ -40,16 +40,17 @@ Navigate to the project folder and run the sample app. Click **Login** and sign 
 
 ### Create a React app (optional)
 
-If you don't have an existing React app, you can quickly create an app by using [Create React App](https://create-react-app.dev/):
+If you don't have an existing React app, you can quickly create one using [Vite](https://vite.dev/):
 
 ```bash
-  npx create-react-app okta-app
+npm create vite@latest okta-app -- --template react
 ```
 
-Go into your root app directory to view the created files:
+Go into your app directory and install the base dependencies:
 
 ```bash
-  cd okta-app
+cd okta-app
+npm install
 ```
 
 ### Install dependencies

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/download-sample.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/download-sample.md
@@ -26,7 +26,6 @@ Create and add a configuration file (`testenv`) to the `okta-auth-js` root folde
 ```txt
 ISSUER=https://{yourOktaDomain}/oauth2/default
 CLIENT_ID={clientId}
-USE_INTERACTION_CODE=true
 ```
 
 #### Run the sample application
@@ -71,4 +70,15 @@ npm install @okta/okta-react@latest
 npm install react-router-dom@5
 ```
 
-> **Note:** The sample code in this use case requires `react-router-dom` version 5.x. Certain objects used in the sample code don't exist in `reactor-router-dom` version 6.x.
+> **Note:** The sample code in this use case requires `react-router-dom` version 5.x. Certain objects used in the sample code don't exist in `react-router-dom` version 6.x or later. Okta's own reference sample app is also still on `react-router-dom` version 5.x, so there's no version 6+ equivalent to switch to yet.
+
+### Add environment variables
+
+Vite only exposes environment variables to your app code when they're prefixed with `VITE_` and read through `import.meta.env`, unlike some other React tooling. Create a `.env` file in your app's root folder with your [app integration settings](#app-integration-settings):
+
+```txt
+VITE_ISSUER=https://{yourOktaDomain}/oauth2/default
+VITE_CLIENT_ID={clientId}
+```
+
+> **Note:** Add `.env` to your `.gitignore` file so you don't commit it to source control.

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/download-sample.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/download-sample.md
@@ -1,6 +1,8 @@
 ### Download the sample React application
 
-To view a simple example of a React app, clone the Auth JS repository and follow the setup procedure:
+Clone the Auth JS repository and follow the setup procedure below to confirm your org and environment work end-to-end.
+
+> **Note:** The generated sample still uses Auth JS's Legacy Mode internally, so its `App.jsx` and `GeneralForm.jsx` source don't match the Step Mode code shown later in this guide. Use the sample only to verify your app integration settings and environment; use this guide's own code snippets as the reference for how to build the sign-in logic.
 
 #### Clone the Auth JS repository
 

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/sign-in-form.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/sign-in-form.md
@@ -1,4 +1,4 @@
-Build a sign-in page that captures both the username and password. As an example, from the test application, see the `index.js` file, which renders the simple sign-in for from the `formtransformer.js` file:
+Build a sign-in page that captures both the username and password. As an example, from the test application, see the `index.js` file, which renders the simple sign-in form from the `formTransformer.js` file:
 
 ```JavaScript
 import React from 'react';
@@ -16,7 +16,7 @@ root.render(
 );
 ```
 
-From the `formtransformer.js` file:
+From the `formTransformer.js` file:
 
 ```JavaScript
 const inputTransformer = nextStep => form => {

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/sign-in-form.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/sign-in-form.md
@@ -1,4 +1,4 @@
-Build a sign-in page that renders whichever fields the current step needs. This password-only flow asks for `username` first and `password` second. See the test application's `index.js` file, which renders the sign-in form using `formTransformer.js`:
+Build a sign-in page that renders whichever fields the current step needs. This password-only flow asks for `username` first and `password` second. See the test application's `main.jsx` file, which renders the sign-in form using `formTransformer.js`:
 
 ```JavaScript
 import React from 'react';

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/sign-in-form.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/sign-in-form.md
@@ -1,4 +1,4 @@
-Build a sign-in page that captures both the username and password. As an example, from the test application, see the `index.js` file, which renders the simple sign-in form from the `formTransformer.js` file:
+Build a sign-in page that renders whichever fields the current step needs — for this password-only flow, that's `username` first, then `password` on the following step. As an example, from the test application, see the `index.js` file, which renders the simple sign-in form from the `formTransformer.js` file:
 
 ```JavaScript
 import React from 'react';

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/sign-in-form.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/sign-in-form.md
@@ -1,4 +1,4 @@
-Build a sign-in page that renders whichever fields the current step needs — for this password-only flow, that's `username` first, then `password` on the following step. As an example, from the test application, see the `index.js` file, which renders the simple sign-in form from the `formTransformer.js` file:
+Build a sign-in page that renders whichever fields the current step needs. This password-only flow asks for `username` first and `password` second. See the test application's `index.js` file, which renders the sign-in form using `formTransformer.js`:
 
 ```JavaScript
 import React from 'react';

--- a/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/sign-in-form.md
+++ b/packages/@okta/vuepress-site/docs/guides/sign-in-to-spa-authjs/main/react/sign-in-form.md
@@ -2,17 +2,17 @@ Build a sign-in page that captures both the username and password. As an example
 
 ```JavaScript
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { BrowserRouter as Router } from 'react-router-dom';
 import App from './App';
 
-ReactDOM.render(
+const root = createRoot(document.getElementById('root'));
+root.render(
   <React.StrictMode>
     <Router>
       <App />
     </Router>
-  </React.StrictMode>,
-  document.getElementById('root')
+  </React.StrictMode>
 );
 ```
 


### PR DESCRIPTION
## Description

#### What's changed?
Updates the React examples in [Sign in to your SPA with Auth JS](https://developer.okta.com/docs/guides/sign-in-to-spa-authjs/react/main/), which had gone stale against current @okta/okta-auth-js (8.x) and were reported by a customer as "incorrect and badly out-of-date."

**`basic-sign-in.md`**
- Rewritten around Auth JS 8.x's Step Mode default: `idx.start()` begins the transaction, and `idx.proceed({ step: 'identify', ...inputValues })` names the remediation step explicitly instead of letting the client guess.
- Added a "Start the sign-in transaction" section showing the `idx.start()` bootstrap step — the previous version jumped straight to handling submission with no documented way to get the initial form fields.
- Added a "The full sign-in component code" section with a complete `App.jsx` so readers see the whole flow together.
- Shows actual usage of the `Security` component from `@okta/okta-react`, including a real `restoreOriginalUri` implementation (`history.replace` + `toRelativeUrl`) — previously listed as a required dependency but never shown in any code sample.
- Switched `config.js` from `process.env` to Vite's `import.meta.env` convention, matching the guide's Vite-based scaffold instructions; added `pkce: true`.
- Fixed a template literal bug in `REDIRECT_URI` (missing `$`).
- Dropped the unused `hasErrorInUrl` import.
- Commented out the sequence diagram — it still shows the old single-call `idx.authenticate(username, password)` flow and no longer matches the two-call `idx.start()` → `idx.proceed({ step })` flow. Design request filed to update it: [OKTA-1220704](https://oktainc.atlassian.net/browse/OKTA-1220704).

**`download-sample.md`**
- Reframed the cloned sample as environment/org verification only — it still hardcodes Legacy Mode internally, so its source no longer matches this guide's Step Mode code.
- Dropped the stale `USE_INTERACTION_CODE` env var (removed from the SDK).
- Switched scaffold instructions from Create React App to Vite, and documented the required `.env`/`VITE_` prefix setup.
- Expanded the `react-router-dom` v5 note into a clearer known-limitation callout.

**`sign-in-form.md`**
- Fixed `apps.js`/`formtransformer.js` naming typos.
- Switched to `createRoot` (React 18) from the deprecated `ReactDOM.render`.

Scope is intentionally limited to the React tab — Vue and Angular tabs are untouched and may need a similar pass separately.

#### Verification
The Step Mode call shapes (`idx.start()`, `step: 'identify'`, `restoreOriginalUri`) were reviewed by [@jaredperreault-okta](https://github.com/jaredperreault-okta) as SDK owner/SME across two review passes ([first](https://github.com/okta/okta-developer-docs/pull/6283#discussion_r3536876012), [second](https://github.com/okta/okta-developer-docs/pull/6283#discussion_r3552382779)), but this hasn't been smoke-tested against a live dev org yet — flagging for a final pass before merge.

Is this PR related to a Monolith release? No.

### Resolves:

[OKTA-889035](https://oktainc.atlassian.net/browse/OKTA-889035)

### Netlify Preview Link:

[Preview link](https://tbs-okta-889035-spa-authjs-react-update--dev-docs-preview.netlify.app/docs/guides/sign-into-spa-redirect/react/main/)
