### PR TITLE
OKTA-1209565 - Update bacon queue name

### DIFF
--- a/.bacon.yml
+++ b/.bacon.yml
@@ -5,11 +5,11 @@ test_suites:
     sort_order: '0'
     timeout: '50'
     criteria: OPTIONAL
-    queue_name: ci-queue-productionJenga-AL2023
+    queue_name: al2023
   - name: 'publish-production'
     script_path: /root/okta/okta-developer-docs/scripts
     script_name: publish
     sort_order: '1'
     timeout: '50'
     criteria: MAINLINE
-    queue_name: small
+    queue_name: al2023

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,7 +5,7 @@ cd ${OKTA_HOME}/${REPO}
 export GENERATED_SITE_LOCATION=dist
 
 # Use latest version of Node
-setup_service node v14.21.1
+setup_service node v16.20.2
 
 if [[ -z "${BUILD_FAILURE}" ]]; then
     export BUILD_FAILURE=1


### PR DESCRIPTION
## Description:
- **What's changed?** 
     - Update bacon `queue_name` to `al2023`
     - Bump production builds to use `node v16`
- **Is this PR related to a Monolith release?** n/a

### Resolves:
* [OKTA-1209565](https://oktainc.atlassian.net/browse/OKTA-1209565)

### Netlify Preview Link:
https://ad-okta-1209565-update-bacon-queue-name--dev-docs-preview.netlify.app/
