### PR TITLE
Gitignore Claude Code local config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ node_modules
 tests/cypress/videos
 tests/cypress/screenshots
 $null
+
+# Claude Code personal config/skills - not meant to be shared
+claude.local.md
+.claude/


### PR DESCRIPTION
## Summary
- `claude.local.md` and `.claude/` were only excluded via personal, machine-local git config (`.git/info/exclude` and a global `~/.gitignore`), not anything committed to the repo.
- A fresh clone or another contributor's machine wouldn't get the same protection, risking an accidental commit of private local config/notes.
- Adds both to the repo's committed `.gitignore` instead.

## Test plan
- [x] Confirmed `claude.local.md` and `.claude/` are currently untracked (`git ls-files` returns nothing for either)
- [x] Confirmed neither is tracked or referenced by CI
- [x] No content change — pure `.gitignore` addition, no docs/code affected
