### PR TITLE
OKTA-1245987 - Add device access attribute table to Identity Engine EL reference

### DIFF
--- a/packages/@okta/vuepress-site/docs/reference/okta-expression-language-in-identity-engine/index.md
+++ b/packages/@okta/vuepress-site/docs/reference/okta-expression-language-in-identity-engine/index.md
@@ -98,6 +98,14 @@ When you create an Okta expression, you can reference EDR attributes and any pro
 
 See [Integrate with Endpoint Detection and Response solutions](https://help.okta.com/okta_help.htm?type=oie&id=ext-edr-integration-main) and [Available EDR signals by vendor](https://help.okta.com/okta_help.htm?type=oie&id=ext-edr-integration-available-signals) for details about `vendor` and `signal`.
 
+### Device access attributes
+
+The following table lists the device access attributes.
+
+| Syntax | Definitions | Examples |
+| -------- | ---------- | ------------ |
+| `device.provider.deviceAccess.joined` | Boolean. Indicates whether the device is joined to Okta for use of advanced capabilities like Device-Bound Single Sign-On (DBSSO). See [DBSSO](https://help.okta.com/okta_help.htm?type=oie&id=ext-oda-dbsso) for more information. | `true` or `false`<br>`device.provider.deviceAccess.joined == true` |
+
 ## Session properties
 
 When you create an Okta expression, you can reference attributes within the `session` context.


### PR DESCRIPTION
## Description:
- **What's changed?** Adds a new "Device access attributes" section and table to the Okta Expression Language in Identity Engine reference, documenting `device.provider.deviceAccess.joined`. Mirrors the equivalent help.okta.com update in [docs-dita-infodev#800](https://github.com/atko-eng/docs-dita-infodev/pull/800) (OKTA-1243351), including the same review feedback on wording (separate table, plural heading, expression-style example, and the "Device-Bound Single Sign-On" description).
- **Is this PR related to a Monolith release?** No.

### Resolves:

* [OKTA-1245987](https://oktainc.atlassian.net/browse/OKTA-1245987)

### Vercel Preview Link:

<!-- Add preview link here -->
