### PR TITLE
Add Okta Client SDK for Kotlin 3.0.0 release note

### DIFF
--- a/packages/@okta/vuepress-site/docs/release-notes/2026-okta-dev-tools/index.md
+++ b/packages/@okta/vuepress-site/docs/release-notes/2026-okta-dev-tools/index.md
@@ -18,8 +18,10 @@ These release notes list customer-visible changes to the Developer Tools. The Ok
 
 | Change | Expected in Preview Orgs |
 | ------ | ------------------------ |
-| [Okta Client SDK for Swift 2.2.0 adds Pushed Authorization Request support](#okta-client-sdk-for-swift-220-adds-pushed-authorization-request-support) | August 5, 2026 |
-| [Bugs fixed in Okta Client SDK for Swift 2.2.0](#bugs-fixed-in-okta-client-sdk-for-swift-220) | August 5, 2026|
+| [Okta Client SDK for Swift 2.2.0 adds Pushed Authorization Request support](#okta-client-sdk-for-swift-2-2-0-adds-pushed-authorization-request-support) | August 5, 2026 |
+| [Bugs fixed in Okta Client SDK for Swift 2.2.0](#bugs-fixed-in-okta-client-sdk-for-swift-2-2-0) | August 5, 2026|
+| [Okta Client SDK for Kotlin 3.0.0 adds Kotlin Multiplatform support](#okta-client-sdk-for-kotlin-3-0-0-adds-kotlin-multiplatform-support) | August 5, 2026 |
+| [Bugs fixed in Okta Client SDK for Kotlin 3.0.0](#bugs-fixed-in-okta-client-sdk-for-kotlin-3-0-0) | August 5, 2026 |
 
 #### Okta Client SDK for Swift 2.2.0 adds Pushed Authorization Request support
 
@@ -32,6 +34,20 @@ Version 2.2.0 of the [Okta Client SDK for Swift](https://github.com/okta/okta-mo
 * WebAuthn and Duo credentials could merge incorrectly during authentication. (OKTA-1209004)
 
 * The SDK rejected the `aud` claim when it was an array, which RFC 7519 §4.1.3 allows.
+
+#### Okta Client SDK for Kotlin 3.0.0 adds Kotlin Multiplatform support
+
+Version 3.0.0 of the [Okta Client SDK for Kotlin](https://github.com/okta/okta-mobile-kotlin) converts the `auth-foundation`, `oauth2`, and `web-authentication-ui` modules from Android-only libraries to Kotlin Multiplatform (Android and JVM). This adds a new cross-platform `OAuth2Client`, a credential management API, and typed rate-limit retry configuration. Version 1.0.0 of `okta-direct-auth` graduates it from beta to its first stable release, adding WebAuthn and passkey authentication support and a full Java-compatible `CompletableFuture` API. See the [CHANGELOG](https://github.com/okta/okta-mobile-kotlin/blob/master/CHANGELOG.md) for details. <!-- OKTA-1244067 -->
+
+#### Bugs fixed in Okta Client SDK for Kotlin 3.0.0
+
+* ID token validation rejected the `aud` claim when it was a JSON array, which RFC 7519 §4.1.3 allows. (OKTA-1239195)
+
+* `TokenEncryptionHandler` could throw a null pointer exception when a device's keystore certificate no longer existed. (OKTA-1209101)
+
+* `AndroidKeystoreUtil.getOrCreateAesKey()` could throw an uncaught `ProviderException` on some OEM devices. (OKTA-1209102)
+
+* A race condition in `DefaultRedirectCoordinator` could silently cancel a step-up authentication redirect. (OKTA-1209107)
 
 ## July
 


### PR DESCRIPTION
## Description:
- **What's changed?** Adds two entries to the 2026.08.0 monthly release under Developer Tools release notes: a feature blurb for the Okta Client SDK for Kotlin 3.0.0 (Kotlin Multiplatform conversion across `auth-foundation`, `oauth2`, and `web-authentication-ui`) and `okta-direct-auth` reaching its 1.0.0 stable release, plus a bug-fix list for four fixes shipped in that same version bump. Also fixes pre-existing broken anchor links on the neighboring Swift entries in this section (decimal version numbers slugify with hyphens on this site, e.g. `2.2.0` → `2-2-0`, not `220`).
- **Is this PR related to a Monolith release?** No — this is a Developer Tools SDK release note (`2026-okta-dev-tools`), not a Monolith release.

### Resolves:

* [OKTA-1244067](https://oktainc.atlassian.net/browse/OKTA-1244067)

### Vercel Preview Link:

<!-- Add preview link here -->
