### PR TITLE
OKTA-1245540 - Update resource class for CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,9 @@ jobs:
   node_build_checks:
       docker:
         - image: cimg/node:14.21.3-browsers
-      resource_class: arm.large
+      resource_class: xlarge.gen2
       environment:
-        NODE_OPTIONS: '--max-old-space-size=6144'
+        NODE_OPTIONS: '--max-old-space-size=8192'
       steps:
         - checkout
         - install-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
   node_build_checks:
       docker:
         - image: cimg/node:14.21.3-browsers
-      resource_class: large
+      resource_class: arm.large
       environment:
         NODE_OPTIONS: '--max-old-space-size=6144'
       steps:

--- a/packages/@okta/vuepress-site/.vuepress/scripts/build.sh
+++ b/packages/@okta/vuepress-site/.vuepress/scripts/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo "[build.sh] NODE_OPTIONS inherited from environment: '${NODE_OPTIONS}'"
-export NODE_OPTIONS="${NODE_OPTIONS:-"--max-old-space-size=6144"}"
+export NODE_OPTIONS="${NODE_OPTIONS:-"--max-old-space-size=8192"}"
 echo "[build.sh] NODE_OPTIONS in effect: '${NODE_OPTIONS}'"
 node -e "console.log('[build.sh] effective V8 heap limit (MB):', Math.round(require('v8').getHeapStatistics().heap_size_limit/1024/1024))"
 export BUILD_WORKER_THREADS="${BUILD_WORKER_THREADS:-2}"


### PR DESCRIPTION
## Description:
- **What's changed?** 
    - Update CircleCI resource class for `node_build_checks`
    - Increase `NODE_OPTIONS` memory limit to `8GB`
- **Is this PR related to a Monolith release?** n/a

### Resolves:
* [OKTA-1245540](https://oktainc.atlassian.net/browse/OKTA-1245540)

### Vercel Preview Link:
https://ad-okta-1245540-update-circleci-resource-class--developer-docs.vercel.app/
