### PR TITLE
[OKTA-1247687] OAG - Add scopes section to guides

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/oag-configure-apps-offline-mode/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oag-configure-apps-offline-mode/main/index.md
@@ -8,7 +8,7 @@ layout: Guides
 
 <ApiLifecycle access="ea" />
 
-This guide explains how to create an app for use with Access Gateway offline mode.
+This guide explains how to create an app for use with Access Gateway offline mode. It covers both OpenID Connect (OIDC) and SAML 2.0 apps. To choose which set of instructions appears, use the **Instructions for** selector at the top of the page.
 
 > **Note:** The Access Gateway APIs used in this guide are available in a Limited Early Access program and may be updated or changed based on feedback.
 

--- a/packages/@okta/vuepress-site/docs/guides/oag-configure-apps-offline-mode/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/oag-configure-apps-offline-mode/main/index.md
@@ -42,6 +42,10 @@ Offline mode apps require you to configure the authentication service and direct
 
 <StackSnippet snippet="requirements" />
 
+## Scopes required to create the app
+
+<StackSnippet snippet="scopes" />
+
 ## Create the app
 
 <StackSnippet snippet="procedure" />

--- a/packages/@okta/vuepress-site/docs/guides/oag-configure-apps-offline-mode/main/openidconnect/learningoutcomes.md
+++ b/packages/@okta/vuepress-site/docs/guides/oag-configure-apps-offline-mode/main/openidconnect/learningoutcomes.md
@@ -1,2 +1,2 @@
-* Create an OpenID Connect (OIDC) app in Access Gateway using the Access Gateway API
+* Create an OIDC app in Access Gateway using the Access Gateway API
 * Configure your client app using the Access Gateway OIDC discovery document

--- a/packages/@okta/vuepress-site/docs/guides/oag-configure-apps-offline-mode/main/openidconnect/procedure.md
+++ b/packages/@okta/vuepress-site/docs/guides/oag-configure-apps-offline-mode/main/openidconnect/procedure.md
@@ -103,6 +103,8 @@ Note the `clientId` in the response. You need it, along with the app's `id`, to 
 
 Access Gateway generates the `clientSecret` for your app when you create it, but doesn't return it in the create response. Retrieve it separately, then store it securely. Your client app needs both `clientId` and `clientSecret` to authenticate.
 
+> **Note:** Retrieving the client secret requires the `okta.oag.app.secrets.read` scope. Rotating it requires the `okta.oag.app.secrets.manage` scope. The `okta.oag.app.secrets.manage` scope also grants read access. Add the required scope to your access token when you enable the Access Gateway API. See [Scopes required for offline mode](/docs/guides/oag-offline-mode/main/#scopes-required-for-offline-mode).
+
 1. Send a `GET` request to the Retrieve the client secret [endpoint](https://developer.okta.com/docs/api/openapi/oag/oag/tags/applications/other/getclientsecret), using the app's `id` as the path parameter.
 1. Store the returned `clientSecret` securely. You can't retrieve the same secret value again after you rotate it.
 

--- a/packages/@okta/vuepress-site/docs/guides/oag-configure-apps-offline-mode/main/openidconnect/scopes.md
+++ b/packages/@okta/vuepress-site/docs/guides/oag-configure-apps-offline-mode/main/openidconnect/scopes.md
@@ -1,0 +1,7 @@
+After you enable the Access Gateway API, add the following scopes to an access token to create and manage offline mode apps:
+
+* `okta.oag.idp.read`
+* `okta.oag.app.manage`
+* `okta.oag.app.secrets.manage`
+
+To create an access token, use the [Access Tokens API](https://developer.okta.com/docs/api/openapi/oag/oag/tags/accesstokens).

--- a/packages/@okta/vuepress-site/docs/guides/oag-configure-apps-offline-mode/main/saml2/scopes.md
+++ b/packages/@okta/vuepress-site/docs/guides/oag-configure-apps-offline-mode/main/saml2/scopes.md
@@ -1,0 +1,6 @@
+After you enable the Access Gateway API, add the following scopes to an access token to create and manage offline mode apps:
+
+* `okta.oag.idp.read`
+* `okta.oag.app.manage`
+
+To create an access token, use the [Access Tokens API](https://developer.okta.com/docs/api/openapi/oag/oag/tags/accesstokens).


### PR DESCRIPTION
## Description:
- **What's changed?** Add client secret scopes note and scopes-required section to OAG guides
- **Is this PR related to a Monolith release?** No

### Resolves:

* [OKTA-1247687](https://oktainc.atlassian.net/browse/OKTA-1247687)

### Vercel Preview Link:

<!-- Add preview link here -->
