### PR TITLE
OKTA-1257809 fix OSQueryCustomChecksTimeout plist type

### DIFF
--- a/packages/@okta/vuepress-site/docs/guides/device-assurance-posture-checks-and-remediation/main/index.md
+++ b/packages/@okta/vuepress-site/docs/guides/device-assurance-posture-checks-and-remediation/main/index.md
@@ -94,7 +94,7 @@ The following example property list (`.plist`) enables custom checks for two org
   <key>OktaVerify.OSQueryAllowedDomains</key>
   <string>your-subdomain.okta.com;your-other-subdomain.okta.com</string>
   <key>OktaVerify.OSQueryCustomChecksTimeout</key>
-  <integer>2</integer>
+  <string>2</string>
 </dict>
 </plist>
 ```


### PR DESCRIPTION
<!-- PLEASE REMEMBER THAT THIS IS A PUBLIC REPO AND ANY PR AND SUBSEQUENT DISCUSSION WILL BE VISIBLE TO ANYONE AND EVERYONE -->

## Description:
- **What's changed?** Fixed the macOS `OktaVerify.OSQueryCustomChecksTimeout` configuration example to use the `<string>` plist type instead of `<integer>`, matching the actual code behavior and help.okta.com's documentation.
- **Is this PR related to a Monolith release?** No.

### Resolves:

* [OKTA-1257809](https://oktainc.atlassian.net/browse/OKTA-1257809)

### Vercel Preview Link:

<!-- Add preview link here -->